### PR TITLE
Delta request-merge

### DIFF
--- a/bugbug/bug_features.py
+++ b/bugbug/bug_features.py
@@ -140,7 +140,8 @@ class delta_request_merge(object):
             for ind_change in change['changes']:
                 if ind_change['added'].startswith('approval-mozilla'):
                     uplift_request_datetime = datetime.strptime(change['when'], '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=timezone.utc)
-                    return versions.getCloserRelease(uplift_request_datetime)[1] - uplift_request_datetime
+                    timedelta = versions.getCloserRelease(uplift_request_datetime)[1] - uplift_request_datetime
+                    return timedelta.days + timedelta.seconds / (24 * 60 * 60)
 
         return None
 

--- a/bugbug/model.py
+++ b/bugbug/model.py
@@ -34,13 +34,9 @@ class Model():
         classes = self.get_labels()
         class_names = sorted(list(set(classes.values())), reverse=True)
 
-        # Get bugs.
-        def bugs_all():
-            return bugzilla.get_bugs()
-
-        # Filter out bugs for which we have no labels.
+        # Get bugs, filtering out those for which we have no labels.
         def bugs():
-            return (bug for bug in bugs_all() if bug['id'] in classes)
+            return (bug for bug in bugzilla.get_bugs() if bug['id'] in classes)
 
         # Calculate labels.
         y = np.array([classes[bug['id']] for bug in bugs()])

--- a/bugbug/model.py
+++ b/bugbug/model.py
@@ -59,7 +59,7 @@ class Model():
         # Use k-fold cross validation to evaluate results.
         if self.cross_validation_enabled:
             scores = cross_val_score(self.clf, X_train, y_train, cv=5)
-            print('CV Accuracy: %0.2f (+/- %0.2f)' % (scores.mean(), scores.std() * 2))
+            print(f'CV Accuracy: f{scores.mean()} (+/- {scores.std() * 2})')
 
         # Evaluate results on the test set.
         self.clf.fit(X_train, y_train)


### PR DESCRIPTION
Changes proposed: A new bug_extractor, that returns the time difference between request date and merge date.

Example:
```
>>> a = delta_request_merge()
>>> a(bug)
('55.0', datetime.datetime(2017, 8, 8, 7, 0, tzinfo=<UTC>))
```

If I'm not wrong, 55 is the required delta here. (right?)
@marco-c Is this similar to what was required?