### PR TITLE
Seperate bug_classifier.py from run.py

### DIFF
--- a/scripts/bug_classifier.py
+++ b/scripts/bug_classifier.py
@@ -8,11 +8,15 @@ import numpy as np
 from bugbug import bugzilla
 from bugbug.models import get_model_class
 
+MODELS_WITH_TYPE = ("component",)
+
 
 def classify_bugs(model_name, classifier):
-    classifier_models = ["component"]
+    if classifier != "default":
+        assert (
+            model_name in MODELS_WITH_TYPE
+        ), f"{classifier} is not a valid classifier type for {model_name}"
 
-    if classifier != "default" and model_name in classifier_models:
         model_file_name = f"{model_name}{classifier}model"
         model_name = f"{model_name}_{classifier}"
     else:

--- a/scripts/bug_classifier.py
+++ b/scripts/bug_classifier.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+
+import argparse
+import os
+
+import numpy as np
+
+from bugbug import bugzilla
+from bugbug.models import get_model_class
+
+
+def classify_bugs(model_name):
+    model_file_name = f"{model_name}model"
+
+    assert os.path.exists(
+        model_file_name
+    ), f"{model_file_name} does not exist. Train the model with trainer.py first."
+
+    model_class = get_model_class(model_name)
+    model = model_class.load(model_file_name)
+
+    for bug in bugzilla.get_bugs():
+        print(
+            f'https://bugzilla.mozilla.org/show_bug.cgi?id={bug["id"]} - {bug["summary"]} '
+        )
+
+        if model.calculate_importance:
+            probas, importance = model.classify(
+                bug, probabilities=True, importances=True
+            )
+
+            feature_names = model.get_human_readable_feature_names()
+
+            model.print_feature_importances(
+                importance["importances"], feature_names, class_probabilities=probas
+            )
+        else:
+            probas = model.classify(bug, probabilities=True, importances=False)
+
+        if np.argmax(probas) == 1:
+            print(f"Positive! {probas}")
+        else:
+            print(f"Negative! {probas}")
+        input()
+
+
+def main():
+    description = "Perform evaluation on bugs using the specified model"
+    parser = argparse.ArgumentParser(description=description)
+
+    parser.add_argument("model", help="Which model to use for evaluation")
+
+    args = parser.parse_args()
+
+    classify_bugs(args.model)

--- a/scripts/bug_classifier.py
+++ b/scripts/bug_classifier.py
@@ -9,8 +9,14 @@ from bugbug import bugzilla
 from bugbug.models import get_model_class
 
 
-def classify_bugs(model_name):
-    model_file_name = f"{model_name}model"
+def classify_bugs(model_name, classifier):
+    classifier_models = ["component"]
+
+    if classifier != "default" and model_name in classifier_models:
+        model_file_name = f"{model_name}{classifier}model"
+        model_name = f"{model_name}_{classifier}"
+    else:
+        model_file_name = f"{model_name}model"
 
     assert os.path.exists(
         model_file_name
@@ -49,7 +55,13 @@ def main():
     parser = argparse.ArgumentParser(description=description)
 
     parser.add_argument("model", help="Which model to use for evaluation")
+    parser.add_argument(
+        "--classifier",
+        help="Type of the classifier. Only used for component classification.",
+        choices=["default", "nn"],
+        default="default",
+    )
 
     args = parser.parse_args()
 
-    classify_bugs(args.model)
+    classify_bugs(args.model, args.classifier)

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
             "bugbug-check = scripts.check:main",
             "bugbug-microannotate-generate = scripts.microannotate_generator:main",
             "bugbug-classify-commit = scripts.commit_classifier:main",
+            "bugbug-classify-bug = scripts.bug_classifier:main",
             "bugbug-regressor-finder = scripts.regressor_finder:main",
         ]
     },


### PR DESCRIPTION
Addresses #339 
Moved code from under `args.classify` in run.py into this script. Also, I removed the model_loading code since it was no longer being used in run.py. 
I was able to run this script with the command;
`python3 -c 'from scripts import bug_classifier; bug_classifier.main()' model`

Example output:
```https://bugzilla.mozilla.org/show_bug.cgi?id=1322441 - The Internet Download Manager add-on can seriously slow down Firefox with e10s 
Top 11 features:
+-----------+----------------------------+---------------------------------+--------------------------+-----------------------------------------------------------------+-------------------------+
|   classes |   Comments contain 'fixed' |   Comments contain 'regression' |   Comments contain 'str' |   status has ever been set to 'affected' and 'unaffected'=False |   Comments contain '52' |
+===========+============================+=================================+==========================+=================================================================+=========================+
|         1 |                   0.139018 |                       -0.104707 |                0.0750531 |                                                      -0.0537768 |                0.052669 |
+-----------+----------------------------+---------------------------------+--------------------------+-----------------------------------------------------------------+-------------------------+

+------------------------------+---------------------------+-------------------------------+--------------------------+--------------------------------+---------------------------+
|   Comments contain 'support' |   Comments contain 'with' |   First comment contains 'we' |   Comments contain 'per' |   First comment contains 'not' |   Comments contain 'some' |
+==============================+===========================+===============================+==========================+================================+===========================+
|                    0.0516413 |                 0.0378344 |                     0.0293846 |               -0.0273952 |                      0.0267647 |                -0.0223058 |
+------------------------------+---------------------------+-------------------------------+--------------------------+--------------------------------+---------------------------+

Positive! [[0.19689035 0.80310965]]
```