### PR TITLE
Add option to disable url cleanup for similarity

### DIFF
--- a/bugbug/similarity.py
+++ b/bugbug/similarity.py
@@ -115,7 +115,7 @@ class BaseSimilarity:
 
 class LSISimilarity(BaseSimilarity):
     def __init__(self, cleanup_urls=True):
-        super().__init__(cleanup_urls)
+        super().__init__(cleanup_urls=cleanup_urls)
         self.corpus = []
 
         for bug in bugzilla.get_bugs():
@@ -162,7 +162,7 @@ class LSISimilarity(BaseSimilarity):
 
 class NeighborsSimilarity(BaseSimilarity):
     def __init__(self, k=10, vectorizer=TfidfVectorizer(), cleanup_urls=True):
-        super().__init__(cleanup_urls)
+        super().__init__(cleanup_urls=cleanup_urls)
         self.vectorizer = vectorizer
         self.similarity_calculator = NearestNeighbors(n_neighbors=k)
         text = []
@@ -187,7 +187,7 @@ class NeighborsSimilarity(BaseSimilarity):
 
 class Word2VecWmdSimilarity(BaseSimilarity):
     def __init__(self, cut_off=0.2, cleanup_urls=True):
-        super().__init__(cleanup_urls)
+        super().__init__(cleanup_urls=cleanup_urls)
         self.corpus = []
         self.bug_ids = []
         self.cut_off = cut_off

--- a/bugbug/similarity.py
+++ b/bugbug/similarity.py
@@ -54,7 +54,6 @@ for bug in bugzilla.get_bugs():
 
 class BaseSimilarity:
     def __init__(self, cleanup_urls=True):
-        self.cleanup_urls = cleanup_urls
         self.cleanup_functions = [
             feature_cleanup.responses(),
             feature_cleanup.hex(),
@@ -63,14 +62,13 @@ class BaseSimilarity:
             feature_cleanup.synonyms(),
             feature_cleanup.crash(),
         ]
+        if cleanup_urls:
+            self.cleanup_functions.append(feature_cleanup.url())
 
     def get_text(self, bug):
         return "{} {}".format(bug["summary"], bug["comments"][0]["text"])
 
     def text_preprocess(self, text, join=False):
-        if self.cleanup_urls:
-            self.cleanup_functions.append(feature_cleanup.url())
-
         for func in self.cleanup_functions:
             text = func(text)
 

--- a/bugbug/similarity.py
+++ b/bugbug/similarity.py
@@ -55,12 +55,7 @@ for bug in bugzilla.get_bugs():
 class BaseSimilarity:
     def __init__(self, cleanup_urls=True):
         self.cleanup_urls = cleanup_urls
-
-    def get_text(self, bug):
-        return "{} {}".format(bug["summary"], bug["comments"][0]["text"])
-
-    def text_preprocess(self, text, join=False):
-        cleanup_functions = [
+        self.cleanup_functions = [
             feature_cleanup.responses(),
             feature_cleanup.hex(),
             feature_cleanup.dll(),
@@ -69,10 +64,14 @@ class BaseSimilarity:
             feature_cleanup.crash(),
         ]
 
-        if self.cleanup_urls:
-            cleanup_functions.append(feature_cleanup.url())
+    def get_text(self, bug):
+        return "{} {}".format(bug["summary"], bug["comments"][0]["text"])
 
-        for func in cleanup_functions:
+    def text_preprocess(self, text, join=False):
+        if self.cleanup_urls:
+            self.cleanup_functions.append(feature_cleanup.url())
+
+        for func in self.cleanup_functions:
             text = func(text)
 
         text = re.sub("[^a-zA-Z0-9]", " ", text)

--- a/bugbug/similarity.py
+++ b/bugbug/similarity.py
@@ -53,8 +53,8 @@ for bug in bugzilla.get_bugs():
 
 
 class BaseSimilarity:
-    def __init__(self):
-        pass
+    def __init__(self, cleanup_urls=True):
+        self.cleanup_urls = cleanup_urls
 
     def get_text(self, bug):
         return "{} {}".format(bug["summary"], bug["comments"][0]["text"])
@@ -65,10 +65,12 @@ class BaseSimilarity:
             feature_cleanup.hex(),
             feature_cleanup.dll(),
             feature_cleanup.fileref(),
-            feature_cleanup.url(),
             feature_cleanup.synonyms(),
             feature_cleanup.crash(),
         ]
+
+        if self.cleanup_urls:
+            cleanup_functions.append(feature_cleanup.url())
 
         for func in cleanup_functions:
             text = func(text)
@@ -112,7 +114,8 @@ class BaseSimilarity:
 
 
 class LSISimilarity(BaseSimilarity):
-    def __init__(self):
+    def __init__(self, cleanup_urls=True):
+        super().__init__(cleanup_urls)
         self.corpus = []
 
         for bug in bugzilla.get_bugs():
@@ -158,7 +161,8 @@ class LSISimilarity(BaseSimilarity):
 
 
 class NeighborsSimilarity(BaseSimilarity):
-    def __init__(self, k=10, vectorizer=TfidfVectorizer()):
+    def __init__(self, k=10, vectorizer=TfidfVectorizer(), cleanup_urls=True):
+        super().__init__(cleanup_urls)
         self.vectorizer = vectorizer
         self.similarity_calculator = NearestNeighbors(n_neighbors=k)
         text = []
@@ -182,7 +186,8 @@ class NeighborsSimilarity(BaseSimilarity):
 
 
 class Word2VecWmdSimilarity(BaseSimilarity):
-    def __init__(self, cut_off=0.2):
+    def __init__(self, cut_off=0.2, cleanup_urls=True):
+        super().__init__(cleanup_urls)
         self.corpus = []
         self.bug_ids = []
         self.cut_off = cut_off

--- a/scripts/evaluate_similarity.py
+++ b/scripts/evaluate_similarity.py
@@ -18,18 +18,29 @@ def parse_args(args):
         help="Similarity algorithm to use",
         choices=["lsi", "neighbors_tfidf", "neighbors_tfidf_bigrams", "word2vec_wmd"],
     )
+    parser.add_argument(
+        "--disable-url-cleanup",
+        help="Don't cleanup urls when training the similarity model",
+        dest="cleanup_urls",
+        default=True,
+        action="store_false",
+    )
     return parser.parse_args(args)
 
 
 def main(args):
+
     if args.algorithm == "lsi":
-        model = LSISimilarity()
+        model = LSISimilarity(cleanup_urls=args.cleanup_urls)
     elif args.algorithm == "neighbors_tfidf":
-        model = NeighborsSimilarity()
+        model = NeighborsSimilarity(cleanup_urls=args.cleanup_urls)
     elif args.algorithm == "neighbors_tfidf_bigrams":
-        model = NeighborsSimilarity(vectorizer=TfidfVectorizer(ngram_range=(1, 2)))
+        model = NeighborsSimilarity(
+            vectorizer=TfidfVectorizer(ngram_range=(1, 2)),
+            cleanup_urls=args.cleanup_urls,
+        )
     elif args.algorithm == "word2vec_wmd":
-        model = Word2VecWmdSimilarity()
+        model = Word2VecWmdSimilarity(cleanup_urls=args.cleanup_urls)
 
     model.evaluation()
 

--- a/scripts/evaluate_similarity.py
+++ b/scripts/evaluate_similarity.py
@@ -36,10 +36,8 @@ def main(args):
     elif args.algorithm == "neighbors_tfidf_bigrams":
 
         def model_creator(**kwargs):
-            return NeighborsSimilarity(
-                vectorizer=TfidfVectorizer(ngram_range=(1, 2)),
-                cleanup_urls=kwargs.pop("cleanup_urls"),
-            )
+            kwargs["vectorizer"] = TfidfVectorizer(ngram_range=(1, 2))
+            return NeighborsSimilarity(**kwargs)
 
     elif args.algorithm == "word2vec_wmd":
         model_creator = Word2VecWmdSimilarity

--- a/scripts/evaluate_similarity.py
+++ b/scripts/evaluate_similarity.py
@@ -29,7 +29,6 @@ def parse_args(args):
 
 
 def main(args):
-
     if args.algorithm == "lsi":
         model = LSISimilarity(cleanup_urls=args.cleanup_urls)
     elif args.algorithm == "neighbors_tfidf":

--- a/scripts/evaluate_similarity.py
+++ b/scripts/evaluate_similarity.py
@@ -35,10 +35,10 @@ def main(args):
         model_creator = NeighborsSimilarity
     elif args.algorithm == "neighbors_tfidf_bigrams":
 
-        def model_creator(cleanup_urls):
+        def model_creator(**kwargs):
             return NeighborsSimilarity(
                 vectorizer=TfidfVectorizer(ngram_range=(1, 2)),
-                cleanup_urls=cleanup_urls,
+                cleanup_urls=kwargs.pop("cleanup_urls"),
             )
 
     elif args.algorithm == "word2vec_wmd":

--- a/scripts/evaluate_similarity.py
+++ b/scripts/evaluate_similarity.py
@@ -30,17 +30,21 @@ def parse_args(args):
 
 def main(args):
     if args.algorithm == "lsi":
-        model = LSISimilarity(cleanup_urls=args.cleanup_urls)
+        model_creator = LSISimilarity
     elif args.algorithm == "neighbors_tfidf":
-        model = NeighborsSimilarity(cleanup_urls=args.cleanup_urls)
+        model_creator = NeighborsSimilarity
     elif args.algorithm == "neighbors_tfidf_bigrams":
-        model = NeighborsSimilarity(
+        model_creator = NeighborsSimilarity
+    elif args.algorithm == "word2vec_wmd":
+        model_creator = Word2VecWmdSimilarity
+
+    if args.algorithm == "neighbors_tfidf_bigrams":
+        model = model_creator(
             vectorizer=TfidfVectorizer(ngram_range=(1, 2)),
             cleanup_urls=args.cleanup_urls,
         )
-    elif args.algorithm == "word2vec_wmd":
-        model = Word2VecWmdSimilarity(cleanup_urls=args.cleanup_urls)
-
+    else:
+        model = model_creator(cleanup_urls=args.cleanup_urls)
     model.evaluation()
 
 

--- a/scripts/evaluate_similarity.py
+++ b/scripts/evaluate_similarity.py
@@ -34,17 +34,17 @@ def main(args):
     elif args.algorithm == "neighbors_tfidf":
         model_creator = NeighborsSimilarity
     elif args.algorithm == "neighbors_tfidf_bigrams":
-        model_creator = NeighborsSimilarity
+
+        def model_creator(cleanup_urls):
+            return NeighborsSimilarity(
+                vectorizer=TfidfVectorizer(ngram_range=(1, 2)),
+                cleanup_urls=cleanup_urls,
+            )
+
     elif args.algorithm == "word2vec_wmd":
         model_creator = Word2VecWmdSimilarity
 
-    if args.algorithm == "neighbors_tfidf_bigrams":
-        model = model_creator(
-            vectorizer=TfidfVectorizer(ngram_range=(1, 2)),
-            cleanup_urls=args.cleanup_urls,
-        )
-    else:
-        model = model_creator(cleanup_urls=args.cleanup_urls)
+    model = model_creator(cleanup_urls=args.cleanup_urls)
     model.evaluation()
 
 


### PR DESCRIPTION
Fixes #725.

I decided to make `cleanup_urls` a variable in the `BaseSimilarity` class, because I thought that passing an extra variable to all of `__init__`, `text_preprocess`, and `get_ similar_bugs` look a bit messy. Thoughts?

I ran the `lsi` algorithm on 5000 bugs.
With cleanup
```
Recall: 41.156462585034014%
Precision: 4.481481481481482%
```
Without cleanup
```
Recall: 41.83673469387755%
Precision: 4.555555555555555%
```