### PR TITLE
In the pulse listener, print exceptions with traceback.print_exc

### DIFF
--- a/http_service/bugbug_http/listener.py
+++ b/http_service/bugbug_http/listener.py
@@ -83,8 +83,8 @@ def _on_message(body, message):
                 logger.warning(
                     "We got status: {} for: {}".format(response.status_code, url)
                 )
-    except Exception as e:
-        traceback.print_tb(e)
+    except Exception:
+        traceback.print_exc()
     finally:
         message.ack()
 


### PR DESCRIPTION
Instead of using traceback.print_tb, which fails when an exception is, for example, a IndexError

Fixes #1738