### PR TITLE
move the grouping options above the graphs and below the summary text

### DIFF
--- a/ui/changes/src/index.html
+++ b/ui/changes/src/index.html
@@ -135,6 +135,7 @@
               Release</label
             >
           </div>
+          <div id="result-graphs"></div>
         </details>
         <details open>
           <summary>

--- a/ui/changes/src/index.js
+++ b/ui/changes/src/index.js
@@ -71,6 +71,7 @@ let options = {
 
 let sortBy = ["Date", "DESC"];
 let resultSummary = document.getElementById("result-summary");
+let resultGraphs = document.getElementById("result-graphs");
 let metabugsDropdown = document.querySelector("#featureMetabugs");
 let allBugTypes;
 
@@ -788,20 +789,21 @@ async function renderSummary(bugSummaries) {
   let summaryText = `${bugText}There are ${bugSummaries.length} bugs with ${changesets} changesets.`;
   resultSummary.textContent = summaryText;
 
+  resultGraphs.textContent = "";
   let testingChartEl = document.createElement("div");
-  resultSummary.append(testingChartEl);
+  resultGraphs.append(testingChartEl);
   renderTestingChart(testingChartEl, bugSummaries);
 
   let riskChartEl = document.createElement("div");
-  resultSummary.append(riskChartEl);
+  resultGraphs.append(riskChartEl);
   await renderRiskChart(riskChartEl, bugSummaries);
 
   let regressionsChartEl = document.createElement("div");
-  resultSummary.append(regressionsChartEl);
+  resultGraphs.append(regressionsChartEl);
   await renderRegressionsChart(regressionsChartEl, bugSummaries);
 
   let typesChartEl = document.createElement("div");
-  resultSummary.append(typesChartEl);
+  resultGraphs.append(typesChartEl);
   await renderTypesChart(typesChartEl, bugSummaries);
 }
 


### PR DESCRIPTION
Just a visual improvement to move the options above the graph instead of buried at the bottom of the section