### PR TITLE
Revert "Commit classifier now applies phabricator patch just after repo clone"

### DIFF
--- a/scripts/commit_classifier.py
+++ b/scripts/commit_classifier.py
@@ -125,30 +125,16 @@ def replace_reviewers(commit_description, reviewers):
 
 
 class CommitClassifier(object):
-    def __init__(
-        self,
-        model_name,
-        repo_dir,
-        git_repo_dir,
-        method_defect_predictor_dir,
-        phabricator_deployment=None,
-        diff_id=None,
-    ):
+    def __init__(self, model_name, repo_dir, git_repo_dir, method_defect_predictor_dir):
         self.model_name = model_name
         self.repo_dir = repo_dir
+
+        self.model = download_and_load_model(model_name)
+        assert self.model is not None
 
         self.git_repo_dir = git_repo_dir
         if git_repo_dir:
             self.clone_git_repo("https://github.com/mozilla/gecko-dev", git_repo_dir)
-
-        repository.clone(self.repo_dir)
-
-        with hglib.open(self.repo_dir) as hg:
-            if phabricator_deployment is not None and diff_id is not None:
-                self.apply_phab(hg, phabricator_deployment, diff_id)
-
-        self.model = download_and_load_model(model_name)
-        assert self.model is not None
 
         self.method_defect_predictor_dir = method_defect_predictor_dir
         if method_defect_predictor_dir:
@@ -565,12 +551,26 @@ class CommitClassifier(object):
             json.dump(features, f)
 
     def classify(
-        self, revision=None, runnable_jobs_path=None,
+        self,
+        revision=None,
+        phabricator_deployment=None,
+        diff_id=None,
+        runnable_jobs_path=None,
     ):
+        if revision is not None:
+            assert phabricator_deployment is None
+            assert diff_id is None
+
+        if diff_id is not None:
+            assert phabricator_deployment is not None
+            assert revision is None
+
         self.update_commit_db()
 
         with hglib.open(self.repo_dir) as hg:
-            if revision is None:
+            if phabricator_deployment is not None and diff_id is not None:
+                self.apply_phab(hg, phabricator_deployment, diff_id)
+
                 revision = hg.log(revrange="not public()")[0].node.decode("utf-8")
 
             # Analyze patch.
@@ -794,23 +794,12 @@ def main():
 
     args = parser.parse_args()
 
-    if args.revision is not None:
-        assert args.phabricator_deployment is None
-        assert args.diff_id is None
-
-    if args.diff_id is not None:
-        assert args.phabricator_deployment is not None
-        assert args.revision is None
-
     classifier = CommitClassifier(
-        args.model,
-        args.repo_dir,
-        args.git_repo_dir,
-        args.method_defect_predictor_dir,
-        args.phabricator_deployment,
-        args.diff_id,
+        args.model, args.repo_dir, args.git_repo_dir, args.method_defect_predictor_dir
     )
-    classifier.classify(args.revision, args.runnable_jobs)
+    classifier.classify(
+        args.revision, args.phabricator_deployment, args.diff_id, args.runnable_jobs
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reverts mozilla/bugbug#1388

@kaushiksk unfortunately it didn't work:
```
Traceback (most recent call last):
  File "/usr/local/bin/bugbug-classify-commit", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/site-packages/scripts/commit_classifier.py", line 813, in main
    classifier.classify(args.revision, args.runnable_jobs)
  File "/usr/local/lib/python3.8/site-packages/scripts/commit_classifier.py", line 574, in classify
    revision = hg.log(revrange="not public()")[0].node.decode("utf-8")
IndexError: list index out of range
```