### PR TITLE
Update to mozci 1.9.1

### DIFF
--- a/infra/mozci_config.toml
+++ b/infra/mozci_config.toml
@@ -1,3 +1,6 @@
+[mozci]
+data_sources = ["hgmo", "taskcluster", "treeherder_client", "adr"]
+
 [mozci.cache]
 retention = 40320
 serializer = "compressedpickle"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ lmdb==0.99
 matplotlib==3.3.2
 mercurial==5.5.2
 microannotate==0.0.20
-mozci==1.8.3
+mozci==1.9.1
 numpy==1.19.2
 orjson==3.4.1
 ortools==8.0.8283


### PR DESCRIPTION
Use hg.mozilla.org, Taskcluster, and Treeherder data sources in addition to ActiveData.