### PR TITLE
Don't skip commits when calculating experiences

### DIFF
--- a/bugbug/repository.py
+++ b/bugbug/repository.py
@@ -581,13 +581,6 @@ def download_commits(repo_dir, date_from):
 
     hg.close()
 
-    # Skip commits which are in .hg-annotate-ignore-revs (mostly consisting of very
-    # large and not meaningful formatting changes).
-    with open(os.path.join(repo_dir, ".hg-annotate-ignore-revs"), "rb") as f:
-        ignore_revs = set(l[:40] for l in f)
-
-    revs = [rev for rev in revs if rev not in ignore_revs]
-
     processes = multiprocessing.cpu_count()
 
     print(f"Mining {len(revs)} commits using {processes} processes...")
@@ -602,13 +595,6 @@ def download_commits(repo_dir, date_from):
         commits = tqdm(commits, total=len(revs_groups))
         commits = list(itertools.chain.from_iterable(commits))
 
-    # Don't analyze backouts.
-    backouts = set(commit.backedoutby for commit in commits if commit.backedoutby != "")
-    commits = [commit for commit in commits if commit.node not in backouts]
-
-    # Don't analyze commits that are not linked to a bug.
-    commits = [commit for commit in commits if commit.bug != b""]
-
     print("Downloading file->component mapping...")
 
     global path_to_component
@@ -622,6 +608,20 @@ def download_commits(repo_dir, date_from):
     }
 
     calculate_experiences(commits)
+
+    # Skip commits which are in .hg-annotate-ignore-revs (mostly consisting of very
+    # large and not meaningful formatting changes).
+    with open(os.path.join(repo_dir, ".hg-annotate-ignore-revs"), "r") as f:
+        ignore_revs = set(l[:40] for l in f)
+
+    commits = [commit for commit in commits if commit.node not in ignore_revs]
+
+    # Don't analyze backouts.
+    backouts = set(commit.backedoutby for commit in commits if commit.backedoutby != "")
+    commits = [commit for commit in commits if commit.node not in backouts]
+
+    # Don't analyze commits that are not linked to a bug.
+    commits = [commit for commit in commits if commit.bug != b""]
 
     # Exclude commits outside the range we care about.
     commits = [commit for commit in commits if commit.pushdate > date_from]

--- a/bugbug/repository.py
+++ b/bugbug/repository.py
@@ -363,7 +363,7 @@ class exp_queue:
         assert day == self.last_day
 
 
-def calculate_experiences(commits):
+def calculate_experiences(commits, commits_to_ignore):
     print(f"Analyzing experiences from {len(commits)} commits...")
 
     first_commit_time = {}
@@ -521,9 +521,6 @@ def calculate_experiences(commits):
         day = (commit.pushdate - first_pushdate).days
         assert day >= 0
 
-        update_experiences("author", day, [commit.author])
-        update_experiences("reviewer", day, commit.reviewers)
-
         # When a file is moved/copied, copy original experience values to the copied path.
         if len(commit.file_copies) > 0:
             for orig, copied in commit.file_copies.items():
@@ -553,19 +550,49 @@ def calculate_experiences(commits):
                         experiences["file"][commit_type][orig]
                     )
 
-        update_complex_experiences("file", day, commit.files)
+        if commit not in commits_to_ignore:
+            update_experiences("author", day, [commit.author])
+            update_experiences("reviewer", day, commit.reviewers)
 
-        update_complex_experiences("directory", day, get_directories(commit.files))
+            update_complex_experiences("file", day, commit.files)
 
-        components = list(
-            set(
-                path_to_component[path]
-                for path in commit.files
-                if path in path_to_component
+            update_complex_experiences("directory", day, get_directories(commit.files))
+
+            components = list(
+                set(
+                    path_to_component[path]
+                    for path in commit.files
+                    if path in path_to_component
+                )
             )
-        )
 
-        update_complex_experiences("component", day, components)
+            update_complex_experiences("component", day, components)
+
+
+def get_commits_to_ignore(repo_dir, commits):
+    # Skip commits which are in .hg-annotate-ignore-revs or which have
+    # 'ignore-this-changeset' in their description (mostly consisting of very
+    # large and not meaningful formatting changes).
+    with open(os.path.join(repo_dir, ".hg-annotate-ignore-revs"), "r") as f:
+        ignore_revs = set(l[:40] for l in f)
+
+    backouts = set(commit.backedoutby for commit in commits if commit.backedoutby != "")
+
+    def should_ignore(commit):
+        if commit.node in ignore_revs or "ignore-this-changeset" in commit.desc:
+            return True
+
+        # Don't analyze backouts.
+        if commit.node in backouts:
+            return True
+
+        # Don't analyze commits that are not linked to a bug.
+        if commit.bug == b"":
+            return True
+
+        return False
+
+    return set(commit for commit in commits if should_ignore(commit))
 
 
 def download_commits(repo_dir, date_from):
@@ -605,24 +632,13 @@ def download_commits(repo_dir, date_from):
         path: "::".join(component) for path, component in path_to_component.items()
     }
 
-    calculate_experiences(commits)
+    commits_to_ignore = get_commits_to_ignore(repo_dir, commits)
+    print(f"{len(commits_to_ignore)} commits to ignore")
 
-    # Skip commits which are in .hg-annotate-ignore-revs or which have
-    # 'ignore-this-changeset' in their description (mostly consisting of very
-    # large and not meaningful formatting changes).
-    with open(os.path.join(repo_dir, ".hg-annotate-ignore-revs"), "r") as f:
-        ignore_revs = set(l[:40] for l in f)
+    calculate_experiences(commits, commits_to_ignore)
 
-    commits = [commit for commit in commits if commit.node not in ignore_revs]
-
-    commits = [commit for commit in commits if "ignore-this-changeset" in commit.desc]
-
-    # Don't analyze backouts.
-    backouts = set(commit.backedoutby for commit in commits if commit.backedoutby != "")
-    commits = [commit for commit in commits if commit.node not in backouts]
-
-    # Don't analyze commits that are not linked to a bug.
-    commits = [commit for commit in commits if commit.bug != b""]
+    # Exclude commits to ignore.
+    commits = [commit for commit in commits if commit not in commits_to_ignore]
 
     # Exclude commits outside the range we care about.
     commits = [commit for commit in commits if commit.pushdate > date_from]

--- a/bugbug/repository.py
+++ b/bugbug/repository.py
@@ -60,6 +60,13 @@ class Commit:
         self.file_copies = file_copies
         self.reviewers = reviewers
 
+    def __eq__(self, other):
+        assert isinstance(other, Commit)
+        return self.node == other.node
+
+    def __hash__(self):
+        return hash(self.node)
+
     def set_experience(
         self, exp_type, commit_type, timespan, exp_sum, exp_max, exp_min
     ):

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -269,7 +269,7 @@ def test_calculate_experiences():
         "apps/file2.jsm": "Firefox::Boh",
     }
 
-    repository.calculate_experiences(list(commits.values()))
+    repository.calculate_experiences(list(commits.values()), set())
 
     assert commits["commit1"].seniority_author == 0
     assert commits["commitbackedout"].seniority_author == 0

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -207,6 +207,19 @@ def test_calculate_experiences():
             file_copies={},
             reviewers=("reviewer1",),
         ),
+        "commit2refactoring": repository.Commit(
+            node="commit2refactoring",
+            author="author2",
+            desc="commit2refactoring",
+            date=datetime(2019, 1, 1),
+            pushdate=datetime(2019, 1, 1),
+            bug="123",
+            backedoutby="",
+            author_email="author2@mozilla.org",
+            files=["dom/file1.cpp"],
+            file_copies={},
+            reviewers=("reviewer1",),
+        ),
         "commit3": repository.Commit(
             node="commit3",
             author="author1",
@@ -269,7 +282,9 @@ def test_calculate_experiences():
         "apps/file2.jsm": "Firefox::Boh",
     }
 
-    repository.calculate_experiences(list(commits.values()), set())
+    repository.calculate_experiences(
+        list(commits.values()), {commits["commit2refactoring"]}
+    )
 
     assert commits["commit1"].seniority_author == 0
     assert commits["commitbackedout"].seniority_author == 0


### PR DESCRIPTION
Unfortunately we need to know when file paths move...