### PR TITLE
Add a small condition to Bugtype model

### DIFF
--- a/bugbug/models/bugtype.py
+++ b/bugbug/models/bugtype.py
@@ -102,7 +102,8 @@ class BugTypeModel(BugModel):
         for bug_data in bugzilla.get_bugs():
             target = np.zeros(len(keyword_list))
             for keyword in bug_data["keywords"]:
-                target[keyword_list.index(keyword_dict[keyword])] = 1
+                if keyword in keyword_dict:
+                    target[keyword_list.index(keyword_dict[keyword])] = 1
 
             classes[int(bug_data["id"])] = target
 


### PR DESCRIPTION
Looks like I missed this earlier, but we currently have only 4 possible target values for the bugtype model, and running the model gives a keyerror. This is because it iterates through keywords that we aren't classifying right now.