### PR TITLE
Prepare taskboot release 0.1.8

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -144,7 +144,7 @@ tasks:
           capabilities:
             privileged: true
           maxRunTime: 10800
-          image: mozilla/taskboot:0.1.7
+          image: mozilla/taskboot:0.1.8
           env:
             REGISTRY: registry.hub.docker.com
             VERSION:
@@ -228,7 +228,7 @@ tasks:
               taskclusterProxy:
                 true
             maxRunTime: 3600
-            image: mozilla/taskboot:0.1.7
+            image: mozilla/taskboot:0.1.8
             env:
               TASKCLUSTER_SECRET: project/relman/bugbug/deploy
             command:
@@ -259,7 +259,7 @@ tasks:
               taskclusterProxy:
                 true
             maxRunTime: 3600
-            image: mozilla/taskboot:0.1.7
+            image: mozilla/taskboot:0.1.8
             env:
               VERSION: {$eval: 'head_branch[10:]'}
             command:
@@ -294,7 +294,7 @@ tasks:
               taskclusterProxy:
                 true
             maxRunTime: 3600
-            image: mozilla/taskboot:0.1.7
+            image: mozilla/taskboot:0.1.8
             env:
               VERSION: {$eval: 'head_branch[10:]'}
             command:
@@ -330,7 +330,7 @@ tasks:
               taskclusterProxy:
                 true
             maxRunTime: 3600
-            image: mozilla/taskboot:0.1.7
+            image: mozilla/taskboot:0.1.8
             env:
               VERSION: {$eval: 'head_branch[10:]'}
             command:

--- a/infra/data-pipeline.yml
+++ b/infra/data-pipeline.yml
@@ -408,7 +408,7 @@ tasks:
         capabilities:
           privileged: true
         maxRunTime: 3600
-        image: mozilla/taskboot:0.1.7
+        image: mozilla/taskboot:0.1.8
         command:
           - "/bin/sh"
           - "-lcxe"
@@ -449,7 +449,7 @@ tasks:
           taskclusterProxy:
             true
         maxRunTime: 3600
-        image: mozilla/taskboot:0.1.7
+        image: mozilla/taskboot:0.1.8
         env:
           TASKCLUSTER_SECRET: project/relman/bugbug/deploy
         command:
@@ -480,14 +480,13 @@ tasks:
           taskclusterProxy:
             true
         maxRunTime: 3600
-        image: mozilla/taskboot:0.1.7
+        image: mozilla/taskboot:0.1.8
         env:
           TASKCLUSTER_SECRET: project/relman/bugbug/deploy
         command:
           - "/bin/sh"
           - "-lcxe"
-          - "taskboot deploy-heroku --artifact-filter public/bugbug/bugbug-http-service.tar --heroku-app bugbug &&
-             taskboot deploy-heroku --artifact-filter public/bugbug/bugbug-http-service-bg-worker.tar --heroku-app bugbug --heroku-dyno-type worker"
+          - "taskboot deploy-heroku --heroku-app bugbug 'web:public/bugbug/bugbug-http-service.tar' 'worker:public/bugbug/bugbug-http-service-bg-worker.tar'"
 
       routes:
         - notify.email.release-mgmt-analysis@mozilla.com.on-failed"


### PR DESCRIPTION
The new taskboot release will solves the double build on non-tag commits and
allow the heroku deploy to be fully atomic.

Fixes #558 and fixes #591.