### PR TITLE
Add support for specific Docker tag in spawn_data_pipeline.py

### DIFF
--- a/infra/spawn_data_pipeline.py
+++ b/infra/spawn_data_pipeline.py
@@ -69,7 +69,7 @@ def main():
 
     id_mapping = {}
 
-    docker_tag = os.getenv("DOCKER_TAG", None)
+    docker_tag = os.getenv("TAG", None)
 
     # First pass, do the template rendering and dependencies resolution
     tasks = []

--- a/infra/spawn_data_pipeline.py
+++ b/infra/spawn_data_pipeline.py
@@ -69,6 +69,8 @@ def main():
 
     id_mapping = {}
 
+    docker_tag = os.getenv("DOCKER_TAG", None)
+
     # First pass, do the template rendering and dependencies resolution
     tasks = []
 
@@ -104,6 +106,14 @@ def main():
             new_dependencies.append(decision_task_id)
 
         payload["dependencies"] = new_dependencies
+
+        # Override the Docker image tag if needed
+        if docker_tag:
+            base_image = payload["payload"]["image"]
+            tagless_image = base_image.rsplit(":", 1)[0]
+
+            new_image = "{}:{}".format(tagless_image, docker_tag)
+            payload["payload"]["image"] = new_image
 
         tasks.append((task_id, payload))
 

--- a/infra/spawn_data_pipeline.py
+++ b/infra/spawn_data_pipeline.py
@@ -110,7 +110,13 @@ def main():
         # Override the Docker image tag if needed
         if docker_tag:
             base_image = payload["payload"]["image"]
-            tagless_image = base_image.rsplit(":", 1)[0]
+            splitted_image = base_image.rsplit(":", 1)
+
+            if len(splitted_image) > 1:
+                err_msg = "Docker tag should be None or 'latest', not {!r}"
+                assert splitted_image[1] == "latest", err_msg.format(splitted_image[1])
+
+            tagless_image = splitted_image[0]
 
             new_image = "{}:{}".format(tagless_image, docker_tag)
             payload["payload"]["image"] = new_image


### PR DESCRIPTION
This is needed in #340. We can either compute the Docker image like I do in this PR or pass the Docker Tag as context as the JSON file is rendered as JSON-e. I have a small preference for the way of this PR as we don't need to put the logic `logic or env.DOCKER_TAG` in all of the pipelines files.