### PR TITLE
Ignore http_service directory when building bugbug base images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -97,4 +97,5 @@ venv/
 # Project-specific stuff
 cache/
 data/
+http_service/
 .taskcluster.yml


### PR DESCRIPTION
Otherwise whenever we make changes to the http_service, the base images are rebuilt.

Regression from 0eb7f91a232857eef8a6b578024ede569dfe85f1

Fixes #1337