### PR TITLE
Revert "Revert "Remove pip from the commit retrieval image""

### DIFF
--- a/infra/dockerfile.commit_retrieval
+++ b/infra/dockerfile.commit_retrieval
@@ -2,12 +2,12 @@ FROM mozilla/bugbug-base:latest
 
 # Mercurial need Python2 :(
 # git is required by the annotate pipeline.
-RUN apt-get update && apt-get install -y python-pip git && rm -rf /var/lib/apt/lists/*
-
-RUN python2 -m pip install --disable-pip-version-check --no-cache-dir mercurial==4.8
-
-# Robustcheckout setup
-RUN hg clone -r 6cd994e30bb1 https://hg.mozilla.org/hgcustom/version-control-tools /version-control-tools/
+RUN apt-get update && \
+    apt-get install -y python python-pip git && \
+    python2 -m pip install --disable-pip-version-check --no-cache-dir mercurial==4.8 && \
+    hg clone -r 6cd994e30bb1 https://hg.mozilla.org/hgcustom/version-control-tools /version-control-tools/ && \
+    apt-get purge -y python-pip && apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY infra/hgrc /root/.hgrc
 


### PR DESCRIPTION
Reverts mozilla/bugbug#686

Turns out it is actually working. The error I saw was about a patch that failed to apply, but the error is the same before/after the changes.