### PR TITLE
Fix http_service classification code

### DIFF
--- a/http_service/models.py
+++ b/http_service/models.py
@@ -74,7 +74,7 @@ def classify_bug(
     # the token here
     bug_ids_set = set(map(int, bug_ids))
     bugzilla.set_token(bugzilla_token)
-    bugs = bugzilla._download(bug_ids)
+    bugs = bugzilla.get(bug_ids)
 
     redis_url = os.environ.get("REDIS_URL", "redis://localhost/0")
     redis = Redis.from_url(redis_url)


### PR DESCRIPTION
Commit 735fccc renamed bugzilla._download to bugzilla.get, update http_service
code to use the new API.