### PR TITLE
Bump version of taskboot to use latest version of img tool

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -137,7 +137,7 @@ tasks:
           capabilities:
             privileged: true
           maxRunTime: 10800
-          image: mozilla/taskboot:0.1.3
+          image: mozilla/taskboot:0.1.4
           env:
             REGISTRY: registry.hub.docker.com
             VERSION:
@@ -221,7 +221,7 @@ tasks:
               taskclusterProxy:
                 true
             maxRunTime: 3600
-            image: mozilla/taskboot:0.1.3
+            image: mozilla/taskboot:0.1.4
             env:
               TASKCLUSTER_SECRET: project/relman/bugbug/deploy
             command:
@@ -253,7 +253,7 @@ tasks:
               taskclusterProxy:
                 true
             maxRunTime: 3600
-            image: mozilla/taskboot:0.1.3
+            image: mozilla/taskboot:0.1.4
             env:
               GIT_REPOSITORY: ${repository}
               GIT_REVISION: ${head_rev}
@@ -291,7 +291,7 @@ tasks:
               taskclusterProxy:
                 true
             maxRunTime: 3600
-            image: mozilla/taskboot:0.1.3
+            image: mozilla/taskboot:0.1.4
             env:
               GIT_REPOSITORY: ${repository}
               GIT_REVISION: ${head_rev}

--- a/infra/data-pipeline.yml
+++ b/infra/data-pipeline.yml
@@ -350,7 +350,7 @@ tasks:
       capabilities:
         privileged: true
       maxRunTime: 3600
-      image: mozilla/taskboot:0.1.3
+      image: mozilla/taskboot:0.1.4
       command:
         - "/bin/sh"
         - "-lcxe"
@@ -390,7 +390,7 @@ tasks:
         taskclusterProxy:
           true
       maxRunTime: 3600
-      image: mozilla/taskboot:0.1.3
+      image: mozilla/taskboot:0.1.4
       env:
         TASKCLUSTER_SECRET: project/relman/bugbug/deploy
       command:
@@ -421,7 +421,7 @@ tasks:
         taskclusterProxy:
           true
       maxRunTime: 3600
-      image: mozilla/taskboot:0.1.3
+      image: mozilla/taskboot:0.1.4
       env:
         TASKCLUSTER_SECRET: project/relman/bugbug/deploy
       command:


### PR DESCRIPTION
It is necessary to support mulit-tag Docker image building