### PR TITLE
Update dockerfile.commit_retrieval to install Mercurial without pip (#922)

### DIFF
--- a/infra/dockerfile.commit_retrieval
+++ b/infra/dockerfile.commit_retrieval
@@ -7,16 +7,16 @@ ARG MERCURIAL_VERSION="5.1"
 
 # git and git-hyper-blame (from depot_tools) are required by the annotate pipeline.
 RUN apt-get update && \
-    apt-get install -y python git curl && \
-    hg clone -r 709c897f2444 https://hg.mozilla.org/hgcustom/version-control-tools /version-control-tools/ && \
+    apt-get install -y python git curl tar && \
     curl -L https://www.mercurial-scm.org/release/mercurial-$MERCURIAL_VERSION.tar.gz | tar -C /opt -xvz && \
     python2 /opt/mercurial-$MERCURIAL_VERSION/setup.py install && \
+    hg clone -r 709c897f2444 https://hg.mozilla.org/hgcustom/version-control-tools /version-control-tools/ && \
     rm -r /version-control-tools/.hg /version-control-tools/ansible /version-control-tools/docs /version-control-tools/testing && \
     git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /depot_tools && \
     cd /depot_tools && git -c advice.detachedHead=false checkout 73065b2067bc1516728a1e6251df751db98f0fba && git apply /root/git_hyper_blame_patch && cd .. && \
     rm -r /depot_tools/.git /depot_tools/recipes /depot_tools/tests /depot_tools/man /depot_tools/testing_support /depot_tools/win_toolchain /depot_tools/bootstrap /depot_tools/fetch_configs && \
     curl -L https://github.com/mozilla/rust-code-analysis/releases/download/v0.0.2/rust-code-analysis-linux-x86_64.tar.bz2 | tar -C /usr/local/bin -xjv && \
-    apt-get purge -y curl && \
+    apt-get purge -y curl tar && \
     apt-get autoremove -y && \
     rm -r /var/lib/apt/lists/*
 

--- a/infra/dockerfile.commit_retrieval
+++ b/infra/dockerfile.commit_retrieval
@@ -2,23 +2,23 @@ FROM mozilla/bugbug-base:latest
 
 COPY infra/git_hyper_blame_patch /root/git_hyper_blame_patch
 
+# Setup mercurial from its own website, without install pip2 which has a lot of dependencies
+ARG MERCURIAL_VERSION="5.1"
+
 # git and git-hyper-blame (from depot_tools) are required by the annotate pipeline.
 RUN apt-get update && \
-    apt-get install -y python python-pip git curl && \
+    apt-get install -y python git curl && \
     hg clone -r 709c897f2444 https://hg.mozilla.org/hgcustom/version-control-tools /version-control-tools/ && \
+    curl -L https://www.mercurial-scm.org/release/mercurial-$MERCURIAL_VERSION.tar.gz | tar -C /opt -xvz && \
+    python2 /opt/mercurial-$MERCURIAL_VERSION/setup.py install && \
     rm -r /version-control-tools/.hg /version-control-tools/ansible /version-control-tools/docs /version-control-tools/testing && \
     git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /depot_tools && \
     cd /depot_tools && git -c advice.detachedHead=false checkout 73065b2067bc1516728a1e6251df751db98f0fba && git apply /root/git_hyper_blame_patch && cd .. && \
     rm -r /depot_tools/.git /depot_tools/recipes /depot_tools/tests /depot_tools/man /depot_tools/testing_support /depot_tools/win_toolchain /depot_tools/bootstrap /depot_tools/fetch_configs && \
     curl -L https://github.com/mozilla/rust-code-analysis/releases/download/v0.0.2/rust-code-analysis-linux-x86_64.tar.bz2 | tar -C /usr/local/bin -xjv && \
-    apt-get purge -y python-pip curl && \
+    apt-get purge -y curl && \
     apt-get autoremove -y && \
     rm -r /var/lib/apt/lists/*
-
-# Setup mercurial from its own website, without install pip2 which has a lot of dependencies
-ARG MERCURIAL_VERSION="5.1"
-RUN curl -L https://www.mercurial-scm.org/release/mercurial-$MERCURIAL_VERSION.tar.gz | tar -C /opt -xvz && \
-    python2 /opt/mercurial-$MERCURIAL_VERSION/setup.py install
 
 ENV PATH="${PATH}:/depot_tools"
 

--- a/infra/dockerfile.commit_retrieval
+++ b/infra/dockerfile.commit_retrieval
@@ -2,11 +2,9 @@ FROM mozilla/bugbug-base:latest
 
 COPY infra/git_hyper_blame_patch /root/git_hyper_blame_patch
 
-# Mercurial need Python2 :(
 # git and git-hyper-blame (from depot_tools) are required by the annotate pipeline.
 RUN apt-get update && \
     apt-get install -y python python-pip git curl && \
-    python2 -m pip install --disable-pip-version-check --no-cache-dir mercurial==5.1 && \
     hg clone -r 709c897f2444 https://hg.mozilla.org/hgcustom/version-control-tools /version-control-tools/ && \
     rm -r /version-control-tools/.hg /version-control-tools/ansible /version-control-tools/docs /version-control-tools/testing && \
     git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /depot_tools && \
@@ -16,6 +14,11 @@ RUN apt-get update && \
     apt-get purge -y python-pip curl && \
     apt-get autoremove -y && \
     rm -r /var/lib/apt/lists/*
+
+# Setup mercurial from its own website, without install pip2 which has a lot of dependencies
+ARG MERCURIAL_VERSION="5.1"
+RUN curl -L https://www.mercurial-scm.org/release/mercurial-$MERCURIAL_VERSION.tar.gz | tar -C /opt -xvz && \
+    python2 /opt/mercurial-$MERCURIAL_VERSION/setup.py install
 
 ENV PATH="${PATH}:/depot_tools"
 


### PR DESCRIPTION
Updated infra/dockerfile.commit_retrieval to install Mercurial from the official homepage (https://www.mercurial-scm.org/) instead of using pip.

Signed-off-by: Arunangshu Biswas <arunangshubsws@gmail.com>