### PR TITLE
Fix default Python version declaration in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,4 +36,4 @@ repos:
     -   id: check-hooks-apply
     -   id: check-useless-excludes
 default_language_version:
-    python: python3.6
+    python: python3.7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,4 +35,5 @@ repos:
     hooks:
     -   id: check-hooks-apply
     -   id: check-useless-excludes
-python_version: python3.6
+default_language_version:
+    python: python3.6

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -35,7 +35,7 @@ tasks:
         workerType: github-worker
         payload:
           maxRunTime: 3600
-          image: python:3.6
+          image: python:3.7
           command:
             - "/bin/bash"
             - "-lcx"

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -35,7 +35,7 @@ tasks:
         workerType: github-worker
         payload:
           maxRunTime: 3600
-          image: python
+          image: python:3.6
           command:
             - "/bin/bash"
             - "-lcx"

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         ]
     },
     classifiers=[
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3 :: Only",
         "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
     ],


### PR DESCRIPTION
The new way of of declaring default Python version was introduced in
pre-commit 1.14.0 and warning about unknown config keys was introduced in
pre-commit 1.17.0.