### PR TITLE
Add Sentry to Pulse listener and Http service

### DIFF
--- a/http_service/bugbug_http/app.py
+++ b/http_service/bugbug_http/app.py
@@ -24,9 +24,14 @@ from redis import Redis
 from rq import Queue
 from rq.exceptions import NoSuchJobError
 from rq.job import Job
+from sentry_sdk.integrations.flask import FlaskIntegration
 
 from bugbug import get_bugbug_version, utils
 from bugbug_http.models import MODELS_NAMES, classify_bug, schedule_tests
+from bugbug_http.sentry import setup_sentry
+
+if os.environ.get("SENTRY_DSN"):
+    setup_sentry(dsn=os.environ.get("SENTRY_DSN"), integrations=[FlaskIntegration()])
 
 API_TOKEN = "X-Api-Key"
 

--- a/http_service/bugbug_http/listener.py
+++ b/http_service/bugbug_http/listener.py
@@ -18,6 +18,8 @@ import requests
 from kombu import Connection, Exchange, Queue
 from kombu.mixins import ConsumerMixin
 
+from bugbug_http.sentry import setup_sentry
+
 logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -25,6 +27,9 @@ logger.setLevel(logging.INFO)
 PORT = os.environ.get("PORT", 8000)
 BUGBUG_HTTP_SERVER = os.environ.get("BUGBUG_HTTP_SERVER", f"http://localhost:{PORT}")
 CONNECTION_URL = "amqp://{}:{}@pulse.mozilla.org:5671/?ssl=1"
+
+if os.environ.get("SENTRY_DSN"):
+    setup_sentry(dsn=os.environ.get("SENTRY_DSN"))
 
 
 class _GenericConsumer(ConsumerMixin):

--- a/http_service/bugbug_http/sentry.py
+++ b/http_service/bugbug_http/sentry.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import logging
+
+import sentry_sdk
+from sentry_sdk.integrations.logging import LoggingIntegration
+
+from bugbug import get_bugbug_version
+
+
+def setup_sentry(dsn, integrations=[]):
+    logging_integration = LoggingIntegration(
+        # Default behaviour: INFO messages will be included as breadcrumbs
+        level=logging.INFO,
+        # Change default behaviour (ERROR messages events)
+        event_level=logging.WARNING,
+    )
+    sentry_sdk.init(
+        dsn=dsn,
+        integrations=[logging_integration] + integrations,
+        release=get_bugbug_version(),
+    )

--- a/http_service/bugbug_http/worker.py
+++ b/http_service/bugbug_http/worker.py
@@ -4,31 +4,18 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import logging
 import os
 import sys
 
-import sentry_sdk
 from redis import Redis
 from rq import Connection, Worker
-from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.rq import RqIntegration
 
 import bugbug_http.boot
-from bugbug import get_bugbug_version
+from bugbug_http.sentry import setup_sentry
 
 if os.environ.get("SENTRY_DSN"):
-    logging_integration = LoggingIntegration(
-        # Default behaviour: INFO messages will be included as breadcrumbs
-        level=logging.INFO,
-        # Change default behaviour (ERROR messages events)
-        event_level=logging.WARNING,
-    )
-    sentry_sdk.init(
-        dsn=os.environ.get("SENTRY_DSN"),
-        integrations=[RqIntegration(), logging_integration],
-        release=get_bugbug_version(),
-    )
+    setup_sentry(dsn=os.environ.get("SENTRY_DSN"), integrations=[RqIntegration()])
 
 
 def main():

--- a/http_service/docker-compose.yml
+++ b/http_service/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - PORT=8000
       - PULSE_USER
       - PULSE_PASSWORD
+      - SENTRY_DSN
     ports:
       - target: 8000
         published: 8000

--- a/http_service/requirements.txt
+++ b/http_service/requirements.txt
@@ -10,4 +10,4 @@ marshmallow==3.7.1
 requests==2.24.0
 rq==1.5.0
 rq-dashboard==0.6.1
-sentry-sdk==0.16.2
+sentry-sdk[flask]==0.16.2


### PR DESCRIPTION
I've tested this change with the patch below [1] and this command `cd http_service && docker-compose build && docker-compose run bugbug-http-service`

[1]
```diff
diff --git a/http_service/Dockerfile.bg_worker b/http_service/Dockerfile.bg_worker
index df4ab3d..62a1a35 100644
--- a/http_service/Dockerfile.bg_worker
+++ b/http_service/Dockerfile.bg_worker
@@ -19,6 +19,6 @@ ENV CHECK_MODELS="${CHECK_MODELS}"
 ARG TAG
 ENV TAG="${TAG}"

-RUN bash /code/http_service/ensure_models.sh
+# RUN bash /code/http_service/ensure_models.sh

 CMD bugbug-http-worker high default low
diff --git a/http_service/bugbug_http/app.py b/http_service/bugbug_http/app.py
index dd0c4c1..ac40063 100644
--- a/http_service/bugbug_http/app.py
+++ b/http_service/bugbug_http/app.py
@@ -33,6 +33,11 @@ from bugbug_http.sentry import setup_sentry
 if os.environ.get("SENTRY_DSN"):
     setup_sentry(dsn=os.environ.get("SENTRY_DSN"), integrations=[FlaskIntegration()])

+import sentry_sdk
+sentry_sdk.capture_exception(Exception("Message from Http service."))
+import sys
+sys.exit(1)
+
 API_TOKEN = "X-Api-Key"

 API_DESCRIPTION = """
diff --git a/http_service/bugbug_http/listener.py b/http_service/bugbug_http/listener.py
index 1921119..a93a5d6 100755
--- a/http_service/bugbug_http/listener.py
+++ b/http_service/bugbug_http/listener.py
@@ -31,6 +31,10 @@ CONNECTION_URL = "amqp://{}:{}@pulse.mozilla.org:5671/?ssl=1"
 if os.environ.get("SENTRY_DSN"):
     setup_sentry(dsn=os.environ.get("SENTRY_DSN"))

+import sentry_sdk
+sentry_sdk.capture_exception(Exception("Message from Pulse listener."))
+import sys
+sys.exit(0)

 class _GenericConsumer(ConsumerMixin):
     def __init__(self, connection, queues, callback):
@@ -94,13 +98,15 @@ def main():
     # Set PULSE_USER and PULSE_PASSWORD as env variables
     user = os.environ.get("PULSE_USER")
     password = os.environ.get("PULSE_PASSWORD")
-    if user and password:
-        with HgPushesConsumer(user, password, _on_message) as consumer:
-            consumer.run()
-    else:
-        logger.warning(
-            "The Pulse listener will be skipped unless you define PULSE_USER & PULSE_PASSWORD"
-        )
+    import sentry_sdk
+    sentry_sdk.capture_exception(Exception("Message from Pulse listener."))
+    # if user and password:
+    #     with HgPushesConsumer(user, password, _on_message) as consumer:
+    #         consumer.run()
+    # else:
+    #     logger.warning(
+    #         "The Pulse listener will be skipped unless you define PULSE_USER & PULSE_PASSWORD"
+    #     )
```