### PR TITLE
Fix old style redis key in classify_bug

### DIFF
--- a/http_service/bugbug_http/app.py
+++ b/http_service/bugbug_http/app.py
@@ -261,7 +261,7 @@ def clean_prediction_cache(job):
 
 
 def get_result(job):
-    LOGGER.debug(f"Checking for existing results for {job}")
+    LOGGER.debug(f"Checking for existing results at {job.result_key}")
     result = redis_conn.get(job.result_key)
 
     if result:


### PR DESCRIPTION
This also refactors all calls that store keys in redis to a 'setkey'
function. The main purpose being so we can log transactions at the debug
level, making it easier to investigate failures like this in the future.

Fixes #1365