### PR TITLE
Make download_commits not analyze all commits when the list of commits to analyze is empty

### DIFF
--- a/bugbug/repository.py
+++ b/bugbug/repository.py
@@ -1005,9 +1005,10 @@ def download_commits(
     with hglib.open(repo_dir) as hg:
         if revs is None:
             revs = get_revs(hg, rev_start)
-            if len(revs) == 0:
-                logger.info("No commits to analyze")
-                return tuple()
+
+        if len(revs) == 0:
+            logger.info("No commits to analyze")
+            return tuple()
 
         first_pushdate = get_first_pushdate(repo_dir)
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -557,6 +557,14 @@ def test_download_commits(fake_hg_repo, use_single_process):
     )
     assert len(list(repository.get_commits())) == 2
 
+    os.remove("data/commits.json")
+    shutil.rmtree("data/commit_experiences.lmdb")
+    commits = repository.download_commits(
+        local, revs=[], use_single_process=use_single_process,
+    )
+    assert len(commits) == 0
+    assert len(list(repository.get_commits())) == 0
+
 
 def test_get_directories():
     assert repository.get_directories("") == []


### PR DESCRIPTION
Fixes #1690
Fixes a regression from b5a194a17e39467cf1405193f9baa99dc9783188