### PR TITLE
Fix rollbacking bugs with no comments

### DIFF
--- a/bugbug/bug_snapshot.py
+++ b/bugbug/bug_snapshot.py
@@ -833,6 +833,18 @@ def rollback(bug, when=None, do_assert=False):
 
                 bug[field] = old_value
 
+    if len(bug["comments"]) == 0:
+        assert_or_log("There must be at least one comment")
+        bug["comments"] = [
+            {
+                "count": 0,
+                "id": 0,
+                "text": "",
+                "author": bug["creator"],
+                "creation_time": bug["creation_time"],
+            }
+        ]
+
     # If the first comment is hidden.
     if bug["comments"][0]["count"] != 0:
         bug["comments"].insert(
@@ -857,17 +869,6 @@ def rollback(bug, when=None, do_assert=False):
         if dateutil.parser.parse(a["creation_time"]) - relativedelta(seconds=3)
         <= rollback_date
     ]
-
-    if len(bug["comments"]) == 0:
-        assert_or_log("There must be at least one comment")
-        bug["comments"] = [
-            {
-                "id": 0,
-                "text": "",
-                "author": bug["creator"],
-                "creation_time": bug["creation_time"],
-            }
-        ]
 
     return bug
 


### PR DESCRIPTION
Should fix #1048. Also contains a few other fixes to get the spambug model running.
@marco-c Quick question: [items_gen](https://github.com/mozilla/bugbug/blob/master/bugbug/model.py#L658) should use `bugzilla.get_bugs(include_invalid=True)` for this particular model, else our training data will have only one label. One way to fix this would be to derive a new class from `BugModel`, and overwrite the `items_gen` method, and use this specifically for the spambug model. Should I go ahead with this fix, or is there a better way?

(Also, results of the spambug model are in the comment below)