### PR TITLE
Ensure the integration tests are green before releasing. Fix #949

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -435,7 +435,7 @@ tasks:
                 apt-get update &&
                 apt-get install -y redis-server &&
                 python -c 'import os; print(os.environ.keys())' &&
-                bash ./scripts/integration_test.sh || true"
+                bash ./scripts/integration_test.sh"
           metadata:
             name: bugbug integration test
             description: bugbug integration test

--- a/infra/data-pipeline.yml
+++ b/infra/data-pipeline.yml
@@ -633,9 +633,44 @@ tasks:
         owner: release-mgmt-analysis@mozilla.com
         source: https://github.com/mozilla/bugbug/raw/master/data-pipeline.yml
 
+    - ID: integration-test
+      created: {$fromNow: ''}
+      deadline: {$fromNow: '119 hours'}
+      expires: {$fromNow: '1 month'}
+      provisionerId: aws-provisioner-v1
+      workerType: relman-svc
+      scopes:
+        - secrets:get:project/relman/bugbug/integration
+      payload:
+        features:
+          taskclusterProxy:
+            true
+        maxRunTime: 10800
+        image: mozilla/bugbug-commit-retrieval:latest
+        env:
+          TC_SECRET_ID: project/relman/bugbug/integration
+        command:
+          - "/bin/bash"
+          - "-lcx"
+          - "git clone --quiet ${repository} &&
+            cd bugbug &&
+            git -c advice.detachedHead=false checkout ${head_rev} &&
+            pip install --quiet . &&
+            pip install --quiet -r test-requirements.txt &&
+            apt-get update &&
+            apt-get install -y redis-server &&
+            python -c 'import os; print(os.environ.keys())' &&
+            bash ./scripts/integration_test.sh || true"
+      metadata:
+        name: bugbug integration test
+        description: bugbug integration test
+        owner: release-mgmt-analysis@mozilla.com
+        source: https://github.com/mozilla/bugbug/raw/master/data-pipeline.yml
+
     - ID: docker-push
       dependencies:
         - docker-build
+        - integration-test
       scopes:
         - secrets:get:project/relman/bugbug/deploy
       created: {$fromNow: ''}

--- a/infra/data-pipeline.yml
+++ b/infra/data-pipeline.yml
@@ -660,7 +660,7 @@ tasks:
             apt-get update &&
             apt-get install -y redis-server &&
             python -c 'import os; print(os.environ.keys())' &&
-            bash ./scripts/integration_test.sh || true"
+            bash ./scripts/integration_test.sh"
       metadata:
         name: bugbug integration test
         description: bugbug integration test

--- a/infra/data-pipeline.yml
+++ b/infra/data-pipeline.yml
@@ -652,9 +652,9 @@ tasks:
         command:
           - "/bin/bash"
           - "-lcx"
-          - "git clone --quiet ${repository} &&
+          - "git clone --quiet https://github.com/mozilla/bugbug &&
             cd bugbug &&
-            git -c advice.detachedHead=false checkout ${head_rev} &&
+            git checkout ${version} &&
             pip install --quiet . &&
             pip install --quiet -r test-requirements.txt &&
             apt-get update &&

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -8,9 +8,10 @@ set -euox pipefail
 
 cd http_service/models/;
 
-# Remove the models
+# Remove the models and any old data
 rm defectenhancementtaskmodel* || true;
 rm backout* || true;
+rm -Rf data || true;
 
 # First retrieve a subset of bugs data
 # TODO: Let the script download the previous DB as it should be pretty fast?


### PR DESCRIPTION
Now that the integration tests are running correctly on taskcluster, ensure we
don't push the bugbug release on Pypi nor push the Docker image if they are
broken as a safety guard.