### PR TITLE
Stop using sklearn.metrics.classification as it is deprecated

### DIFF
--- a/bugbug/model.py
+++ b/bugbug/model.py
@@ -18,7 +18,7 @@ from imblearn.metrics import (
 from imblearn.pipeline import make_pipeline
 from sklearn import metrics
 from sklearn.feature_extraction.text import TfidfVectorizer
-from sklearn.metrics.classification import precision_recall_fscore_support
+from sklearn.metrics import precision_recall_fscore_support
 from sklearn.model_selection import cross_validate, train_test_split
 from tabulate import tabulate
 


### PR DESCRIPTION
sklearn.metrics.classification is deprecated #1184