### PR TITLE
Compress results with zstandard when storing them in Redis

### DIFF
--- a/http_service/bugbug_http/app.py
+++ b/http_service/bugbug_http/app.py
@@ -13,6 +13,7 @@ from typing import Any, Callable, List, Optional
 
 import libmozdata
 import orjson
+import zstandard
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
 from apispec_webframeworks.flask import FlaskPlugin
@@ -78,6 +79,7 @@ BUGZILLA_API_URL = (
     + "/rest/bug"
 )
 
+dctx = zstandard.ZstdDecompressor()
 
 logging.basicConfig(level=logging.DEBUG)
 LOGGER = logging.getLogger()
@@ -296,7 +298,7 @@ def get_result(job):
 
     if result:
         LOGGER.debug(f"Found {result}")
-        return orjson.loads(result)
+        return orjson.loads(dctx.decompress(result))
 
     return None
 

--- a/http_service/tests/conftest.py
+++ b/http_service/tests/conftest.py
@@ -14,9 +14,11 @@ from typing import Callable, Dict, Tuple
 
 import hglib
 import numpy as np
+import orjson
 import py.path
 import pytest
 import responses
+import zstandard
 from _pytest.monkeypatch import MonkeyPatch
 from rq.exceptions import NoSuchJobError
 
@@ -141,7 +143,8 @@ def add_result():
 
     def inner(key, data, change_time=None):
         result_key = f"bugbug:job_result:{key}"
-        app.redis_conn.set(result_key, json.dumps(data))
+        cctx = zstandard.ZstdCompressor(level=10)
+        app.redis_conn.set(result_key, cctx.compress(orjson.dumps(data)))
 
     return inner
 

--- a/http_service/tests/test_schedule_tests.py
+++ b/http_service/tests/test_schedule_tests.py
@@ -8,6 +8,7 @@ from typing import Callable, Dict, List, Tuple
 
 import hglib
 import pytest
+import zstandard
 
 from bugbug_http import models
 
@@ -94,7 +95,9 @@ def test_simple_schedule(
 
     # Assert the test selection result is stored in Redis.
     result = json.loads(
-        models.redis.get(f"bugbug:job_result:schedule_tests:mozilla-central_{rev}")
+        zstandard.ZstdDecompressor().decompress(
+            models.redis.get(f"bugbug:job_result:schedule_tests:mozilla-central_{rev}")
+        )
     )
     assert len(result) == 6
     assert result["tasks"] == labels_to_choose


### PR DESCRIPTION
This allows us to store ten times more results in the Redis cache.

Fixes #1616