### PR TITLE
change default filter to be based on previous two releases instead of a hardcoded date

### DIFF
--- a/ui/changes/src/index.html
+++ b/ui/changes/src/index.html
@@ -36,7 +36,7 @@
           <hr />
           <label
             >Start date<br />
-            <input id="startDate" type="date" value="2020-10-01" />
+            <input id="startDate" type="date" />
           </label>
           <label
             >End date<br />
@@ -86,7 +86,7 @@
           <label>
             Version<br />
             <select name="releaseVersions" id="releaseVersions" multiple>
-              <option value="N/A" selected>N/A</option>
+              <option value="N/A">N/A</option>
             </select>
           </label>
           <label

--- a/ui/changes/src/index.js
+++ b/ui/changes/src/index.js
@@ -333,9 +333,13 @@ async function populateVersions() {
     let el = document.createElement("option");
     el.setAttribute("value", version);
     el.textContent = version;
-    el.selected = true;
+    el.selected = false;
     versionSelector.appendChild(el);
   }
+
+  // For now, previous two releases by default:
+  versionSelector.lastChild.selected = true;
+  versionSelector.lastChild.previousSibling.selected = true;
 }
 
 function renderTestingChart(chartEl, bugSummaries) {


### PR DESCRIPTION
Two functional changes here that we'll need to decide if we want:

1) This will get reset every time you reload the page (i.e. if you've selected all releases manually and then reload). This is an existing issue but currently it will reselect _all_ releases every time.
2) It deselects N/A which makes some of the reporting like "number of bugs by type" less useful (since it now doesn't include unfixed bugs). I wonder if we really should have a separate checkbox for "include unfixed bugs" rather than putting it into the release dropdown anyway. 