### PR TITLE
Revert "Add Docker build task"

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -146,38 +146,6 @@ tasks:
           owner: ${user}@users.noreply.github.com
           source: ${repository}/raw/${head_rev}/.taskcluster.yml
 
-      - taskId: {$eval: as_slugid("docker_build")}
-        created: {$fromNow: ''}
-        deadline: {$fromNow: '1 hour'}
-        provisionerId: aws-provisioner-v1
-        workerType: releng-svc
-        payload:
-          capabilities:
-            privileged: true
-          maxRunTime: 3600
-          image: babadie/taskboot:latest
-          env:
-            GIT_REPOSITORY: ${repository}
-            GIT_REVISION: ${head_rev}
-          command:
-            - taskboot
-            - build
-            - infra/dockerfile.base
-            - --write
-            - /base.tar
-          artifacts:
-            public/bugbug-base.tar:
-              expires: {$fromNow: '2 weeks'}
-              path: /base.tar
-              type: file
-        scopes:
-          - docker-worker:capability:privileged
-        metadata:
-          name: bugbug docker build
-          description: bugbug docker build
-          owner: ${user}@users.noreply.github.com
-          source: ${repository}/raw/${head_rev}/.taskcluster.yml
-
       - $if: 'tasks_for == "github-push" && head_branch[:10] == "refs/tags/"'
         then:
           dependencies:


### PR DESCRIPTION
Reverts mozilla/bugbug#265 because of https://github.com/mozilla/bugbug/commit/f6d6a0867d76941a051e6d06d1ef3a0f1b9db81c#commitcomment-33130698.

We'll need to add a branch role, similar to the tag role, and add the necessary scopes to both.