### PR TITLE
Make sure we run the 'http_service' tests in CI

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -103,6 +103,7 @@ tasks:
                pip install --disable-pip-version-check --quiet --no-cache-dir -r infra/spawn_pipeline_requirements.txt &&
                pip install --disable-pip-version-check --quiet --no-cache-dir -r test-requirements.txt &&
                python -m pytest --cov=./ tests/test_*.py &&
+               python -m pytest --cov=./ http_service/tests/test_*.py &&
                bash <(curl -s https://codecov.io/bash)"
         metadata:
           name: bugbug tests


### PR DESCRIPTION
Running them alongside the `/tests` directory in the same pytest invocation results in:
```
pytest fixture "mock_data" not found
```

for each of the http_service tests. I guess `pytest` registers it from the /tests/conftest.py file first, and then later can't find it anywhere in `/http_service/tests`.

This gets around the issue in CI, but running:
```
pytest tests http_service/tests
```

still fails locally for me.