### PR TITLE
Add a parameter to only download commits starting from a given date

### DIFF
--- a/bugbug/repository.py
+++ b/bugbug/repository.py
@@ -11,9 +11,9 @@ import os
 import subprocess
 from collections import namedtuple
 from datetime import datetime
-from datetime import timedelta
 
 import hglib
+from dateutil import relativedelta
 from parsepatch.patch import Patch
 from tqdm import tqdm
 
@@ -173,6 +173,6 @@ if __name__ == '__main__':
     parser.add_argument('repository_dir', help='Path to the repository', action='store')
     args = parser.parse_args()
 
-    two_years_and_six_months_ago = datetime.utcnow() - timedelta(547)
+    two_years_and_six_months_ago = datetime.utcnow() - relativedelta(years=2, months=6)
 
     download_commits(args.repository_dir, two_years_and_six_months_ago)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ parsepatch==0.1.3
 gensim==3.7.1
 keras==2.2.4
 tqdm==4.31.1
+python-dateutil==2.8.0


### PR DESCRIPTION
In the Bugzilla case, we download all bugs from a start date to an end date.
In the repo case, we can ignore all bugs before the start date, but if we want to have all commits for all bugs, we can't limit the end date.

Limiting the start date is enough though to reduce the number of commits from ~500k to ~80k.