### PR TITLE
Create the initial data pipeline task definition

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party = dateutil,flask,gensim,hglib,imblearn,keras,libmozdata,numpy,pandas,parsepatch,pytest,requests,setuptools,shap,sklearn,spacy,taskcluster,tqdm,xgboost,zstandard
+known_third_party = dateutil,flask,gensim,hglib,imblearn,jsone,keras,libmozdata,numpy,pandas,parsepatch,pytest,requests,setuptools,shap,sklearn,spacy,taskcluster,tqdm,xgboost,yaml,zstandard

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -219,6 +219,7 @@ tasks:
             - {$eval: as_slugid("docker_build")}
           scopes:
             - secrets:get:project/relman/bugbug/deploy
+            - queue:route:project.relman.bugbug.deploy_ending.*
           taskId: {$eval: as_slugid("docker_push")}
           created: {$fromNow: ''}
           deadline: {$fromNow: '4 hours'}
@@ -235,6 +236,8 @@ tasks:
             command:
               - taskboot
               - push-artifact
+          routes:
+            - project.relman.bugbug.deploy_ending
           metadata:
             name: bugbug docker push
             description: bugbug docker push

--- a/data-pipeline.yml
+++ b/data-pipeline.yml
@@ -4,7 +4,7 @@ tasks:
     created: {$fromNow: ''}
     deadline: {$fromNow: '12 hours'}
     provisionerId: aws-provisioner-v1
-    workerType: releng-svc # TODO FIX ME BEFORE MERGING
+    workerType: releng-svc-compute
     payload:
       maxRunTime: 43200
       image: mozilla/bugbug-commit-retrieval
@@ -15,7 +15,7 @@ tasks:
           type: file
 
     routes:
-      # - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
+      - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
       - notify.irc-channel.#bugbug.on-failed
     metadata:
       name: bugbug commit retrieval
@@ -46,7 +46,7 @@ tasks:
       - "secrets:get:project/relman/bugbug/production"
 
     routes:
-      # - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
+      - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
       - notify.irc-channel.#bugbug.on-failed
     metadata:
       name: bugbug bugs retrieval
@@ -58,7 +58,7 @@ tasks:
     created: {$fromNow: ''}
     deadline: {$fromNow: '48 hours'}
     provisionerId: aws-provisioner-v1
-    workerType: releng-svc # TODO FIX ME BEFORE MERGING
+    workerType: releng-svc-compute
     dependencies:
       - commit-retrieval
       - bugs-retrieval
@@ -72,7 +72,7 @@ tasks:
           type: file
 
     routes:
-      # - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
+      - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
       - notify.irc-channel.#bugbug.on-failed
     metadata:
       name: bugbug train component model
@@ -84,7 +84,7 @@ tasks:
     created: {$fromNow: ''}
     deadline: {$fromNow: '48 hours'}
     provisionerId: aws-provisioner-v1
-    workerType: releng-svc # TODO FIX ME BEFORE MERGING
+    workerType: releng-svc-compute
     dependencies:
       - commit-retrieval
       - bugs-retrieval
@@ -98,7 +98,7 @@ tasks:
           type: file
 
     routes:
-      # - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
+      - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
       - notify.irc-channel.#bugbug.on-failed
     metadata:
       name: bugbug train defect model
@@ -110,7 +110,7 @@ tasks:
     created: {$fromNow: ''}
     deadline: {$fromNow: '48 hours'}
     provisionerId: aws-provisioner-v1
-    workerType: releng-svc # TODO FIX ME BEFORE MERGING
+    workerType: releng-svc-compute
     dependencies:
       - commit-retrieval
       - bugs-retrieval
@@ -124,7 +124,7 @@ tasks:
           type: file
 
     routes:
-      # - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
+      - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
       - notify.irc-channel.#bugbug.on-failed
     metadata:
       name: bugbug train regression model
@@ -136,7 +136,7 @@ tasks:
     created: {$fromNow: ''}
     deadline: {$fromNow: '48 hours'}
     provisionerId: aws-provisioner-v1
-    workerType: releng-svc # TODO FIX ME BEFORE MERGING
+    workerType: releng-svc-compute
     dependencies:
       - commit-retrieval
       - bugs-retrieval
@@ -150,7 +150,7 @@ tasks:
           type: file
 
     routes:
-      # - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
+      - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
       - notify.irc-channel.#bugbug.on-failed
     metadata:
       name: bugbug train tracking model
@@ -190,7 +190,7 @@ tasks:
       - docker-worker:capability:privileged
 
     routes:
-      # - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
+      - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
       - notify.irc-channel.#bugbug.on-failed
     metadata:
       name: bugbug docker http build
@@ -220,7 +220,7 @@ tasks:
         - push-artifact
 
     routes:
-      # - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
+      - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
       - notify.irc-channel.#bugbug.on-failed
     metadata:
       name: bugbug docker http push

--- a/data-pipeline.yml
+++ b/data-pipeline.yml
@@ -1,0 +1,229 @@
+version: 1
+tasks:
+  - ID: commit-retrieval
+    created: {$fromNow: ''}
+    deadline: {$fromNow: '12 hours'}
+    provisionerId: aws-provisioner-v1
+    workerType: releng-svc # TODO FIX ME BEFORE MERGING
+    payload:
+      maxRunTime: 43200
+      image: mozilla/bugbug-commit-retrieval
+
+      artifacts:
+        public/commits.json.xz:
+          path: /data/commits.json.xz
+          type: file
+
+    routes:
+      # - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
+      - notify.irc-channel.#bugbug.on-failed
+    metadata:
+      name: bugbug commit retrieval
+      description: bugbug commit retrieval
+      owner: release-mgmt-analysis@mozilla.com
+      source: https://github.com/mozilla/bugbug/raw/master/data-pipeline.yml
+
+  - ID: bugs-retrieval
+    created: {$fromNow: ''}
+    deadline: {$fromNow: '24 hours'}
+    provisionerId: aws-provisioner-v1
+    workerType: releng-svc
+    payload:
+      env:
+        TC_SECRET_ID: project/relman/bugbug/production
+      maxRunTime: 86400
+      image: mozilla/bugbug-bugs-retrieval
+
+      artifacts:
+        public/bugs.json.xz:
+          path: /data/bugs.json.xz
+          type: file
+
+      features:
+        taskclusterProxy:
+          true
+    scopes:
+      - "secrets:get:project/relman/bugbug/production"
+
+    routes:
+      # - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
+      - notify.irc-channel.#bugbug.on-failed
+    metadata:
+      name: bugbug bugs retrieval
+      description: bugbug bugs retrieval
+      owner: release-mgmt-analysis@mozilla.com
+      source: https://github.com/mozilla/bugbug/raw/master/data-pipeline.yml
+
+  - ID: train-component
+    created: {$fromNow: ''}
+    deadline: {$fromNow: '48 hours'}
+    provisionerId: aws-provisioner-v1
+    workerType: releng-svc # TODO FIX ME BEFORE MERGING
+    dependencies:
+      - commit-retrieval
+      - bugs-retrieval
+    payload:
+      maxRunTime: 25200
+      image: mozilla/bugbug-train-component
+
+      artifacts:
+        public/componentmodel.xz:
+          path: /componentmodel.xz
+          type: file
+
+    routes:
+      # - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
+      - notify.irc-channel.#bugbug.on-failed
+    metadata:
+      name: bugbug train component model
+      description: bugbug train component model
+      owner: release-mgmt-analysis@mozilla.com
+      source: https://github.com/mozilla/bugbug/raw/master/data-pipeline.yml
+
+  - ID: train-defect
+    created: {$fromNow: ''}
+    deadline: {$fromNow: '48 hours'}
+    provisionerId: aws-provisioner-v1
+    workerType: releng-svc # TODO FIX ME BEFORE MERGING
+    dependencies:
+      - commit-retrieval
+      - bugs-retrieval
+    payload:
+      maxRunTime: 25200
+      image: mozilla/bugbug-train-defect
+
+      artifacts:
+        public/defectenhancementtaskmodel.xz:
+          path: /defectenhancementtaskmodel.xz
+          type: file
+
+    routes:
+      # - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
+      - notify.irc-channel.#bugbug.on-failed
+    metadata:
+      name: bugbug train defect model
+      description: bugbug train defect model
+      owner: release-mgmt-analysis@mozilla.com
+      source: https://github.com/mozilla/bugbug/raw/master/data-pipeline.yml
+
+  - ID: train-regression
+    created: {$fromNow: ''}
+    deadline: {$fromNow: '48 hours'}
+    provisionerId: aws-provisioner-v1
+    workerType: releng-svc # TODO FIX ME BEFORE MERGING
+    dependencies:
+      - commit-retrieval
+      - bugs-retrieval
+    payload:
+      maxRunTime: 25200
+      image: mozilla/bugbug-train-regression
+
+      artifacts:
+        public/regressionmodel.xz:
+          path: /regressionmodel.xz
+          type: file
+
+    routes:
+      # - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
+      - notify.irc-channel.#bugbug.on-failed
+    metadata:
+      name: bugbug train regression model
+      description: bugbug train regression model
+      owner: release-mgmt-analysis@mozilla.com
+      source: https://github.com/mozilla/bugbug/raw/master/data-pipeline.yml
+
+  - ID: train-tracking
+    created: {$fromNow: ''}
+    deadline: {$fromNow: '48 hours'}
+    provisionerId: aws-provisioner-v1
+    workerType: releng-svc # TODO FIX ME BEFORE MERGING
+    dependencies:
+      - commit-retrieval
+      - bugs-retrieval
+    payload:
+      maxRunTime: 25200
+      image: mozilla/bugbug-train-tracking
+
+      artifacts:
+        public/trackingmodel.xz:
+          path: /trackingmodel.xz
+          type: file
+
+    routes:
+      # - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
+      - notify.irc-channel.#bugbug.on-failed
+    metadata:
+      name: bugbug train tracking model
+      description: bugbug train tracking model
+      owner: release-mgmt-analysis@mozilla.com
+      source: https://github.com/mozilla/bugbug/raw/master/data-pipeline.yml
+
+  - ID: docker-build
+    created: {$fromNow: ''}
+    deadline: {$fromNow: '49 hours'}
+    provisionerId: aws-provisioner-v1
+    workerType: releng-svc
+    dependencies:
+      - train-tracking
+      - train-regression
+      - train-defect
+      - train-component
+    payload:
+      capabilities:
+        privileged: true
+      maxRunTime: 3600
+      image: mozilla/taskboot:latest
+      command:
+        - "/bin/sh"
+        - "-lcxe"
+        - "git clone https://github.com/mozilla/bugbug /code &&
+           cd /code &&
+           git checkout master &&
+           python http_service/download_models.py &&
+           taskboot --target /code build-compose --registry=registry.hub.docker.com --write /images --service bugbug-http-service"
+      artifacts:
+        public/bugbug:
+          expires: {$fromNow: '2 weeks'}
+          path: /images
+          type: directory
+    scopes:
+      - docker-worker:capability:privileged
+
+    routes:
+      # - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
+      - notify.irc-channel.#bugbug.on-failed
+    metadata:
+      name: bugbug docker http build
+      description: bugbug docker http build
+      owner: release-mgmt-analysis@mozilla.com
+      source: https://github.com/mozilla/bugbug/raw/master/data-pipeline.yml
+
+  - ID: docker-push
+    dependencies:
+      - docker-build
+    scopes:
+      - secrets:get:project/relman/bugbug/deploy
+    created: {$fromNow: ''}
+    deadline: {$fromNow: '50 hour'}
+    provisionerId: aws-provisioner-v1
+    workerType: github-worker
+    payload:
+      features:
+        taskclusterProxy:
+          true
+      maxRunTime: 3600
+      image: mozilla/taskboot:latest
+      env:
+        TASKCLUSTER_SECRET: project/relman/bugbug/deploy
+      command:
+        - taskboot
+        - push-artifact
+
+    routes:
+      # - notify.email.release-mgmt-analysis@mozilla.com.on-failed"
+      - notify.irc-channel.#bugbug.on-failed
+    metadata:
+      name: bugbug docker http push
+      description: bugbug docker http push
+      owner: release-mgmt-analysis@mozilla.com
+      source: https://github.com/mozilla/bugbug/raw/master/data-pipeline.yml

--- a/infra/spawn_data_pipeline.py
+++ b/infra/spawn_data_pipeline.py
@@ -1,0 +1,124 @@
+#!/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Mozilla
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This script triggers the data pipeline for the bugbug project
+"""
+
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+
+import jsone
+import requests.packages.urllib3
+import taskcluster
+import yaml
+
+requests.packages.urllib3.disable_warnings()
+
+TASKCLUSTER_DEFAULT_URL = "https://taskcluster.net"
+
+
+def get_taskcluster_options():
+    """
+    Helper to get the Taskcluster setup options
+    according to current environment (local or Taskcluster)
+    """
+    options = taskcluster.optionsFromEnvironment()
+    proxy_url = os.environ.get("TASKCLUSTER_PROXY_URL")
+
+    if proxy_url is not None:
+        # Always use proxy url when available
+        options["rootUrl"] = proxy_url
+
+    if "rootUrl" not in options:
+        # Always have a value in root url
+        options["rootUrl"] = TASKCLUSTER_DEFAULT_URL
+
+    return options
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Spawn tasks for bugbug data pipeline")
+    parser.add_argument("data_pipeline_json")
+
+    args = parser.parse_args()
+    decision_task_id = os.environ.get("TASK_ID")
+    options = get_taskcluster_options()
+    add_self = False
+    if decision_task_id:
+        add_self = True
+        task_group_id = decision_task_id
+    else:
+        task_group_id = taskcluster.utils.slugId()
+    keys = {"taskGroupId": task_group_id}
+
+    id_mapping = {}
+
+    # First pass, do the template rendering and dependencies resolution
+    tasks = []
+
+    with open(args.data_pipeline_json) as pipeline_file:
+        raw_tasks = yaml.load(pipeline_file.read())
+
+    for task in raw_tasks["tasks"]:
+        # Try render the task template
+        context = {}
+        payload = jsone.render(task, context)
+        # raise Exception(payload)
+        # # TODO: the task_id will not match the taskId in the yaml file
+        task_id = taskcluster.utils.slugId()
+        task_internal_id = payload.pop("ID")
+
+        if task_internal_id in id_mapping:
+            raise ValueError("Conflicting IDS {}".format(task_internal_id))
+
+        id_mapping[task_internal_id] = task_id
+
+        for key, value in keys.items():
+            payload[key] = value
+
+        # Process the dependencies
+        new_dependencies = []
+        for dependency in payload.get("dependencies", []):
+            new_dependencies.append(id_mapping[dependency])
+
+        if add_self:
+            new_dependencies.append(decision_task_id)
+
+        payload["dependencies"] = new_dependencies
+
+        print("TASK", task_id, payload)
+        tasks.append((task_id, payload))
+
+    print("https://tools.taskcluster.net/task-group-inspector/#/" + task_group_id)
+    # Now sends them
+    queue = taskcluster.Queue(options)
+    try:
+        for task_id, task_payload in tasks:
+            queue.createTask(task_id, task_payload)
+
+        print("https://tools.taskcluster.net/task-group-inspector/#/" + task_group_id)
+    except taskcluster.exceptions.TaskclusterAuthFailure as e:
+        print("TaskclusterAuthFailure: {}".format(e.body), file=sys.stderr)
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/taskcluster-hook-pipeline-start.json
+++ b/infra/taskcluster-hook-pipeline-start.json
@@ -50,6 +50,7 @@
         "provisionerId": "aws-provisioner-v1",
         "retries": 5,
         "routes": [
+            "notify.email.release-mgmt-analysis@mozilla.com.on-failed",
             "notify.irc-channel.#bugbug.on-failed"
         ],
         "schedulerId": "-",

--- a/infra/taskcluster-hook-pipeline-start.json
+++ b/infra/taskcluster-hook-pipeline-start.json
@@ -1,6 +1,12 @@
 {
+    "bindings": [
+        {
+            "exchange": "exchange/taskcluster-queue/v1/task-completed",
+            "routingKeyPattern": "route.project.relman.bugbug.deploy_ending"
+        }
+    ],
     "schedule": [
-        "0 0 * * * *"
+        "0 0 0 * * 0"
     ],
     "metadata": {
         "description": "",
@@ -29,25 +35,27 @@
             "cache": {},
             "capabilities": {},
             "command": [
-                "/hello"
+                "/bin/bash",
+                "-lcx",
+                "git clone https://github.com/mozilla/bugbug && cd bugbug && git checkout data-pipeline-definition && pip install taskcluster json-e requests pyyaml && python infra/spawn_data_pipeline.py data-pipeline.yml"
             ],
             "env": {},
             "features": {
                 "taskclusterProxy": true
             },
-            "image": "hello-world",
+            "image": "python:3.7.3",
             "maxRunTime": 7200
         },
         "priority": "normal",
         "provisionerId": "aws-provisioner-v1",
         "retries": 5,
         "routes": [
-            "notify.email.release-mgmt-analysis@mozilla.com.on-failed",
             "notify.irc-channel.#bugbug.on-failed"
         ],
         "schedulerId": "-",
         "scopes": [
-            "assume:hook-id:project-relman/bugbug"
+            "assume:hook-id:project-relman/bugbug",
+            "secrets:get:project/relman/bugbug/production"
         ],
         "tags": {},
         "workerType": "taskcluster-generic"


### PR DESCRIPTION
There is a hook (which runs every day at midnight) that will spawn the
data-pipeline using the latest docker images that were build on latest
release. The hook itself is updated on each release and is versionned in this
repository.

The hook will runs once every week and on every successful release.

Add task for building the Docker image for HTTP service.

Fixes #284 and fixes #291.