### PR TITLE
Disable feature importance for spambug model

### DIFF
--- a/bugbug/models/spambug.py
+++ b/bugbug/models/spambug.py
@@ -18,6 +18,7 @@ class SpamBugModel(BugModel):
         BugModel.__init__(self, lemmatization)
 
         self.sampler = RandomUnderSampler(random_state=0)
+        self.calculate_importance = False
 
         feature_extractors = [
             bug_features.has_str(),


### PR DESCRIPTION
Fixes: #1200 

Tried it locally, training the model doesn't crash anymore. Once this is merged, we can move ahead with using the model in relman-auto-nag.