### PR TITLE
Bump taskboot to version 1.0.7. Fix #581

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -143,7 +143,7 @@ tasks:
           capabilities:
             privileged: true
           maxRunTime: 10800
-          image: mozilla/taskboot:0.1.6
+          image: mozilla/taskboot:0.1.7
           env:
             REGISTRY: registry.hub.docker.com
             VERSION:
@@ -227,7 +227,7 @@ tasks:
               taskclusterProxy:
                 true
             maxRunTime: 3600
-            image: mozilla/taskboot:0.1.6
+            image: mozilla/taskboot:0.1.7
             env:
               TASKCLUSTER_SECRET: project/relman/bugbug/deploy
             command:
@@ -259,7 +259,7 @@ tasks:
               taskclusterProxy:
                 true
             maxRunTime: 3600
-            image: mozilla/taskboot:0.1.6
+            image: mozilla/taskboot:0.1.7
             env:
               VERSION: {$eval: 'head_branch[10:]'}
             command:
@@ -295,7 +295,7 @@ tasks:
               taskclusterProxy:
                 true
             maxRunTime: 3600
-            image: mozilla/taskboot:0.1.6
+            image: mozilla/taskboot:0.1.7
             env:
               VERSION: {$eval: 'head_branch[10:]'}
             command:

--- a/infra/data-pipeline.yml
+++ b/infra/data-pipeline.yml
@@ -364,15 +364,15 @@ tasks:
       capabilities:
         privileged: true
       maxRunTime: 3600
-      image: mozilla/taskboot:0.1.6
+      image: mozilla/taskboot:0.1.7
       command:
         - "/bin/sh"
         - "-lcxe"
         - "git clone --quiet https://github.com/mozilla/bugbug /code &&
            cd /code &&
            git checkout master &&
-           taskboot --target /code build-compose --registry=registry.hub.docker.com --write /images --service bugbug-http-service --tag ${version} --build-arg BUGBUG_VERSION=${version} &&
-           taskboot --target /code build-compose --registry=registry.hub.docker.com --write /images --service bugbug-http-service-bg-worker --tag ${version} --build-arg BUGBUG_VERSION=${version}"
+           taskboot --cache /cache --target /code build-compose --registry=registry.hub.docker.com --write /images --service bugbug-http-service --tag ${version} --tag latest --build-arg BUGBUG_VERSION=${version} &&
+           taskboot --cache /cache --target /code build-compose --registry=registry.hub.docker.com --write /images --service bugbug-http-service-bg-worker --tag ${version} --tag latest --build-arg BUGBUG_VERSION=${version}"
       artifacts:
         public/bugbug:
           expires: {$fromNow: '2 weeks'}
@@ -405,7 +405,7 @@ tasks:
         taskclusterProxy:
           true
       maxRunTime: 3600
-      image: mozilla/taskboot:0.1.6
+      image: mozilla/taskboot:0.1.7
       env:
         TASKCLUSTER_SECRET: project/relman/bugbug/deploy
       command:
@@ -436,7 +436,7 @@ tasks:
         taskclusterProxy:
           true
       maxRunTime: 3600
-      image: mozilla/taskboot:0.1.6
+      image: mozilla/taskboot:0.1.7
       env:
         TASKCLUSTER_SECRET: project/relman/bugbug/deploy
       command:


### PR DESCRIPTION
Now that https://github.com/mozilla/task-boot/issues/39 is fixed, let's update
task-boot version to use it.

Also add missing tags and cache option when building Docker images in
data-pipeline.yml

Fixes #572 and fixes #581.