### PR TITLE
Get updates for github issues based on last_modified (#259)

### DIFF
--- a/scripts/github_issue_retriever.py
+++ b/scripts/github_issue_retriever.py
@@ -4,17 +4,48 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import argparse
+from logging import getLogger
 
 from bugbug import db, github
 from bugbug.utils import zstd_compress
+
+logger = getLogger(__name__)
 
 
 class Retriever(object):
     def retrieve_issues(
         self, owner: str, repo: str, state: str, retrieve_events: bool
     ) -> None:
+
+        last_modified = None
         db.download(github.GITHUB_ISSUES_DB)
-        github.download_issues(owner, repo, state, retrieve_events)
+
+        try:
+            last_modified = db.last_modified(github.GITHUB_ISSUES_DB)
+        except Exception:
+            pass
+
+        if last_modified:
+            logger.info(
+                f"Retrieving issues modified or created since the last run on {last_modified.isoformat()}"
+            )
+            data = github.fetch_issues_updated_since_timestamp(
+                owner, repo, state, last_modified.isoformat(), retrieve_events
+            )
+
+            updated_ids = set(issue["id"] for issue in data)
+
+            logger.info(
+                "Deleting issues that were changed since the last run and saving updates"
+            )
+            github.delete_issues(lambda issue: issue["id"] in updated_ids)
+
+            db.append(github.GITHUB_ISSUES_DB, data)
+            logger.info("Updating finished")
+        else:
+            logger.info("Retrieving all issues since last_modified is not available")
+            github.download_issues(owner, repo, state, retrieve_events)
+
         zstd_compress(github.GITHUB_ISSUES_DB)
 
 


### PR DESCRIPTION
This is a follow-up for https://github.com/mozilla/bugbug/pull/2242 (fetching and saving updates if `last_modified` is available and if not, download all issues)