### PR TITLE
Revert "Add support for specific Docker tag in spawn_data_pipeline.py"

### DIFF
--- a/infra/spawn_data_pipeline.py
+++ b/infra/spawn_data_pipeline.py
@@ -69,8 +69,6 @@ def main():
 
     id_mapping = {}
 
-    docker_tag = os.getenv("TAG", None)
-
     # First pass, do the template rendering and dependencies resolution
     tasks = []
 
@@ -106,20 +104,6 @@ def main():
             new_dependencies.append(decision_task_id)
 
         payload["dependencies"] = new_dependencies
-
-        # Override the Docker image tag if needed
-        if docker_tag:
-            base_image = payload["payload"]["image"]
-            splitted_image = base_image.rsplit(":", 1)
-
-            if len(splitted_image) > 1:
-                err_msg = "Docker tag should be None or 'latest', not {!r}"
-                assert splitted_image[1] == "latest", err_msg.format(splitted_image[1])
-
-            tagless_image = splitted_image[0]
-
-            new_image = "{}:{}".format(tagless_image, docker_tag)
-            payload["payload"]["image"] = new_image
 
         tasks.append((task_id, payload))
 


### PR DESCRIPTION
Reverts mozilla/bugbug#489

Actually we can't do this, as we'd overwrite the tag for taskboot too.