### PR TITLE
Add eslint deps to package.json

### DIFF
--- a/ui/changes/package.json
+++ b/ui/changes/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "npx snowpack dev",
+    "lint": "eslint .",
     "release": "npx snowpack build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -12,6 +13,11 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "eslint": "^7.20.0",
+    "eslint-config-prettier": "^7.2.0",
+    "eslint-config-standard": "^16.0.2",
+    "eslint-plugin-mozilla": "^2.9.2",
+    "eslint-plugin-prettier": "^3.3.1",
     "prettier": "^2.2.1",
     "snowpack": "^3.0.11"
   },


### PR DESCRIPTION
Some initial work on #2005.

This will at least make it easy to run ESLint via <kbd>npm run lint</kbd>; but there are still several (421 problems (412 errors, 9 warnings)) issues to resolve. Running <kbd>npm run lint -- --fix</kbd> will autofix 293 of the issues, leaving us with 106 problems (106 errors, 0 warnings) to manually resolve.