### PR TITLE
Add security model for detecting security bugs

### DIFF
--- a/bugbug/models/__init__.py
+++ b/bugbug/models/__init__.py
@@ -21,6 +21,7 @@ MODELS = {
     "regression": "bugbug.models.regression.RegressionModel",
     "regressionrange": "bugbug.models.regressionrange.RegressionRangeModel",
     "regressor": "bugbug.models.regressor.RegressorModel",
+    "security": "bugbug.models.security.SecurityModel",
     "stepstoreproduce": "bugbug.models.stepstoreproduce.StepsToReproduceModel",
     "tracking": "bugbug.models.tracking.TrackingModel",
     "uplift": "bugbug.models.uplift.UpliftModel",

--- a/bugbug/models/security.py
+++ b/bugbug/models/security.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import xgboost
+from imblearn.under_sampling import RandomUnderSampler
+from sklearn.compose import ColumnTransformer
+from sklearn.feature_extraction import DictVectorizer
+from sklearn.pipeline import Pipeline
+
+from bugbug import bug_features, bugzilla, feature_cleanup
+from bugbug.model import BugModel
+
+SEC_KEYWORDS_LIST = [
+    "sec-audit",
+    "sec-critical",
+    "sec-high",
+    "sec-incident",
+    "sec-low",
+    "sec-moderate",
+    "sec-other",
+    "sec-vector",
+    "sec-want",
+]
+
+
+class SecurityModel(BugModel):
+    def __init__(self, lemmatization=False):
+        BugModel.__init__(self, lemmatization)
+
+        self.sampler = RandomUnderSampler(random_state=0)
+
+        feature_extractors = [
+            bug_features.has_str(),
+            bug_features.severity(),
+            bug_features.keywords(set(SEC_KEYWORDS_LIST)),
+            bug_features.has_crash_signature(),
+            bug_features.patches(),
+            bug_features.reporter_experience(),
+        ]
+
+        cleanup_functions = [
+            feature_cleanup.fileref(),
+            feature_cleanup.url(),
+            feature_cleanup.synonyms(),
+        ]
+
+        self.extraction_pipeline = Pipeline(
+            [
+                (
+                    "bug_extractor",
+                    bug_features.BugExtractor(
+                        feature_extractors,
+                        cleanup_functions,
+                        rollback=True,
+                        rollback_when=self.rollback,
+                    ),
+                ),
+                (
+                    "union",
+                    ColumnTransformer(
+                        [
+                            ("data", DictVectorizer(), "data"),
+                            ("title", self.text_vectorizer(), "title"),
+                            ("comments", self.text_vectorizer(), "comments"),
+                        ]
+                    ),
+                ),
+            ]
+        )
+
+        self.clf = xgboost.XGBClassifier(n_jobs=16)
+        self.clf.set_params(predictor="cpu_predictor")
+
+    def rollback(self, change):
+        return any(change["added"].startswith(prefix) for prefix in SEC_KEYWORDS_LIST)
+
+    def get_labels(self):
+        classes = {}
+
+        for bug_data in bugzilla.get_bugs():
+            bug_id = int(bug_data["id"])
+            for key in SEC_KEYWORDS_LIST:
+                if key in bug_data["keywords"]:
+                    classes[bug_id] = 1
+                else:
+                    classes[bug_id] = 0
+
+        print(
+            "{} bugs have security rating".format(
+                sum(1 for label in classes.values() if label == 1)
+            )
+        )
+        print(
+            "{} bugs don't have a security range".format(
+                sum(1 for label in classes.values() if label == 0)
+            )
+        )
+
+        return classes, [0, 1]
+
+    def get_feature_names(self):
+        return self.extraction_pipeline.named_steps["union"].get_feature_names()


### PR DESCRIPTION
Hi Marco, 
this is the first model for triaging security bugs I wrote. 
This one simply detects if a bug is security related and checks the result against the presence of sec-* keywords on actual triaged bugs.