### PR TITLE
Fix artifact name for Heroku deploy. Fix #572

### DIFF
--- a/infra/data-pipeline.yml
+++ b/infra/data-pipeline.yml
@@ -442,8 +442,8 @@ tasks:
       command:
         - "/bin/sh"
         - "-lcxe"
-        - "taskboot deploy-heroku --artifact-filter public/bugbug/bugbug-http-service.tar --heroku-app bugbug &&
-           taskboot deploy-heroku --artifact-filter public/bugbug/bugbug-http-service-bg-worker.tar --heroku-app bugbug --heroku-dyno-type worker"
+        - "taskboot deploy-heroku --artifact-filter public/bugbug/registry.hub.docker.com_mozilla_bugbug-http-service_${version}.tar --heroku-app bugbug &&
+           taskboot deploy-heroku --artifact-filter public/bugbug/registry.hub.docker.com_mozilla_bugbug-http-service-bg-worker_${version}.tar --heroku-app bugbug --heroku-dyno-type worker"
 
     routes:
       - notify.email.release-mgmt-analysis@mozilla.com.on-failed"


### PR DESCRIPTION
Following https://github.com/mozilla/task-boot/pull/38, the artifacts names
changed, update data-pipeline invocations of task-boot with the updated names.