### PR TITLE
add test for repository.download_component_mapping

### DIFF
--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -284,26 +284,7 @@ def test_download_component_mapping():
         responses.HEAD,
         "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.latest.source.source-bugzilla-info/artifacts/public/components.json",
         status=200,
-        headers={"ETag": "102"},
-    )
-
-    responses.add(
-        responses.GET,
-        "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.latest.source.source-bugzilla-info/artifacts/public/components.json",
-        status=200,
-        json={"README.txt": ["Core", "General"]},
-    )
-
-    repository.download_component_mapping()
-    assert len(repository.path_to_component) == 1
-    assert repository.path_to_component["README.txt"] == "Core::General"
-
-    responses.reset()
-    responses.add(
-        responses.HEAD,
-        "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.latest.source.source-bugzilla-info/artifacts/public/components.json",
-        status=200,
-        headers={"ETag": "102"},
+        headers={"ETag": "101"},
     )
 
     responses.add(
@@ -314,8 +295,9 @@ def test_download_component_mapping():
     )
 
     repository.download_component_mapping()
-    assert len(repository.path_to_component) == 1
-    assert repository.path_to_component["README.txt"] == "Core::General"
+    assert len(repository.path_to_component) == 2
+    assert repository.path_to_component["AUTHORS"] == "mozilla.org::Licensing"
+    assert repository.path_to_component["Cargo.lock"] == "Firefox Build System::General"
 
 
 @responses.activate

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -287,13 +287,6 @@ def test_download_component_mapping():
         headers={"ETag": "101"},
     )
 
-    responses.add(
-        responses.GET,
-        "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.latest.source.source-bugzilla-info/artifacts/public/components.json",
-        status=200,
-        json={"AUTHORS": ["mozilla.org", "Licensing"]},
-    )
-
     repository.download_component_mapping()
     assert len(repository.path_to_component) == 2
     assert repository.path_to_component["AUTHORS"] == "mozilla.org::Licensing"

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -238,6 +238,87 @@ def test_hg_log(fake_hg_repo):
 
 
 @responses.activate
+def test_download_component_mapping():
+    responses.add(
+        responses.HEAD,
+        "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.latest.source.source-bugzilla-info/artifacts/public/components.json",
+        status=200,
+        headers={"ETag": "100"},
+    )
+
+    responses.add(
+        responses.GET,
+        "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.latest.source.source-bugzilla-info/artifacts/public/components.json",
+        status=200,
+        json={},
+    )
+
+    repository.download_component_mapping()
+    assert len(repository.path_to_component) == 0
+
+    responses.reset()
+    responses.add(
+        responses.HEAD,
+        "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.latest.source.source-bugzilla-info/artifacts/public/components.json",
+        status=200,
+        headers={"ETag": "101"},
+    )
+
+    responses.add(
+        responses.GET,
+        "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.latest.source.source-bugzilla-info/artifacts/public/components.json",
+        status=200,
+        json={
+            "AUTHORS": ["mozilla.org", "Licensing"],
+            "Cargo.lock": ["Firefox Build System", "General"],
+        },
+    )
+
+    repository.download_component_mapping()
+    assert len(repository.path_to_component) == 2
+    assert repository.path_to_component["AUTHORS"] == "mozilla.org::Licensing"
+    assert repository.path_to_component["Cargo.lock"] == "Firefox Build System::General"
+
+    responses.reset()
+    responses.add(
+        responses.HEAD,
+        "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.latest.source.source-bugzilla-info/artifacts/public/components.json",
+        status=200,
+        headers={"ETag": "102"},
+    )
+
+    responses.add(
+        responses.GET,
+        "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.latest.source.source-bugzilla-info/artifacts/public/components.json",
+        status=200,
+        json={"README.txt": ["Core", "General"]},
+    )
+
+    repository.download_component_mapping()
+    assert len(repository.path_to_component) == 1
+    assert repository.path_to_component["README.txt"] == "Core::General"
+
+    responses.reset()
+    responses.add(
+        responses.HEAD,
+        "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.latest.source.source-bugzilla-info/artifacts/public/components.json",
+        status=200,
+        headers={"ETag": "102"},
+    )
+
+    responses.add(
+        responses.GET,
+        "https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.latest.source.source-bugzilla-info/artifacts/public/components.json",
+        status=200,
+        json={"AUTHORS": ["mozilla.org", "Licensing"]},
+    )
+
+    repository.download_component_mapping()
+    assert len(repository.path_to_component) == 1
+    assert repository.path_to_component["README.txt"] == "Core::General"
+
+
+@responses.activate
 def test_download_commits(fake_hg_repo):
     hg, local, remote = fake_hg_repo
 


### PR DESCRIPTION
Pull Request for issue #535.
Test cases:
1. Downloading 0 components
2. Downloading 2 components
3. Downloading 2 component with same e-tag as previous download