### PR TITLE
Fix crash when command-line argument historical  is passed for unsupported tasks.

### DIFF
--- a/run.py
+++ b/run.py
@@ -40,7 +40,10 @@ def parse_args(args):
     )
     parser.add_argument("--token", help="Bugzilla token", action="store")
     parser.add_argument(
-        "--historical", help="Analyze historical bugs", action="store_true"
+        "--historical",
+        help="""Analyze historical bugs. Only used for defect, bugtype,
+                defectenhancementtask and regression tasks.""",
+        action="store_true",
     )
     return parser.parse_args(args)
 
@@ -53,10 +56,8 @@ def main(args):
     if args.goal == "component":
         if args.classifier == "default":
             model_class_name = "component"
-        elif args.classifier == "nn":
-            model_class_name = "component_nn"
         else:
-            raise ValueError(f"Unknown value {args.classifier}")
+            model_class_name = "component_nn"
     else:
         model_class_name = args.goal
 
@@ -66,7 +67,14 @@ def main(args):
         db.download(bugzilla.BUGS_DB)
         db.download(repository.COMMITS_DB)
 
-        if args.historical:
+        historical_supported_tasks = [
+            "defect",
+            "bugtype",
+            "defectenhancementtask",
+            "regression",
+        ]
+
+        if args.goal in historical_supported_tasks:
             model = model_class(args.lemmatization, args.historical)
         else:
             model = model_class(args.lemmatization)

--- a/run.py
+++ b/run.py
@@ -28,7 +28,7 @@ def parse_args(args):
     )
     parser.add_argument(
         "--classifier",
-        help="Type of the classifier",
+        help="Type of the classifier. Only used for component classification.",
         choices=["default", "nn"],
         default="default",
     )
@@ -50,8 +50,6 @@ def main(args):
         args.goal, "" if args.classifier == "default" else args.classifier
     )
 
-    model_class_name = args.goal
-
     if args.goal == "component":
         if args.classifier == "default":
             model_class_name = "component"
@@ -59,6 +57,8 @@ def main(args):
             model_class_name = "component_nn"
         else:
             raise ValueError(f"Unknown value {args.classifier}")
+    else:
+        model_class_name = args.goal
 
     model_class = get_model_class(model_class_name)
 


### PR DESCRIPTION
If  the command-line argument `--historical` is passed for unsupported tasks the program crashes since other models don't have the parameter in their constructor. This PR fixes this issue by ignoring the command-line argument when it is passed for unsupported tasks.

Also a condition to raise ValueError when unknown classifier is passed is removed since this checking is already done by ArgumentParser.