### PR TITLE
Start tracking the start of the data pipeline. #648

### DIFF
--- a/infra/taskcluster-hook-pipeline-start.json
+++ b/infra/taskcluster-hook-pipeline-start.json
@@ -51,7 +51,8 @@
         "retries": 5,
         "routes": [
             "notify.email.release-mgmt-analysis@mozilla.com.on-failed",
-            "notify.irc-channel.#bugbug.on-failed"
+            "notify.irc-channel.#bugbug.on-failed",
+            "index.project.relman.bugbug.data-pipeline-start"
         ],
         "schedulerId": "-",
         "scopes": [


### PR DESCRIPTION
This way we can automate the stop of a running data pipeline during the
rollback process. The index route doesn't contains the version which would
require to update the `set_hook_version.py` script to add it.