### PR TITLE
Better help description for the classifier command-line argument.

### DIFF
--- a/run.py
+++ b/run.py
@@ -28,7 +28,7 @@ def parse_args(args):
     )
     parser.add_argument(
         "--classifier",
-        help="Type of the classifier",
+        help="Type of the classifier. Only used for component classification.",
         choices=["default", "nn"],
         default="default",
     )
@@ -50,8 +50,6 @@ def main(args):
         args.goal, "" if args.classifier == "default" else args.classifier
     )
 
-    model_class_name = args.goal
-
     if args.goal == "component":
         if args.classifier == "default":
             model_class_name = "component"
@@ -59,6 +57,8 @@ def main(args):
             model_class_name = "component_nn"
         else:
             raise ValueError(f"Unknown value {args.classifier}")
+    else:
+        model_class_name = args.goal
 
     model_class = get_model_class(model_class_name)
 


### PR DESCRIPTION
The command-line argument `--classify` is only used for the component classification task. This PR modifies the help text to better reflect this.

Also a small change is done moving `model_class_name = args.goal` to an else clause. This ensures that `model_class_name` is not reassigned after initialization. I believe it expresses the logic more clearly.
