### PR TITLE
Removes the experimental Dockerfile syntax

### DIFF
--- a/infra/dockerfile.base
+++ b/infra/dockerfile.base
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile:experimental
 FROM python:3.7.3-slim
 
 # Setup dependencies in a cachable step
@@ -10,6 +9,5 @@ RUN apt-get update && \
 		apt-get autoremove -y && \
 		rm -rf /var/lib/apt/lists/*
 
-# Setup bugbug with a bind RO mount
-RUN --mount=type=bind,target=/tmp/bugbug \
-	pip install /tmp/bugbug
+COPY . /tmp/bugbug
+RUN pip install /tmp/bugbug


### PR DESCRIPTION
This way we can still builds locally with docker-compose. We don't uses the
experiment syntax anymore.