### PR TITLE
Fix index error to accept metric files

### DIFF
--- a/scripts/analyze_training_metrics.py
+++ b/scripts/analyze_training_metrics.py
@@ -87,10 +87,10 @@ def parse_metric_file(metric_file_path: Path) -> Tuple[datetime, str, Dict[str, 
     # TODO: Might be better storing it in the file
     file_path_parts = metric_file_path.stem.split("_")
 
-    assert file_path_parts[:5] == ["metric", "project", "bugbug", "train"]
-    model_name = file_path_parts[5]
-    assert file_path_parts[6:8] == ["per", "date"]
-    date_parts = list(map(int, file_path_parts[8:14]))
+    assert file_path_parts[:4] == ["metric", "project", "bugbug", "train"]
+    model_name = file_path_parts[4]
+    assert file_path_parts[5:7] == ["per", "date"]
+    date_parts = list(map(int, file_path_parts[7:13]))
     date = datetime(
         date_parts[0],
         date_parts[1],


### PR DESCRIPTION
This fixes an index error in the parse_metric_file function which prevented it from accepting the metric files as mentioned in #1824.