### PR TITLE
replace deprecated download_bugs_between with get_ids_between

### DIFF
--- a/run.py
+++ b/run.py
@@ -125,13 +125,14 @@ def main(args):
         today = datetime.utcnow()
         a_week_ago = today - timedelta(7)
         bugzilla.set_token(args.token)
-        bugs = bugzilla.download_bugs_between(a_week_ago, today)
+        bug_ids = bugzilla.get_ids_between(a_week_ago, today)
+        bugs = bugzilla.get(bug_ids)
 
         print(f"Classifying {len(bugs)} bugs...")
 
         rows = [["Bug", f"{args.goal}(model)", args.goal, "Title"]]
 
-        for bug in bugs:
+        for bug in bugs.values():
             p = model.classify(bug, probabilities=True)
             rows.append(
                 [


### PR DESCRIPTION
Looks like `bugzilla.download_bugs_between` was removed in commit 735fccc, and replaced with `bugzilla.get_ids_between`, but it was missed in this file.

I ran it and was able to generate the csv successfully (Got about ~1156 bugs).