### PR TITLE
Return a list of tasks known by the test selection model

### DIFF
--- a/http_service/bugbug_http/boot.py
+++ b/http_service/bugbug_http/boot.py
@@ -7,7 +7,6 @@ import concurrent.futures
 import logging
 import os
 
-import mozci.push
 import requests
 
 from bugbug import repository, test_scheduling, utils
@@ -93,14 +92,11 @@ def boot_worker():
     def retrieve_schedulable_tasks():
         # Store in a file the list of tasks in the latest autoland push.
         r = requests.get(
-            "https://hg.mozilla.org/integration/autoland/json-pushes?version=2"
+            "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.autoland.latest.taskgraph.decision/artifacts/public/target-tasks.json"
         )
         r.raise_for_status()
-        data = r.json()
-        last_push = data["pushes"][str(data["lastpushid"])]
-        last_push_revs = last_push["changesets"][::-1]
         with open("known_tasks", "w") as f:
-            f.write("\n".join(mozci.push.Push(last_push_revs).target_task_labels))
+            f.write("\n".join(r.json()))
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
         clone_autoland_future = executor.submit(clone_autoland)

--- a/http_service/bugbug_http/models.py
+++ b/http_service/bugbug_http/models.py
@@ -6,6 +6,8 @@
 import logging
 import os
 from datetime import timedelta
+from functools import lru_cache
+from typing import Tuple
 
 import orjson
 import requests
@@ -103,6 +105,12 @@ def classify_bug(model_name, bug_ids, bugzilla_token):
     return "OK"
 
 
+@lru_cache(maxsize=None)
+def get_known_tasks() -> Tuple[str, ...]:
+    with open("known_tasks", "r") as f:
+        return tuple(l.strip() for l in f)
+
+
 def schedule_tests(branch, rev):
     from bugbug_http.app import JobInfo
     from bugbug_http import REPO_DIR
@@ -159,6 +167,7 @@ def schedule_tests(branch, rev):
         "groups": groups,
         "reduced_tasks": {t: c for t, c in tasks.items() if t in reduced},
         "reduced_tasks_higher": {t: c for t, c in tasks.items() if t in reduced_higher},
+        "known_tasks": get_known_tasks(),
     }
     setkey(job.result_key, orjson.dumps(data))
 

--- a/http_service/tests/conftest.py
+++ b/http_service/tests/conftest.py
@@ -271,6 +271,9 @@ def mock_component_taskcluster_artifact():
 
 @pytest.fixture
 def mock_schedule_tests_classify(monkeypatch):
+    with open("known_tasks", "w") as f:
+        f.write("prova")
+
     # Initialize a mock past failures DB.
     for granularity in ("label", "group"):
         past_failures_data = test_scheduling.get_past_failures(granularity)

--- a/http_service/tests/test_schedule_tests.py
+++ b/http_service/tests/test_schedule_tests.py
@@ -82,4 +82,5 @@ def test_simple_schedule(
         "groups": groups_to_choose,
         "reduced_tasks": reduced_labels,
         "reduced_tasks_higher": reduced_labels,
+        "known_tasks": ["prova"],
     }


### PR DESCRIPTION
The list of known tasks is generated during the HTTP service's boot.
This way, since the HTTP service is restarted ~daily, we will schedule newly added
tasks for all pushes in approximately a whole day since their introduction (useful
to gather enough data about them for the next training run, and to help sheriffs
identify if they are intermittently failing).

Fixes #1528