### PR TITLE
Separate generate_sheet from run.py

### DIFF
--- a/scripts/generate_sheet.py
+++ b/scripts/generate_sheet.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+import argparse
+import csv
+import os
+from datetime import datetime, timedelta
+
+from bugbug import bugzilla
+from bugbug.models import get_model_class
+
+
+def generate_sheet(model_name, token):
+    model_file_name = f"{model_name}model"
+
+    assert os.path.exists(
+        model_file_name
+    ), f"{model_file_name} does not exist. Train the model with trainer.py first."
+
+    model_class = get_model_class(model_name)
+    model = model_class.load(model_file_name)
+
+    today = datetime.utcnow()
+    a_week_ago = today - timedelta(7)
+    bugzilla.set_token(token)
+    bug_ids = bugzilla.get_ids_between(a_week_ago, today)
+    bugs = bugzilla.get(bug_ids)
+
+    print(f"Classifying {len(bugs)} bugs...")
+
+    rows = [["Bug", f"{model_name}(model)", model_name, "Title"]]
+
+    for bug in bugs.values():
+        p = model.classify(bug, probabilities=True)
+        rows.append(
+            [
+                f'https://bugzilla.mozilla.org/show_bug.cgi?id={bug["id"]}',
+                "y" if p[0][1] >= 0.7 else "n",
+                "",
+                bug["summary"],
+            ]
+        )
+
+    os.makedirs("sheets", exist_ok=True)
+    with open(
+        os.path.join(
+            "sheets",
+            f'{model_name}-{datetime.utcnow().strftime("%Y-%m-%d")}-labels.csv',
+        ),
+        "w",
+    ) as f:
+        writer = csv.writer(f)
+        writer.writerows(rows)
+
+
+def main():
+    description = "Perform evaluation on bugs from last week on the specified model and generate a csv file "
+    parser = argparse.ArgumentParser(description=description)
+
+    parser.add_argument("model", help="Which model to generate a csv for.")
+    parser.add_argument("token", help="Bugzilla token")
+
+    args = parser.parse_args()
+
+    generate_sheet(args.model, args.token)


### PR DESCRIPTION
Addresses #339
I moved the code to load the model and everything under `if args.generate_sheet:` from run.py into this script.
I was able to run the command with 
`python3 -c 'from scripts import generate_sheet; generate_sheet.main()' model token`.

Here's an example of the csv that was generated.
![image](https://user-images.githubusercontent.com/23666591/62259361-0d5ebb80-b3dc-11e9-82aa-a8a9b27509f4.png)
