### PR TITLE
Add a similarity feature for duplicate classifier

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party = dateutil,flask,hglib,imblearn,jsone,libmozdata,models,numpy,pandas,pkg_resources,pytest,redis,requests,responses,rq,setuptools,shap,sklearn,taskcluster,tqdm,xgboost,yaml,zstandard
+known_third_party = dateutil,flask,hglib,imblearn,jsone,libmozdata,models,numpy,pandas,pkg_resources,pytest,redis,requests,responses,rq,scipy,setuptools,shap,sklearn,taskcluster,tqdm,xgboost,yaml,zstandard

--- a/bugbug/models/duplicate.py
+++ b/bugbug/models/duplicate.py
@@ -4,21 +4,77 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import random
+from itertools import islice
 
+import numpy as np
+from scipy import sparse
+from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.calibration import CalibratedClassifierCV
-from sklearn.compose import ColumnTransformer
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import LabelEncoder
 from sklearn.svm import LinearSVC
 
 from bugbug import bug_features, bugzilla, feature_cleanup
 from bugbug.model import BugCoupleModel
+from bugbug.utils import StructuredColumnTransformer
 
 NUM_DUPLICATES = 7000
 NUM_DUP_NONDUPS = 3500
 NUM_NONDUPS_NONDUPS = 3500
 
 REPORTERS_TO_IGNORE = {"intermittent-bug-filer@mozilla.bugs", "wptsync@mozilla.bugs"}
+
+
+class titletransformer(BaseEstimator, TransformerMixin):
+    def __init__(self, vocab):
+        self.vectorizer = TfidfVectorizer()
+        self.vocab = vocab
+
+    def transform(self, df, y=None):
+        return self.vectorizer.transform(df)
+
+    def fit(self, X, y=None):
+        self.vectorizer.fit(self.vocab)
+        return self
+
+
+class similarity_calculator(BaseEstimator, TransformerMixin):
+    def __init__(self):
+        pass
+
+    def transform(self, df, y=None):
+        similarity_title = np.expand_dims(
+            np.diagonal(
+                cosine_similarity(np.squeeze(df["title1"]), np.squeeze(df["title2"]))
+            ),
+            axis=1,
+        )
+        similarity_comment = np.expand_dims(
+            np.diagonal(
+                cosine_similarity(
+                    np.squeeze(df["first_comment1"]), np.squeeze(df["first_comment2"])
+                )
+            ),
+            axis=1,
+        )
+        return sparse.csr_matrix(
+            np.concatenate(
+                [
+                    np.squeeze(df["title1"]),
+                    np.squeeze(df["title2"]),
+                    np.squeeze(df["first_comment1"]),
+                    np.squeeze(df["first_comment2"]),
+                    similarity_title,
+                    similarity_comment,
+                ],
+                axis=1,
+            )
+        )
+
+    def fit(self, X, y=None):
+        return self
 
 
 class LinearSVCWithLabelEncoding(CalibratedClassifierCV):
@@ -35,6 +91,12 @@ class DuplicateModel(BugCoupleModel):
     def __init__(self, lemmatization=False):
         BugCoupleModel.__init__(self, lemmatization)
 
+        vocabulary = {"title": [], "first_comment": []}
+
+        for bug in islice(bugzilla.get_bugs(), 5000):
+            vocabulary["title"].append(bug["summary"])
+            vocabulary["first_comment"].append(bug["comments"][0]["text"])
+
         self.calculate_importance = False
 
         cleanup_functions = [
@@ -49,11 +111,30 @@ class DuplicateModel(BugCoupleModel):
 
         self.extraction_pipeline = Pipeline(
             [
-                ("bug_extractor", bug_features.BugExtractor([], cleanup_functions)),
                 (
-                    "union",
-                    ColumnTransformer([("text", self.text_vectorizer(), "text")]),
+                    "bug_extractor",
+                    bug_features.BugExtractor([], cleanup_functions, merge_data=False),
                 ),
+                (
+                    "structuredtransformer",
+                    StructuredColumnTransformer(
+                        [
+                            ("title1", titletransformer(vocabulary["title"]), "title1"),
+                            ("title2", titletransformer(vocabulary["title"]), "title2"),
+                            (
+                                "first_comment1",
+                                titletransformer(vocabulary["first_comment"]),
+                                "first_comment1",
+                            ),
+                            (
+                                "first_comment2",
+                                titletransformer(vocabulary["first_comment"]),
+                                "first_comment2",
+                            ),
+                        ]
+                    ),
+                ),
+                ("add_similarity_and_concat", similarity_calculator()),
             ]
         )
 


### PR DESCRIPTION
Fixes : #582 

Caveat : StructuredColumnTransformer converts sparse matrices to dense matrices, increasing the memory size of the inputs. (https://github.com/mozilla/bugbug/blob/master/bugbug/utils.py#L44).
Thus, I haven't been able to test the performance of this model so far.