### PR TITLE
Submit logged warnings to Sentry

### DIFF
--- a/http_service/bugbug_http/worker.py
+++ b/http_service/bugbug_http/worker.py
@@ -4,21 +4,29 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import logging
 import os
 import sys
 
 import sentry_sdk
 from redis import Redis
 from rq import Connection, Worker
+from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.rq import RqIntegration
 
 import bugbug_http.boot
 from bugbug import get_bugbug_version
 
 if os.environ.get("SENTRY_DSN"):
+    logging_integration = LoggingIntegration(
+        # Default behaviour: INFO messages will be included as breadcrumbs
+        level=logging.INFO,
+        # Change default behaviour (ERROR messages events)
+        event_level=logging.WARNING,
+    )
     sentry_sdk.init(
-        os.environ.get("SENTRY_DSN"),
-        integrations=[RqIntegration()],
+        dsn=os.environ.get("SENTRY_DSN"),
+        integrations=[RqIntegration(), logging_integration],
         release=get_bugbug_version(),
     )
 


### PR DESCRIPTION
Fixes #1721

Sentry by default logs `ERROR` messages as events, however, we would
like to track `WARNING` messages as well.