### PR TITLE
Use scientific literature names for Halstead

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -93,7 +93,7 @@ tasks:
                pip install --disable-pip-version-check --quiet --no-cache-dir mercurial==5.3 &&
                hg clone -r ce06125e4728 https://hg.mozilla.org/hgcustom/version-control-tools /version-control-tools/ &&
                git clone --quiet ${repository} &&
-               curl -L https://github.com/mozilla/rust-code-analysis/releases/download/v0.0.10/rust-code-analysis-linux-x86_64.tar.gz | tar -C /usr/bin -xzv --strip=1 && chmod +x /usr/bin/rust-code-analysis &&
+               curl -L https://github.com/mozilla/rust-code-analysis/releases/download/v0.0.11/rust-code-analysis-linux-x86_64.tar.gz | tar -C /usr/bin -xzv --strip=1 && chmod +x /usr/bin/rust-code-analysis &&
                cd bugbug &&
                git -c advice.detachedHead=false checkout ${head_rev} &&
                cp infra/hgrc /etc/mercurial/hgrc.d/bugbug.rc &&
@@ -126,7 +126,7 @@ tasks:
             - "pip install --disable-pip-version-check --quiet --no-cache-dir mercurial==5.3 &&
                hg clone -r ce06125e4728 https://hg.mozilla.org/hgcustom/version-control-tools /version-control-tools/ &&
                git clone --quiet ${repository} &&
-               curl -L https://github.com/mozilla/rust-code-analysis/releases/download/v0.0.10/rust-code-analysis-linux-x86_64.tar.gz | tar -C /usr/bin -xzv --strip=1 && chmod +x /usr/bin/rust-code-analysis &&
+               curl -L https://github.com/mozilla/rust-code-analysis/releases/download/v0.0.11/rust-code-analysis-linux-x86_64.tar.gz | tar -C /usr/bin -xzv --strip=1 && chmod +x /usr/bin/rust-code-analysis &&
                cd bugbug &&
                git -c advice.detachedHead=false checkout ${head_rev} &&
                cp infra/hgrc /etc/mercurial/hgrc.d/bugbug.rc &&

--- a/bugbug/commit_features.py
+++ b/bugbug/commit_features.py
@@ -134,43 +134,29 @@ class source_code_file_metrics(object):
     def __call__(self, commit, **kwargs):
         return {
             "Average cyclomatic": commit["average_cyclomatic"],
-            "Average number of unique operands": commit[
-                "average_halstead_unique_operands"
-            ],
-            "Average number of operands": commit["average_halstead_operands"],
-            "Average number of unique operators": commit[
-                "average_halstead_unique_operators"
-            ],
-            "Average number of operators": commit["average_halstead_operators"],
+            "Average number of unique operands": commit["average_halstead_n2"],
+            "Average number of operands": commit["average_halstead_N2"],
+            "Average number of unique operators": commit["average_halstead_n1"],
+            "Average number of operators": commit["average_halstead_N1"],
             "Average number of source loc": commit["average_source_loc"],
             "Average number of logical loc": commit["average_logical_loc"],
             "Maximum cyclomatic": commit["maximum_cyclomatic"],
-            "Maximum number of unique operands": commit[
-                "maximum_halstead_unique_operands"
-            ],
-            "Maximum number of operands": commit["maximum_halstead_operands"],
-            "Maximum number of unique operators": commit[
-                "maximum_halstead_unique_operators"
-            ],
-            "Maximum number of operators": commit["maximum_halstead_operators"],
+            "Maximum number of unique operands": commit["maximum_halstead_n2"],
+            "Maximum number of operands": commit["maximum_halstead_N2"],
+            "Maximum number of unique operators": commit["maximum_halstead_n1"],
+            "Maximum number of operators": commit["maximum_halstead_N1"],
             "Maximum number of source loc": commit["maximum_source_loc"],
             "Maximum number of logical loc": commit["maximum_logical_loc"],
             "Minimum cyclomatic": commit["minimum_cyclomatic"],
-            "Minimum number of unique operands": commit[
-                "minimum_halstead_unique_operands"
-            ],
-            "Minimum number of operands": commit["minimum_halstead_operands"],
-            "Minimum number of unique operators": commit[
-                "minimum_halstead_unique_operators"
-            ],
-            "Minimum number of operators": commit["minimum_halstead_operators"],
+            "Minimum number of unique operands": commit["minimum_halstead_n2"],
+            "Minimum number of operands": commit["minimum_halstead_N2"],
+            "Minimum number of unique operators": commit["minimum_halstead_n1"],
+            "Minimum number of operators": commit["minimum_halstead_N1"],
             "Minimum number of source loc": commit["minimum_source_loc"],
             "Minimum number of logical loc": commit["minimum_logical_loc"],
-            "Total of number of operands": commit["total_halstead_operands"],
-            "Total of number of unique operators": commit[
-                "total_halstead_unique_operators"
-            ],
-            "Total number of operators": commit["total_halstead_operators"],
+            "Total of number of operands": commit["total_halstead_N2"],
+            "Total of number of unique operators": commit["total_halstead_n1"],
+            "Total number of operators": commit["total_halstead_N1"],
             "Total number of source loc": commit["total_source_loc"],
             "Total number of logical loc": commit["total_logical_loc"],
         }
@@ -540,68 +526,36 @@ def merge_commits(commits):
         "test_deleted": sum(commit["test_deleted"] for commit in commits),
         "average_cyclomatic": sum(commit["average_cyclomatic"] for commit in commits)
         / len(commits),
-        "average_halstead_unique_operands": sum(
-            commit["average_halstead_unique_operands"] for commit in commits
-        )
+        "average_halstead_n2": sum(commit["average_halstead_n2"] for commit in commits)
         / len(commits),
-        "average_halstead_operands": sum(
-            commit["average_halstead_operands"] for commit in commits
-        )
+        "average_halstead_N2": sum(commit["average_halstead_N2"] for commit in commits)
         / len(commits),
-        "average_halstead_unique_operators": sum(
-            commit["average_halstead_unique_operators"] for commit in commits
-        )
+        "average_halstead_n1": sum(commit["average_halstead_n1"] for commit in commits)
         / len(commits),
-        "average_halstead_operators": sum(
-            commit["average_halstead_operators"] for commit in commits
-        )
+        "average_halstead_N1": sum(commit["average_halstead_N1"] for commit in commits)
         / len(commits),
         "average_source_loc": sum(commit["average_source_loc"] for commit in commits)
         / len(commits),
         "average_logical_loc": sum(commit["average_logical_loc"] for commit in commits)
         / len(commits),
         "maximum_cyclomatic": max(commit["maximum_cyclomatic"] for commit in commits),
-        "maximum_halstead_unique_operands": max(
-            commit["maximum_halstead_unique_operands"] for commit in commits
-        ),
-        "maximum_halstead_operands": max(
-            commit["maximum_halstead_operands"] for commit in commits
-        ),
-        "maximum_halstead_unique_operators": max(
-            commit["maximum_halstead_unique_operators"] for commit in commits
-        ),
-        "maximum_halstead_operators": max(
-            commit["maximum_halstead_operators"] for commit in commits
-        ),
+        "maximum_halstead_n2": max(commit["maximum_halstead_n2"] for commit in commits),
+        "maximum_halstead_N2": max(commit["maximum_halstead_N2"] for commit in commits),
+        "maximum_halstead_n1": max(commit["maximum_halstead_n1"] for commit in commits),
+        "maximum_halstead_N1": max(commit["maximum_halstead_N1"] for commit in commits),
         "maximum_source_loc": max(commit["maximum_source_loc"] for commit in commits),
         "maximum_logical_loc": max(commit["maximum_logical_loc"] for commit in commits),
         "minimum_cyclomatic": min(commit["minimum_cyclomatic"] for commit in commits),
-        "minimum_halstead_unique_operands": min(
-            commit["minimum_halstead_unique_operands"] for commit in commits
-        ),
-        "minimum_halstead_operands": min(
-            commit["minimum_halstead_operands"] for commit in commits
-        ),
-        "minimum_halstead_unique_operators": min(
-            commit["minimum_halstead_unique_operators"] for commit in commits
-        ),
-        "minimum_halstead_operators": min(
-            commit["minimum_halstead_operators"] for commit in commits
-        ),
+        "minimum_halstead_n2": min(commit["minimum_halstead_n2"] for commit in commits),
+        "minimum_halstead_N2": min(commit["minimum_halstead_N2"] for commit in commits),
+        "minimum_halstead_n1": min(commit["minimum_halstead_n1"] for commit in commits),
+        "minimum_halstead_N1": min(commit["minimum_halstead_N1"] for commit in commits),
         "minimum_source_loc": min(commit["minimum_source_loc"] for commit in commits),
         "minimum_logical_loc": min(commit["minimum_logical_loc"] for commit in commits),
-        "total_halstead_unique_operands": sum(
-            commit["total_halstead_unique_operands"] for commit in commits
-        ),
-        "total_halstead_operands": sum(
-            commit["total_halstead_operands"] for commit in commits
-        ),
-        "total_halstead_unique_operators": sum(
-            commit["total_halstead_unique_operators"] for commit in commits
-        ),
-        "total_halstead_operators": sum(
-            commit["total_halstead_operators"] for commit in commits
-        ),
+        "total_halstead_n2": sum(commit["total_halstead_n2"] for commit in commits),
+        "total_halstead_N2": sum(commit["total_halstead_N2"] for commit in commits),
+        "total_halstead_n1": sum(commit["total_halstead_n1"] for commit in commits),
+        "total_halstead_N1": sum(commit["total_halstead_N1"] for commit in commits),
         "total_source_loc": sum(commit["total_source_loc"] for commit in commits),
         "total_logical_loc": sum(commit["total_logical_loc"] for commit in commits),
     }

--- a/bugbug/repository.py
+++ b/bugbug/repository.py
@@ -141,31 +141,31 @@ class Commit:
         self.minimum_test_file_size = 0
         self.test_files_modified_num = 0
         self.average_cyclomatic = 0.0
-        self.average_halstead_operands = 0.0
-        self.average_halstead_unique_operands = 0.0
-        self.average_halstead_operators = 0.0
-        self.average_halstead_unique_operators = 0.0
+        self.average_halstead_N1 = 0.0
+        self.average_halstead_n1 = 0.0
+        self.average_halstead_N2 = 0.0
+        self.average_halstead_n2 = 0.0
         self.average_source_loc = 0.0
         self.average_logical_loc = 0.0
         self.maximum_cyclomatic = 0
-        self.maximum_halstead_operands = 0
-        self.maximum_halstead_unique_operands = 0
-        self.maximum_halstead_operators = 0
-        self.maximum_halstead_unique_operators = 0
+        self.maximum_halstead_N2 = 0
+        self.maximum_halstead_n2 = 0
+        self.maximum_halstead_N1 = 0
+        self.maximum_halstead_n1 = 0
         self.maximum_source_loc = 0
         self.maximum_logical_loc = 0
         self.minimum_cyclomatic = sys.maxsize
-        self.minimum_halstead_operands = sys.maxsize
-        self.minimum_halstead_unique_operands = sys.maxsize
-        self.minimum_halstead_operators = sys.maxsize
-        self.minimum_halstead_unique_operators = sys.maxsize
+        self.minimum_halstead_N1 = sys.maxsize
+        self.minimum_halstead_n1 = sys.maxsize
+        self.minimum_halstead_N2 = sys.maxsize
+        self.minimum_halstead_n2 = sys.maxsize
         self.minimum_source_loc = sys.maxsize
         self.minimum_logical_loc = sys.maxsize
         self.total_cyclomatic = 0
-        self.total_halstead_operands = 0
-        self.total_halstead_unique_operands = 0
-        self.total_halstead_operators = 0
-        self.total_halstead_unique_operators = 0
+        self.total_halstead_N1 = 0
+        self.total_halstead_n1 = 0
+        self.total_halstead_N2 = 0
+        self.total_halstead_n2 = 0
         self.total_source_loc = 0
         self.total_logical_loc = 0
 
@@ -358,31 +358,27 @@ def get_metrics(commit, metrics_space):
     if metrics_space["kind"] == "function":
         metrics = metrics_space["metrics"]
         commit.total_cyclomatic += metrics["cyclomatic"]
-        commit.total_halstead_unique_operands += metrics["halstead"]["unique_operands"]
-        commit.total_halstead_operands += metrics["halstead"]["operands"]
-        commit.total_halstead_unique_operators += metrics["halstead"][
-            "unique_operators"
-        ]
-        commit.total_halstead_operators += metrics["halstead"]["operators"]
+        commit.total_halstead_n2 += metrics["halstead"]["n2"]
+        commit.total_halstead_N2 += metrics["halstead"]["N2"]
+        commit.total_halstead_n1 += metrics["halstead"]["n1"]
+        commit.total_halstead_N1 += metrics["halstead"]["N1"]
         commit.total_source_loc += metrics["loc"]["sloc"]
         commit.total_logical_loc += metrics["loc"]["lloc"]
 
         commit.maximum_cyclomatic = max(
             commit.maximum_cyclomatic, metrics["cyclomatic"]
         )
-        commit.maximum_halstead_unique_operands = max(
-            commit.maximum_halstead_unique_operands,
-            metrics["halstead"]["unique_operands"],
+        commit.maximum_halstead_n2 = max(
+            commit.maximum_halstead_n2, metrics["halstead"]["n2"],
         )
-        commit.maximum_halstead_operands = max(
-            metrics["halstead"]["operands"], commit.maximum_halstead_operands
+        commit.maximum_halstead_N2 = max(
+            metrics["halstead"]["N2"], commit.maximum_halstead_N2
         )
-        commit.maximum_halstead_unique_operators = max(
-            metrics["halstead"]["unique_operators"],
-            commit.maximum_halstead_unique_operators,
+        commit.maximum_halstead_n1 = max(
+            metrics["halstead"]["n1"], commit.maximum_halstead_n1,
         )
-        commit.maximum_halstead_operators = max(
-            metrics["halstead"]["operators"], commit.maximum_halstead_operators
+        commit.maximum_halstead_N1 = max(
+            metrics["halstead"]["N1"], commit.maximum_halstead_N1
         )
         commit.maximum_source_loc = max(
             metrics["loc"]["sloc"], commit.maximum_source_loc
@@ -394,19 +390,17 @@ def get_metrics(commit, metrics_space):
         commit.minimum_cyclomatic = min(
             commit.minimum_cyclomatic, metrics["cyclomatic"]
         )
-        commit.minimum_halstead_unique_operands = min(
-            commit.minimum_halstead_unique_operands,
-            metrics["halstead"]["unique_operands"],
+        commit.minimum_halstead_n2 = min(
+            commit.minimum_halstead_n2, metrics["halstead"]["n2"],
         )
-        commit.minimum_halstead_operands = min(
-            metrics["halstead"]["operands"], commit.minimum_halstead_operands
+        commit.minimum_halstead_N2 = min(
+            metrics["halstead"]["N2"], commit.minimum_halstead_N2
         )
-        commit.minimum_halstead_unique_operators = min(
-            metrics["halstead"]["unique_operators"],
-            commit.minimum_halstead_unique_operators,
+        commit.minimum_halstead_n1 = min(
+            metrics["halstead"]["n1"], commit.minimum_halstead_n1,
         )
-        commit.minimum_halstead_operators = min(
-            metrics["halstead"]["operators"], commit.minimum_halstead_operators
+        commit.minimum_halstead_N1 = min(
+            metrics["halstead"]["N1"], commit.minimum_halstead_N1
         )
         commit.minimum_source_loc = min(
             metrics["loc"]["sloc"], commit.minimum_source_loc
@@ -537,28 +531,20 @@ def transform(hg, repo_dir, commit):
 
     if metrics_file_count:
         commit.average_cyclomatic = commit.total_cyclomatic / metrics_file_count
-        commit.average_halstead_unique_operands = (
-            commit.total_halstead_unique_operands / metrics_file_count
-        )
-        commit.average_halstead_operands = (
-            commit.total_halstead_operands / metrics_file_count
-        )
-        commit.average_halstead_unique_operators = (
-            commit.total_halstead_unique_operators / metrics_file_count
-        )
-        commit.average_halstead_operators = (
-            commit.total_halstead_operators / metrics_file_count
-        )
+        commit.average_halstead_n2 = commit.total_halstead_n2 / metrics_file_count
+        commit.average_halstead_N2 = commit.total_halstead_N2 / metrics_file_count
+        commit.average_halstead_n1 = commit.total_halstead_n1 / metrics_file_count
+        commit.average_halstead_N1 = commit.total_halstead_N1 / metrics_file_count
         commit.average_source_loc = commit.total_source_loc / metrics_file_count
         commit.average_logical_loc = commit.total_logical_loc / metrics_file_count
     else:
         # these values are initialized with sys.maxsize (because we take the min)
         # if no files, then reset them to 0 (it'd be stupid to have min > max)
         commit.minimum_cyclomatic = 0
-        commit.minimum_halstead_operands = 0
-        commit.minimum_halstead_unique_operands = 0
-        commit.minimum_halstead_operators = 0
-        commit.minimum_halstead_unique_operators = 0
+        commit.minimum_halstead_N2 = 0
+        commit.minimum_halstead_n2 = 0
+        commit.minimum_halstead_N1 = 0
+        commit.minimum_halstead_n1 = 0
         commit.minimum_source_loc = 0
         commit.minimum_logical_loc = 0
 

--- a/infra/dockerfile.commit_retrieval
+++ b/infra/dockerfile.commit_retrieval
@@ -11,7 +11,7 @@ RUN apt-get update && \
     pip install --disable-pip-version-check --quiet --no-cache-dir mercurial==5.3 && \
     hg clone -r ce06125e4728 https://hg.mozilla.org/hgcustom/version-control-tools /version-control-tools/ && \
     rm -r /version-control-tools/.hg /version-control-tools/ansible /version-control-tools/docs /version-control-tools/testing && \
-    curl -L https://github.com/mozilla/rust-code-analysis/releases/download/v0.0.10/rust-code-analysis-linux-x86_64.tar.gz | tar -C /usr/bin -xzv --strip=1 && \
+    curl -L https://github.com/mozilla/rust-code-analysis/releases/download/v0.0.11/rust-code-analysis-linux-x86_64.tar.gz | tar -C /usr/bin -xzv --strip=1 && \
     apt-get purge -y gcc g++ curl && \
     apt-get autoremove -y && \
     rm -r /var/lib/apt/lists/*


### PR DESCRIPTION
Starting from https://github.com/mozilla/rust-code-analysis/pull/115, `rust-code-analysis` is using scientific literature names for the `Halstead` metric, so it would be better to change those names even here. 

Thanks in advance for your review! :)