### PR TITLE
Return 404 when model doesn't exist

### DIFF
--- a/http_service/bugbug_http/app.py
+++ b/http_service/bugbug_http/app.py
@@ -262,6 +262,9 @@ def model_prediction(model_name, bug_id):
     else:
         LOGGER.info("Request with API TOKEN %r", auth)
 
+    if model_name not in MODELS_NAMES:
+        return jsonify({"error": f"Model {model_name} doesn't exist"}), 404
+
     # Get the latest change from Bugzilla for the bug
     bug = get_bugs_last_change_time([bug_id])
 
@@ -404,6 +407,9 @@ def batch_prediction(model_name):
         return jsonify(UnauthorizedError().dump({}).data), 401
     else:
         LOGGER.info("Request with API TOKEN %r", auth)
+
+    if model_name not in MODELS_NAMES:
+        return jsonify({"error": f"Model {model_name} doesn't exist"}), 404
 
     # TODO Check is JSON is valid and validate against a request schema
     batch_body = json.loads(request.data)

--- a/http_service/tests/test_app.py
+++ b/http_service/tests/test_app.py
@@ -66,3 +66,18 @@ def test_non_int_batch(client):
             ]
         }
     }
+
+
+def test_unknown_model(client):
+    """Start with  a blank database,"""
+    bugs = [1, 2, 3]
+    unknown_model = "unknown_model"
+
+    rv = client.post(
+        f"/{unknown_model}/predict/batch",
+        data=json.dumps({"bugs": bugs}),
+        headers={API_TOKEN: "test"},
+    )
+
+    assert rv.status_code == 404
+    assert rv.json == {"error": f"Model {unknown_model} doesn't exist"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,5 @@ tabulate==0.8.6
 taskcluster==25.4.0
 tenacity==6.1.0
 tqdm==4.43.0
-xgboost==0.90
+xgboost==1.0.1
 zstandard==0.13.0


### PR DESCRIPTION
Fixes #1265

Returns 404 with an error message when an unknown model is used.
Added test cases for the same.