### PR TITLE
Pre-load bugbug models in the RQ worker. Fix #557

### DIFF
--- a/http_service/Dockerfile
+++ b/http_service/Dockerfile
@@ -2,13 +2,13 @@ ARG BUGBUG_VERSION=latest
 
 FROM mozilla/bugbug-base:$BUGBUG_VERSION
 
-COPY requirements.txt /code/bugbug_http_service/
+COPY requirements.txt /code/http_service/
 
-RUN pip install -r /code/bugbug_http_service/requirements.txt
+RUN pip install -r /code/http_service/requirements.txt
 
-COPY . /code/bugbug_http_service/
+COPY . /code/http_service/
 
 # Load the models
 WORKDIR /code/
 
-CMD gunicorn -b 0.0.0.0:$PORT bugbug_http_service.app --preload --timeout 30 -w 3
+CMD gunicorn -b 0.0.0.0:$PORT http_service.app --preload --timeout 30 -w 3

--- a/http_service/Dockerfile.bg_worker
+++ b/http_service/Dockerfile.bg_worker
@@ -2,11 +2,11 @@ ARG BUGBUG_VERSION=latest
 
 FROM mozilla/bugbug-base:$BUGBUG_VERSION
 
-COPY requirements.txt /code/bugbug_http_service/
+COPY requirements.txt /code/http_service/
 
-RUN pip install -r /code/bugbug_http_service/requirements.txt
+RUN pip install -r /code/http_service/requirements.txt
 
-COPY . /code/bugbug_http_service/
+COPY . /code/http_service/
 
 # Load the models
 WORKDIR /code/
@@ -14,6 +14,6 @@ WORKDIR /code/
 ARG CHECK_MODELS
 ENV CHECK_MODELS="${CHECK_MODELS}"
 
-RUN bash /code/bugbug_http_service/ensure_models.sh
+RUN bash /code/http_service/ensure_models.sh
 
-CMD rq worker high default low -u $REDIS_URL
+CMD python /code/http_service/worker.py high default low

--- a/http_service/check_models.py
+++ b/http_service/check_models.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 # Non-relative imports might be brittle
-from models import MODELS_NAMES, load_model
+from models import MODELS_NAMES, get_model
 
 logging.basicConfig(level=logging.INFO)
 LOGGER = logging.getLogger()
@@ -17,7 +17,7 @@ LOGGER = logging.getLogger()
 def check_models():
     for model_name in MODELS_NAMES:
         # Try loading the model
-        load_model(model_name)
+        get_model(model_name)
 
 
 if __name__ == "__main__":

--- a/http_service/worker.py
+++ b/http_service/worker.py
@@ -6,16 +6,21 @@
 
 import os
 import sys
-from os.path import dirname, join
+from os.path import abspath, dirname, join
 
 from redis import Redis
 from rq import Connection, Worker
 
-import http_service.models  # Need to import at with the same name
+sys.path.insert(0, abspath(join(dirname(__file__), "..")))
+
+# We need to make sure that the models.py file is imported with the same name
+# than in the HTTP docker container or the cache will not match. If we import
+# it as models, the cache will be located at
+# `sys.modules['models'].MODEL_CACHE` while the job will look the models in
+# `sys.modules['http_service.models'].MODEL_CACHE`
+import http_service.models  # noqa: E402 isort:skip
 
 # Preload libraries
-sys.path.insert(0, dirname(join(__file__, "..")))
-
 http_service.models.preload_models()
 
 # Provide queue names to listen to as arguments to this script,

--- a/http_service/worker.py
+++ b/http_service/worker.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+from os.path import dirname, join
+
+from redis import Redis
+from rq import Connection, Worker
+
+import http_service.models  # Need to import at with the same name
+
+# Preload libraries
+sys.path.insert(0, dirname(join(__file__, "..")))
+
+http_service.models.preload_models()
+
+# Provide queue names to listen to as arguments to this script,
+# similar to rq worker
+redis_url = os.environ.get("REDIS_URL", "redis://localhost/0")
+redis_conn = Redis.from_url(redis_url)
+with Connection(connection=redis_conn):
+    qs = sys.argv[1:] or ["default"]
+
+    w = Worker(qs)
+    w.work()


### PR DESCRIPTION
Implements our own background worker script in order to be able to load the
bugbug models before the RQ worker is forking. This way we load them once at
startup and each job will be able to reuse it.