### PR TITLE
Modify linting task to only run on modified files

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -21,6 +21,14 @@ tasks:
         then: ${event.after}
         else: ${event.release.tag_name}
 
+    base_rev:
+      $if: 'tasks_for == "github-pull-request"'
+      then: ${event.pull_request.base.sha}
+      else:
+        $if: 'tasks_for == "github-push"'
+        then: ${event.before}
+        else: ${event.release.tag_name}
+
     repository:
       $if: 'tasks_for == "github-pull-request"'
       then: ${event.pull_request.head.repo.html_url}
@@ -44,8 +52,8 @@ tasks:
                git -c advice.detachedHead=false checkout ${head_rev} &&
                pip install --quiet -r test-requirements.txt &&
                git remote add upstream https://github.com/mozilla/bugbug &&
-               git fetch upstream master &&
-               pre-commit run --files $(git diff --name-only --diff-filter=d upstream/master...${head_rev})"
+               git fetch upstream &&
+               pre-commit run --files $(git diff --name-only --diff-filter=d ${base_rev}...${head_rev})"
         metadata:
           name: bugbug lint
           description: bugbug lint

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -45,7 +45,7 @@ tasks:
                pip install --quiet -r test-requirements.txt &&
                git remote add upstream https://github.com/mozilla/bugbug &&
                git fetch upstream master &&
-               pre-commit run --files $(git diff --name-only --diff-filter=d upstream/master...)"
+               pre-commit run --files $(git diff --name-only --diff-filter=d upstream/master...${head_branch})"
         metadata:
           name: bugbug lint
           description: bugbug lint

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -44,6 +44,7 @@ tasks:
                git -c advice.detachedHead=false checkout ${head_rev} &&
                pip install --quiet -r test-requirements.txt &&
                git remote add upstream https://github.com/mozilla/bugbug &&
+               git fetch upstream master &&
                pre-commit run --files $(git diff --name-only --diff-filter=d upstream/master...)"
         metadata:
           name: bugbug lint

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -21,14 +21,6 @@ tasks:
         then: ${event.after}
         else: ${event.release.tag_name}
 
-    base_rev:
-      $if: 'tasks_for == "github-pull-request"'
-      then: ${event.pull_request.base.sha}
-      else:
-        $if: 'tasks_for == "github-push"'
-        then: ${event.before}
-        else: ${event.release.tag_name}
-
     repository:
       $if: 'tasks_for == "github-pull-request"'
       then: ${event.pull_request.head.repo.html_url}
@@ -51,9 +43,7 @@ tasks:
                cd bugbug &&
                git -c advice.detachedHead=false checkout ${head_rev} &&
                pip install --quiet -r test-requirements.txt &&
-               git remote add upstream https://github.com/mozilla/bugbug &&
-               git fetch --quiet upstream &&
-               pre-commit run --files $(git diff --name-only --diff-filter=d ${base_rev}...${head_rev})"
+               pre-commit run -a"
         metadata:
           name: bugbug lint
           description: bugbug lint

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -45,7 +45,7 @@ tasks:
                pip install --quiet -r test-requirements.txt &&
                git remote add upstream https://github.com/mozilla/bugbug &&
                git fetch upstream master &&
-               pre-commit run --files $(git diff --name-only --diff-filter=d upstream/master...${head_branch})"
+               pre-commit run --files $(git diff --name-only --diff-filter=d upstream/master...${head_rev})"
         metadata:
           name: bugbug lint
           description: bugbug lint

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -52,7 +52,7 @@ tasks:
                git -c advice.detachedHead=false checkout ${head_rev} &&
                pip install --quiet -r test-requirements.txt &&
                git remote add upstream https://github.com/mozilla/bugbug &&
-               git fetch upstream &&
+               git fetch --quiet upstream &&
                pre-commit run --files $(git diff --name-only --diff-filter=d ${base_rev}...${head_rev})"
         metadata:
           name: bugbug lint

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -43,7 +43,8 @@ tasks:
                cd bugbug &&
                git -c advice.detachedHead=false checkout ${head_rev} &&
                pip install --quiet -r test-requirements.txt &&
-               pre-commit run -a" # TODO Be smarter and run only on modified files
+               git remote add upstream https://github.com/mozilla/bugbug &&
+               pre-commit run --files $(git diff --name-only --diff-filter=d upstream/master...)"
         metadata:
           name: bugbug lint
           description: bugbug lint


### PR DESCRIPTION
Addresses issue #298 .
I'm comparing against the master branch of the original repo; `upstream/master...` will compare the original repo to what's currently checked out, from their common ancestor. The `diff-filter` is an exclusive filter, that filters out files that have been deleted.