### PR TITLE
Add 'has bug ever had enhancement severity' as a feature

### DIFF
--- a/bugbug/bug_features.py
+++ b/bugbug/bug_features.py
@@ -287,6 +287,16 @@ class is_reporter_a_developer(object):
         return bug_reporter()(bug).strip() in author_ids
 
 
+class had_severity_enhancement(object):
+    def __call__(self, bug, **kwargs):
+        for history in bug['history']:
+            for change in history['changes']:
+                if change['field_name'].startswith('severity') and change['added'] == 'enhancement':
+                    return True
+
+        return False
+
+
 def cleanup_url(text):
     text = re.sub(r'http[s]?://(hg.mozilla|searchfox|dxr.mozilla)\S+', '__CODE_REFERENCE_URL__', text)
     return re.sub(r'http\S+', '__URL__', text)

--- a/bugbug/bug_features.py
+++ b/bugbug/bug_features.py
@@ -291,7 +291,7 @@ class had_severity_enhancement(object):
     def __call__(self, bug, **kwargs):
         for history in bug['history']:
             for change in history['changes']:
-                if change['field_name'].startswith('severity') and change['added'] == 'enhancement':
+                if change['field_name'] == 'severity' and change['added'] == 'enhancement':
                     return True
 
         return False

--- a/bugbug/models/bug.py
+++ b/bugbug/models/bug.py
@@ -43,6 +43,7 @@ class BugModel(Model):
             bug_features.affected_then_unaffected(),
             bug_features.product(),
             bug_features.component(),
+            bug_features.had_severity_enhancement(),
         ]
 
         cleanup_functions = [

--- a/bugbug/models/bug.py
+++ b/bugbug/models/bug.py
@@ -43,7 +43,6 @@ class BugModel(Model):
             bug_features.affected_then_unaffected(),
             bug_features.product(),
             bug_features.component(),
-            bug_features.had_severity_enhancement(),
         ]
 
         cleanup_functions = [


### PR DESCRIPTION
Fixes #244 

Seems that it decreases accuracy and precision (probably, I made a mistake in the code)

Results from adding the feature to bug model:

`Bug model w/o changes:`

X: (12962, 23196), y: (12962,)
Cross Validation scores:
Accuracy: f0.9448782359977217 (+/- 0.007763551330820037)
Precision: f0.9809508579821962 (+/- 0.00484645684240443)
Recall: f0.9527701408503688 (+/- 0.005441856489968034)
X_train: (19564, 23196), y_train: (19564,)
X_test: (1297, 23196), y_test: (1297,)


`Bug with had_severity_enhancement:`
X: (12962, 23198), y: (12962,)
Cross Validation scores:
Accuracy: f0.944363545955013 (+/- 0.007056090474553454)
Precision: f0.9805366638677574 (+/- 0.005402590257671274)
Recall: f0.9525655896247857 (+/- 0.004274797084254216)
X_train: (19564, 23198), y_train: (19564,)
X_test: (1297, 23198), y_test: (1297,)


Also, from https://github.com/mozilla/bugbug/issues/244#issuecomment-480284787, should a new model `old_bug` be added?