### PR TITLE
Store experiences directly in the commit object

### DIFF
--- a/bugbug/commit_features.py
+++ b/bugbug/commit_features.py
@@ -41,24 +41,30 @@ class author_experience_90_days(object):
 
 
 def get_exps(exp_type, commit):
-    suffix = "experience" if exp_type == "reviewer" else "touched_prev"
-
-    val_total = commit[f"{exp_type}_{suffix}"]
-    val_timespan = commit[f"{exp_type}_{suffix}_{EXPERIENCE_TIMESPAN_TEXT}"]
-
     items_key = f"{exp_type}s" if exp_type != "directory" else "directories"
     items_num = len(commit[items_key])
 
     return {
         "num": items_num,
-        "sum": val_total["sum"],
-        "max": val_total["max"],
-        "min": val_total["min"],
-        "avg": val_total["sum"] / items_num if items_num > 0 else 0,
-        f"sum_{EXPERIENCE_TIMESPAN_TEXT}": val_timespan["sum"],
-        f"max_{EXPERIENCE_TIMESPAN_TEXT}": val_timespan["max"],
-        f"min_{EXPERIENCE_TIMESPAN_TEXT}": val_timespan["min"],
-        f"avg_{EXPERIENCE_TIMESPAN_TEXT}": val_timespan["sum"] / items_num
+        "sum": commit[f"touched_prev_total_{exp_type}_sum"],
+        "max": commit[f"touched_prev_total_{exp_type}_max"],
+        "min": commit[f"touched_prev_total_{exp_type}_min"],
+        "avg": commit[f"touched_prev_total_{exp_type}_sum"] / items_num
+        if items_num > 0
+        else 0,
+        f"sum_{EXPERIENCE_TIMESPAN_TEXT}": commit[
+            f"touched_prev_{EXPERIENCE_TIMESPAN_TEXT}_{exp_type}_sum"
+        ],
+        f"max_{EXPERIENCE_TIMESPAN_TEXT}": commit[
+            f"touched_prev_{EXPERIENCE_TIMESPAN_TEXT}_{exp_type}_max"
+        ],
+        f"min_{EXPERIENCE_TIMESPAN_TEXT}": commit[
+            f"touched_prev_{EXPERIENCE_TIMESPAN_TEXT}_{exp_type}_min"
+        ],
+        f"avg_{EXPERIENCE_TIMESPAN_TEXT}": commit[
+            f"touched_prev_{EXPERIENCE_TIMESPAN_TEXT}_{exp_type}_sum"
+        ]
+        / items_num
         if items_num > 0
         else 0,
     }
@@ -67,9 +73,9 @@ def get_exps(exp_type, commit):
 class author_experience(object):
     def __call__(self, commit, **kwargs):
         return {
-            "total": commit["author_experience"],
+            "total": commit["touched_prev_total_author_sum"],
             EXPERIENCE_TIMESPAN_TEXT: commit[
-                f"author_experience_{EXPERIENCE_TIMESPAN_TEXT}"
+                f"touched_prev_{EXPERIENCE_TIMESPAN_TEXT}_author_sum"
             ],
         }
 

--- a/bugbug/repository.py
+++ b/bugbug/repository.py
@@ -339,7 +339,7 @@ def calculate_experiences(commits):
 
     global seniority
 
-    first_commit_time = defaultdict(int)
+    first_commit_time = {}
 
     for commit in tqdm(commits):
         if commit.author not in first_commit_time:

--- a/bugbug/repository.py
+++ b/bugbug/repository.py
@@ -341,7 +341,7 @@ def calculate_experiences(commits):
 
     first_commit_time = defaultdict(int)
 
-    for commit in commits:
+    for commit in tqdm(commits):
         if commit.author not in first_commit_time:
             first_commit_time[commit.author] = commit.pushdate
             seniority[commit.node] = 0

--- a/bugbug/repository.py
+++ b/bugbug/repository.py
@@ -69,8 +69,6 @@ class Commit:
             setattr(self, f"{exp_str}min", exp_min)
 
 
-seniority = defaultdict(int)
-
 # This is only a temporary hack: Should be removed after the template issue with reviewers (https://bugzilla.mozilla.org/show_bug.cgi?id=1528938)
 # gets fixed. Most of this code is copied from https://github.com/mozilla/version-control-tools/blob/2c2812d4a41b690203672a183b1dd85ca8b39e01/pylib/mozautomation/mozautomation/commitparser.py#L129
 def get_reviewers(commit_description, flag_re=None):
@@ -180,7 +178,7 @@ def _transform(commit):
         if attr.startswith(f"touched_prev"):
             obj[attr] = value
 
-    obj["seniority"] = seniority[commit.node]
+    obj["seniority_author"] = commit.seniority_author
 
     sizes = []
 
@@ -337,17 +335,15 @@ def get_revs(hg, date_from=None):
 def calculate_experiences(commits):
     print(f"Analyzing experiences from {len(commits)} commits...")
 
-    global seniority
-
     first_commit_time = {}
 
     for commit in tqdm(commits):
         if commit.author not in first_commit_time:
             first_commit_time[commit.author] = commit.pushdate
-            seniority[commit.node] = 0
+            commit.seniority_author = 0
         else:
             time_lapse = commit.pushdate - first_commit_time[commit.author]
-            seniority[commit.node] = time_lapse.days
+            commit.seniority_author = time_lapse.days
 
     first_pushdate = commits[0].pushdate
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -193,264 +193,168 @@ def test_calculate_experiences():
 
     repository.calculate_experiences(commits)
 
-    assert repository.experiences_by_commit["total"]["author"]["commit1"] == 0
-    assert repository.experiences_by_commit["total"]["author"]["commit2"] == 0
-    assert repository.experiences_by_commit["total"]["author"]["commit3"] == 1
-    assert repository.experiences_by_commit["total"]["author"]["commit4"] == 1
-    assert repository.experiences_by_commit["total"]["author"]["commit5"] == 0
-    assert repository.experiences_by_commit["total"]["author"]["commit6"] == 1
+    assert commits[0].touched_prev_total_author_sum == 0
+    assert commits[1].touched_prev_total_author_sum == 0
+    assert commits[2].touched_prev_total_author_sum == 1
+    assert commits[3].touched_prev_total_author_sum == 1
+    assert commits[4].touched_prev_total_author_sum == 0
+    assert commits[5].touched_prev_total_author_sum == 1
 
-    assert repository.experiences_by_commit["90_days"]["author"]["commit1"] == 0
-    assert repository.experiences_by_commit["90_days"]["author"]["commit2"] == 0
-    assert repository.experiences_by_commit["90_days"]["author"]["commit3"] == 1
-    assert repository.experiences_by_commit["90_days"]["author"]["commit4"] == 0
-    assert repository.experiences_by_commit["90_days"]["author"]["commit5"] == 0
-    assert repository.experiences_by_commit["90_days"]["author"]["commit6"] == 1
+    assert commits[0].touched_prev_90_days_author_sum == 0
+    assert commits[1].touched_prev_90_days_author_sum == 0
+    assert commits[2].touched_prev_90_days_author_sum == 1
+    assert commits[3].touched_prev_90_days_author_sum == 0
+    assert commits[4].touched_prev_90_days_author_sum == 0
+    assert commits[5].touched_prev_90_days_author_sum == 1
 
-    assert repository.experiences_by_commit["total"]["reviewer"]["commit1"] == {
-        "sum": 0,
-        "max": 0,
-        "min": 0,
-    }
-    assert repository.experiences_by_commit["total"]["reviewer"]["commit2"] == {
-        "sum": 1,
-        "max": 1,
-        "min": 1,
-    }
-    assert repository.experiences_by_commit["total"]["reviewer"]["commit3"] == {
-        "sum": 1,
-        "max": 1,
-        "min": 1,
-    }
-    assert repository.experiences_by_commit["total"]["reviewer"]["commit4"] == {
-        "sum": 4,
-        "max": 2,
-        "min": 2,
-    }
-    assert repository.experiences_by_commit["total"]["reviewer"]["commit5"] == {
-        "sum": 0,
-        "max": 0,
-        "min": 0,
-    }
-    assert repository.experiences_by_commit["total"]["reviewer"]["commit6"] == {
-        "sum": 1,
-        "max": 1,
-        "min": 1,
-    }
+    assert commits[0].touched_prev_total_reviewer_sum == 0
+    assert commits[0].touched_prev_total_reviewer_max == 0
+    assert commits[0].touched_prev_total_reviewer_min == 0
+    assert commits[1].touched_prev_total_reviewer_sum == 1
+    assert commits[1].touched_prev_total_reviewer_max == 1
+    assert commits[1].touched_prev_total_reviewer_min == 1
+    assert commits[2].touched_prev_total_reviewer_sum == 1
+    assert commits[2].touched_prev_total_reviewer_max == 1
+    assert commits[2].touched_prev_total_reviewer_min == 1
+    assert commits[3].touched_prev_total_reviewer_sum == 4
+    assert commits[3].touched_prev_total_reviewer_max == 2
+    assert commits[3].touched_prev_total_reviewer_min == 2
+    assert commits[4].touched_prev_total_reviewer_sum == 0
+    assert commits[4].touched_prev_total_reviewer_max == 0
+    assert commits[4].touched_prev_total_reviewer_min == 0
+    assert commits[5].touched_prev_total_reviewer_sum == 1
+    assert commits[5].touched_prev_total_reviewer_max == 1
+    assert commits[5].touched_prev_total_reviewer_min == 1
 
-    assert repository.experiences_by_commit["90_days"]["reviewer"]["commit1"] == {
-        "sum": 0,
-        "max": 0,
-        "min": 0,
-    }
-    assert repository.experiences_by_commit["90_days"]["reviewer"]["commit2"] == {
-        "sum": 1,
-        "max": 1,
-        "min": 1,
-    }
-    assert repository.experiences_by_commit["90_days"]["reviewer"]["commit3"] == {
-        "sum": 1,
-        "max": 1,
-        "min": 1,
-    }
-    assert repository.experiences_by_commit["90_days"]["reviewer"]["commit4"] == {
-        "sum": 0,
-        "max": 0,
-        "min": 0,
-    }
-    assert repository.experiences_by_commit["90_days"]["reviewer"]["commit5"] == {
-        "sum": 0,
-        "max": 0,
-        "min": 0,
-    }
-    assert repository.experiences_by_commit["90_days"]["reviewer"]["commit6"] == {
-        "sum": 1,
-        "max": 1,
-        "min": 1,
-    }
+    assert commits[0].touched_prev_90_days_reviewer_sum == 0
+    assert commits[0].touched_prev_90_days_reviewer_max == 0
+    assert commits[0].touched_prev_90_days_reviewer_min == 0
+    assert commits[1].touched_prev_90_days_reviewer_sum == 1
+    assert commits[1].touched_prev_90_days_reviewer_max == 1
+    assert commits[1].touched_prev_90_days_reviewer_min == 1
+    assert commits[2].touched_prev_90_days_reviewer_sum == 1
+    assert commits[2].touched_prev_90_days_reviewer_max == 1
+    assert commits[2].touched_prev_90_days_reviewer_min == 1
+    assert commits[3].touched_prev_90_days_reviewer_sum == 0
+    assert commits[3].touched_prev_90_days_reviewer_max == 0
+    assert commits[3].touched_prev_90_days_reviewer_min == 0
+    assert commits[4].touched_prev_90_days_reviewer_sum == 0
+    assert commits[4].touched_prev_90_days_reviewer_max == 0
+    assert commits[4].touched_prev_90_days_reviewer_min == 0
+    assert commits[5].touched_prev_90_days_reviewer_sum == 1
+    assert commits[5].touched_prev_90_days_reviewer_max == 1
+    assert commits[5].touched_prev_90_days_reviewer_min == 1
 
-    assert repository.experiences_by_commit["total"]["file"]["commit1"] == {
-        "sum": 0,
-        "max": 0,
-        "min": 0,
-    }
-    assert repository.experiences_by_commit["total"]["file"]["commit2"] == {
-        "sum": 1,
-        "max": 1,
-        "min": 1,
-    }
-    assert repository.experiences_by_commit["total"]["file"]["commit3"] == {
-        "sum": 1,
-        "max": 1,
-        "min": 0,
-    }
-    assert repository.experiences_by_commit["total"]["file"]["commit4"] == {
-        "sum": 2,
-        "max": 2,
-        "min": 0,
-    }
-    assert repository.experiences_by_commit["total"]["file"]["commit5"] == {
-        "sum": 3,
-        "max": 3,
-        "min": 3,
-    }
-    assert repository.experiences_by_commit["total"]["file"]["commit6"] == {
-        "sum": 4,
-        "max": 4,
-        "min": 4,
-    }
+    assert commits[0].touched_prev_total_file_sum == 0
+    assert commits[0].touched_prev_total_file_max == 0
+    assert commits[0].touched_prev_total_file_min == 0
+    assert commits[1].touched_prev_total_file_sum == 1
+    assert commits[1].touched_prev_total_file_max == 1
+    assert commits[1].touched_prev_total_file_min == 1
+    assert commits[2].touched_prev_total_file_sum == 1
+    assert commits[2].touched_prev_total_file_max == 1
+    assert commits[2].touched_prev_total_file_min == 0
+    assert commits[3].touched_prev_total_file_sum == 2
+    assert commits[3].touched_prev_total_file_max == 2
+    assert commits[3].touched_prev_total_file_min == 0
+    assert commits[4].touched_prev_total_file_sum == 3
+    assert commits[4].touched_prev_total_file_max == 3
+    assert commits[4].touched_prev_total_file_min == 3
+    assert commits[5].touched_prev_total_file_sum == 4
+    assert commits[5].touched_prev_total_file_max == 4
+    assert commits[5].touched_prev_total_file_min == 4
 
-    assert repository.experiences_by_commit["90_days"]["file"]["commit1"] == {
-        "sum": 0,
-        "max": 0,
-        "min": 0,
-    }
-    assert repository.experiences_by_commit["90_days"]["file"]["commit2"] == {
-        "sum": 1,
-        "max": 1,
-        "min": 1,
-    }
-    assert repository.experiences_by_commit["90_days"]["file"]["commit3"] == {
-        "sum": 1,
-        "max": 1,
-        "min": 0,
-    }
-    assert repository.experiences_by_commit["90_days"]["file"]["commit4"] == {
-        "sum": 0,
-        "max": 0,
-        "min": 0,
-    }
-    assert repository.experiences_by_commit["90_days"]["file"]["commit5"] == {
-        "sum": 1,
-        "max": 1,
-        "min": 1,
-    }
-    assert repository.experiences_by_commit["90_days"]["file"]["commit6"] == {
-        "sum": 2,
-        "max": 2,
-        "min": 2,
-    }
+    assert commits[0].touched_prev_90_days_file_sum == 0
+    assert commits[0].touched_prev_90_days_file_max == 0
+    assert commits[0].touched_prev_90_days_file_min == 0
+    assert commits[1].touched_prev_90_days_file_sum == 1
+    assert commits[1].touched_prev_90_days_file_max == 1
+    assert commits[1].touched_prev_90_days_file_min == 1
+    assert commits[2].touched_prev_90_days_file_sum == 1
+    assert commits[2].touched_prev_90_days_file_max == 1
+    assert commits[2].touched_prev_90_days_file_min == 0
+    assert commits[3].touched_prev_90_days_file_sum == 0
+    assert commits[3].touched_prev_90_days_file_max == 0
+    assert commits[3].touched_prev_90_days_file_min == 0
+    assert commits[4].touched_prev_90_days_file_sum == 1
+    assert commits[4].touched_prev_90_days_file_max == 1
+    assert commits[4].touched_prev_90_days_file_min == 1
+    assert commits[5].touched_prev_90_days_file_sum == 2
+    assert commits[5].touched_prev_90_days_file_max == 2
+    assert commits[5].touched_prev_90_days_file_min == 2
 
-    assert repository.experiences_by_commit["total"]["directory"]["commit1"] == {
-        "sum": 0,
-        "max": 0,
-        "min": 0,
-    }
-    assert repository.experiences_by_commit["total"]["directory"]["commit2"] == {
-        "sum": 1,
-        "max": 1,
-        "min": 1,
-    }
-    assert repository.experiences_by_commit["total"]["directory"]["commit3"] == {
-        "sum": 2,
-        "max": 2,
-        "min": 1,
-    }
-    assert repository.experiences_by_commit["total"]["directory"]["commit4"] == {
-        "sum": 3,
-        "max": 3,
-        "min": 2,
-    }
-    assert repository.experiences_by_commit["total"]["directory"]["commit5"] == {
-        "sum": 4,
-        "max": 4,
-        "min": 4,
-    }
-    assert repository.experiences_by_commit["total"]["directory"]["commit6"] == {
-        "sum": 5,
-        "max": 5,
-        "min": 5,
-    }
+    assert commits[0].touched_prev_total_directory_sum == 0
+    assert commits[0].touched_prev_total_directory_max == 0
+    assert commits[0].touched_prev_total_directory_min == 0
+    assert commits[1].touched_prev_total_directory_sum == 1
+    assert commits[1].touched_prev_total_directory_max == 1
+    assert commits[1].touched_prev_total_directory_min == 1
+    assert commits[2].touched_prev_total_directory_sum == 2
+    assert commits[2].touched_prev_total_directory_max == 2
+    assert commits[2].touched_prev_total_directory_min == 1
+    assert commits[3].touched_prev_total_directory_sum == 3
+    assert commits[3].touched_prev_total_directory_max == 3
+    assert commits[3].touched_prev_total_directory_min == 2
+    assert commits[4].touched_prev_total_directory_sum == 4
+    assert commits[4].touched_prev_total_directory_max == 4
+    assert commits[4].touched_prev_total_directory_min == 4
+    assert commits[5].touched_prev_total_directory_sum == 5
+    assert commits[5].touched_prev_total_directory_max == 5
+    assert commits[5].touched_prev_total_directory_min == 5
 
-    assert repository.experiences_by_commit["90_days"]["directory"]["commit1"] == {
-        "sum": 0,
-        "max": 0,
-        "min": 0,
-    }
-    assert repository.experiences_by_commit["90_days"]["directory"]["commit2"] == {
-        "sum": 1,
-        "max": 1,
-        "min": 1,
-    }
-    assert repository.experiences_by_commit["90_days"]["directory"]["commit3"] == {
-        "sum": 2,
-        "max": 2,
-        "min": 1,
-    }
-    assert repository.experiences_by_commit["90_days"]["directory"]["commit4"] == {
-        "sum": 0,
-        "max": 0,
-        "min": 0,
-    }
-    assert repository.experiences_by_commit["90_days"]["directory"]["commit5"] == {
-        "sum": 1,
-        "max": 1,
-        "min": 1,
-    }
-    assert repository.experiences_by_commit["90_days"]["directory"]["commit6"] == {
-        "sum": 2,
-        "max": 2,
-        "min": 2,
-    }
+    assert commits[0].touched_prev_90_days_directory_sum == 0
+    assert commits[0].touched_prev_90_days_directory_max == 0
+    assert commits[0].touched_prev_90_days_directory_min == 0
+    assert commits[1].touched_prev_90_days_directory_sum == 1
+    assert commits[1].touched_prev_90_days_directory_max == 1
+    assert commits[1].touched_prev_90_days_directory_min == 1
+    assert commits[2].touched_prev_90_days_directory_sum == 2
+    assert commits[2].touched_prev_90_days_directory_max == 2
+    assert commits[2].touched_prev_90_days_directory_min == 1
+    assert commits[3].touched_prev_90_days_directory_sum == 0
+    assert commits[3].touched_prev_90_days_directory_max == 0
+    assert commits[3].touched_prev_90_days_directory_min == 0
+    assert commits[4].touched_prev_90_days_directory_sum == 1
+    assert commits[4].touched_prev_90_days_directory_max == 1
+    assert commits[4].touched_prev_90_days_directory_min == 1
+    assert commits[5].touched_prev_90_days_directory_sum == 2
+    assert commits[5].touched_prev_90_days_directory_max == 2
+    assert commits[5].touched_prev_90_days_directory_min == 2
 
-    assert repository.experiences_by_commit["total"]["component"]["commit1"] == {
-        "sum": 0,
-        "max": 0,
-        "min": 0,
-    }
-    assert repository.experiences_by_commit["total"]["component"]["commit2"] == {
-        "sum": 1,
-        "max": 1,
-        "min": 1,
-    }
-    assert repository.experiences_by_commit["total"]["component"]["commit3"] == {
-        "sum": 1,
-        "max": 1,
-        "min": 0,
-    }
-    assert repository.experiences_by_commit["total"]["component"]["commit4"] == {
-        "sum": 3,
-        "max": 2,
-        "min": 2,
-    }
-    assert repository.experiences_by_commit["total"]["component"]["commit5"] == {
-        "sum": 3,
-        "max": 3,
-        "min": 3,
-    }
-    assert repository.experiences_by_commit["total"]["component"]["commit6"] == {
-        "sum": 4,
-        "max": 4,
-        "min": 4,
-    }
+    assert commits[0].touched_prev_total_component_sum == 0
+    assert commits[0].touched_prev_total_component_max == 0
+    assert commits[0].touched_prev_total_component_min == 0
+    assert commits[1].touched_prev_total_component_sum == 1
+    assert commits[1].touched_prev_total_component_max == 1
+    assert commits[1].touched_prev_total_component_min == 1
+    assert commits[2].touched_prev_total_component_sum == 1
+    assert commits[2].touched_prev_total_component_max == 1
+    assert commits[2].touched_prev_total_component_min == 0
+    assert commits[3].touched_prev_total_component_sum == 3
+    assert commits[3].touched_prev_total_component_max == 2
+    assert commits[3].touched_prev_total_component_min == 2
+    assert commits[4].touched_prev_total_component_sum == 3
+    assert commits[4].touched_prev_total_component_max == 3
+    assert commits[4].touched_prev_total_component_min == 3
+    assert commits[5].touched_prev_total_component_sum == 4
+    assert commits[5].touched_prev_total_component_max == 4
+    assert commits[5].touched_prev_total_component_min == 4
 
-    assert repository.experiences_by_commit["90_days"]["component"]["commit1"] == {
-        "sum": 0,
-        "max": 0,
-        "min": 0,
-    }
-    assert repository.experiences_by_commit["90_days"]["component"]["commit2"] == {
-        "sum": 1,
-        "max": 1,
-        "min": 1,
-    }
-    assert repository.experiences_by_commit["90_days"]["component"]["commit3"] == {
-        "sum": 1,
-        "max": 1,
-        "min": 0,
-    }
-    assert repository.experiences_by_commit["90_days"]["component"]["commit4"] == {
-        "sum": 0,
-        "max": 0,
-        "min": 0,
-    }
-    assert repository.experiences_by_commit["90_days"]["component"]["commit5"] == {
-        "sum": 1,
-        "max": 1,
-        "min": 1,
-    }
-    assert repository.experiences_by_commit["90_days"]["component"]["commit6"] == {
-        "sum": 2,
-        "max": 2,
-        "min": 2,
-    }
+    assert commits[0].touched_prev_90_days_component_sum == 0
+    assert commits[0].touched_prev_90_days_component_max == 0
+    assert commits[0].touched_prev_90_days_component_min == 0
+    assert commits[1].touched_prev_90_days_component_sum == 1
+    assert commits[1].touched_prev_90_days_component_max == 1
+    assert commits[1].touched_prev_90_days_component_min == 1
+    assert commits[2].touched_prev_90_days_component_sum == 1
+    assert commits[2].touched_prev_90_days_component_max == 1
+    assert commits[2].touched_prev_90_days_component_min == 0
+    assert commits[3].touched_prev_90_days_component_sum == 0
+    assert commits[3].touched_prev_90_days_component_max == 0
+    assert commits[3].touched_prev_90_days_component_min == 0
+    assert commits[4].touched_prev_90_days_component_sum == 1
+    assert commits[4].touched_prev_90_days_component_max == 1
+    assert commits[4].touched_prev_90_days_component_min == 1
+    assert commits[5].touched_prev_90_days_component_sum == 2
+    assert commits[5].touched_prev_90_days_component_max == 2
+    assert commits[5].touched_prev_90_days_component_min == 2


### PR DESCRIPTION
This way we can avoid the huge dict of dicts of dicts mapping commit hashes to experiences