### PR TITLE
Building http_service via docker-compose on localhost fails

### DIFF
--- a/http_service/Dockerfile.bg_worker
+++ b/http_service/Dockerfile.bg_worker
@@ -14,7 +14,7 @@ RUN pip install --disable-pip-version-check --quiet --no-cache-dir /code/http_se
 WORKDIR /code/
 
 ARG CHECK_MODELS
-ENV CHECK_MODELS="${CHECK_MODELS}"
+ENV CHECK_MODELS="${CHECK_MODELS:-0}"
 
 ARG TAG
 ENV TAG="${TAG}"


### PR DESCRIPTION
Fixes #1710

This modifies the background worker to set the CHECK_MODELS variable to 0
if externally to the image the variable has not been set.

This fixes this error:

```shell
```shell
$> docker-compose build
....
Step 12/13 : RUN bash /code/http_service/ensure_models.sh
 ---> Running in 4b03554bd165
+ '[' '' == 0 ']'
+ python -m bugbug_http.download_models
2020-07-21 19:59:39,204:INFO:matplotlib.font_manager:generated new fontManager
2020-07-21 19:59:39,446:INFO:bugbug.utils:Downloading https://community-tc.services.mozilla.com/api/index/v1/task/project.relman.bugbug.train_defectenhancementtask.v0.0.280/artifacts/public/defectenhancementtaskmodel.zst...
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/runpy.py", line 193, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.8/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.8/site-packages/bugbug_http/download_models.py", line 34, in <module>
    download_models()
  File "/usr/local/lib/python3.8/site-packages/bugbug_http/download_models.py", line 17, in download_models
    utils.download_model(model_name)
  File "/usr/local/lib/python3.8/site-packages/bugbug/utils.py", line 223, in download_model
    updated = download_check_etag(url)
  File "/usr/local/lib/python3.8/site-packages/bugbug/utils.py", line 191, in download_check_etag
    r.raise_for_status()
  File "/usr/local/lib/python3.8/site-packages/requests/models.py", line 941, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://community-tc.services.mozilla.com/api/queue/v1/task/aijm6q3_TauLb1yHvp4D1Q/artifacts/public%2Fdefectenhancementtaskmodel.zst
ERROR: Service 'bugbug-http-service-bg-worker' failed to build: The command '/bin/sh -c bash /code/http_service/ensure_models.sh' returned a non-zero code: 1
```
```