### PR TITLE
Only consider draft changesets when getting the stack of patches to apply from a try push

### DIFF
--- a/bugbug/utils.py
+++ b/bugbug/utils.py
@@ -419,7 +419,11 @@ def get_hgmo_stack(branch: str, revision: str) -> list:
     url = f"https://hg.mozilla.org/{branch}/json-automationrelevance/{revision}"
     r = get_session("hgmo").get(url)
     r.raise_for_status()
-    return r.json()["changesets"]
+    return [
+        c
+        for c in r.json()["changesets"]
+        if branch != "try" or c.get("phase") == "draft"
+    ]
 
 
 def get_hgmo_patch(branch: str, revision: str) -> str:

--- a/http_service/tests/fixtures/hgmo_try/bad123.json
+++ b/http_service/tests/fixtures/hgmo_try/bad123.json
@@ -4,7 +4,8 @@
             "node": "bad123",
             "parents": [
                 "BASE_HISTORY_2"
-            ]
+            ],
+            "phase": "draft"
         }
     ],
     "visible": true

--- a/http_service/tests/fixtures/hgmo_try/needRemote.json
+++ b/http_service/tests/fixtures/hgmo_try/needRemote.json
@@ -1,10 +1,18 @@
 {
     "changesets": [
         {
+            "node": "aPublicParent",
+            "parents": [
+                "REVISION_DOES_NOT_EXIST"
+            ],
+            "phase": "public"
+        },
+        {
             "node": "needRemote",
             "parents": [
                 "PULLED_FROM_REMOTE"
-            ]
+            ],
+            "phase": "draft"
         }
     ],
     "visible": true

--- a/http_service/tests/fixtures/hgmo_try/normal456.json
+++ b/http_service/tests/fixtures/hgmo_try/normal456.json
@@ -4,13 +4,15 @@
             "node": "localParent456",
             "parents": [
                 "BASE_HISTORY_1"
-            ]
+            ],
+            "phase": "draft"
         },
         {
             "node": "normal456",
             "parents": [
                 "localParent456"
-            ]
+            ],
+            "phase": "draft"
         }
     ],
     "visible": true

--- a/http_service/tests/fixtures/hgmo_try/orphan456.json
+++ b/http_service/tests/fixtures/hgmo_try/orphan456.json
@@ -4,7 +4,8 @@
             "node": "orphan456",
             "parents": [
                 "REVISION_DOES_NOT_EXIST"
-            ]
+            ],
+            "phase": "draft"
         }
     ],
     "visible": true


### PR DESCRIPTION
Otherwise pushes such as https://treeherder.mozilla.org/#/jobs?repo=try&selectedJob=296920031&revision=ada172630f8641c8ec0fc9de09755658f7a5eaa7 will definitely timeout as we'd have 76 patches to apply and analyze.