### PR TITLE
script to generate duplicate classifier results

### DIFF
--- a/bugbug/bugzilla.py
+++ b/bugbug/bugzilla.py
@@ -107,7 +107,7 @@ def _download(ids_or_query):
     return new_bugs
 
 
-def download_bugs_between(date_from, date_to, security=False):
+def download_bugs_between(date_from, date_to, security=False, store=True):
     products = {
         "Add-on SDK",
         "Android Background Services",
@@ -169,10 +169,15 @@ def download_bugs_between(date_from, date_to, security=False):
 
             all_bugs += [bug for bug in new_bugs.values()]
 
-            db.append(
-                BUGS_DB,
-                (bug for bug_id, bug in new_bugs.items() if bug_id not in old_bug_ids),
-            )
+            if store:
+                db.append(
+                    BUGS_DB,
+                    (
+                        bug
+                        for bug_id, bug in new_bugs.items()
+                        if bug_id not in old_bug_ids
+                    ),
+                )
 
     return all_bugs
 

--- a/scripts/generate_duplicate_sheet.py
+++ b/scripts/generate_duplicate_sheet.py
@@ -2,6 +2,7 @@
 
 import csv
 import itertools
+import json
 from datetime import datetime, timedelta
 
 from bugbug import bugzilla
@@ -10,16 +11,23 @@ from bugbug.models.duplicate import DuplicateModel
 m = DuplicateModel.load("duplicatemodel")
 
 REPORTERS_TO_IGNORE = {"intermittent-bug-filer@mozilla.bugs", "wptsync@mozilla.bugs"}
-test_bugs = bugzilla.download_bugs_between(
-    datetime.now() - timedelta(days=21), datetime.now(), store=False
-)
 
-test_bugs = [bug for bug in test_bugs if not bug["creator"] in REPORTERS_TO_IGNORE]
 
-bug_tuples = itertools.combinations(test_bugs, 2)
+try:
+    with open("duplicate_test_bugs.json", "r") as f:
+        test_bugs = json.load(f)
+except FileNotFoundError:
+    test_bugs = bugzilla.download_bugs_between(
+        datetime.now() - timedelta(days=1), datetime.now(), store=False
+    )
+    test_bugs = [bug for bug in test_bugs if not bug["creator"] in REPORTERS_TO_IGNORE]
+    with open("duplicate_test_bugs.json", "w") as f:
+        json.dump(test_bugs, f)
+
+bug_tuples = list(itertools.combinations(test_bugs, 2))
 
 # Warning: Classifying all the test bugs takes a while
-probs = [m.classify(bug_tuples)]
+probs = m.classify(bug_tuples, probabilities=True)
 
 with open("duplicate_predictions.csv", "w") as csvfile:
     spamwriter = csv.writer(csvfile)

--- a/scripts/generate_duplicate_sheet.py
+++ b/scripts/generate_duplicate_sheet.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+import csv
+import itertools
+from datetime import datetime, timedelta
+
+from bugbug import bugzilla
+from bugbug.models.duplicate import DuplicateModel
+
+m = DuplicateModel.load("duplicatemodel")
+
+REPORTERS_TO_IGNORE = {"intermittent-bug-filer@mozilla.bugs", "wptsync@mozilla.bugs"}
+test_bugs = bugzilla.download_bugs_between(
+    datetime.now() - timedelta(days=21), datetime.now(), store=False
+)
+
+test_bugs = [bug for bug in test_bugs if not bug["creator"] in REPORTERS_TO_IGNORE]
+
+bug_tuples = itertools.combinations(test_bugs, 2)
+
+# Warning: Classifying all the test bugs takes a while
+probs = [m.classify(bug_tuples)]
+
+with open("duplicate_predictions.csv", "w") as csvfile:
+    spamwriter = csv.writer(csvfile)
+
+    spamwriter.writerow(
+        ["bug 1 ID", "bug 1 summary", "bug 2 ID", "bug 2 summary", "prediction"]
+    )
+
+    for bug_tuple, prob in zip(bug_tuples, probs):
+
+        if prob[1] > 0.8:
+            spamwriter.writerow(
+                [
+                    f'https://bugzilla.mozilla.org/show_bug.cgi?id={bug_tuple[0]["id"]}',
+                    bug_tuple[0]["summary"],
+                    f'https://bugzilla.mozilla.org/show_bug.cgi?id={bug_tuple[1]["id"]}',
+                    bug_tuple[1]["summary"],
+                    prob[1],
+                ]
+            )


### PR DESCRIPTION
The following script:

1. Trains a duplicate model
2. Classifies the bugs from the previous 3 weeks
3. Writes out the result to duplicate_predictions.csv file.