### PR TITLE
Update component nn model

### DIFF
--- a/bugbug/models/component_nn.py
+++ b/bugbug/models/component_nn.py
@@ -326,7 +326,7 @@ class ComponentNNModel(ComponentModel):
                             (
                                 "bug_reporter",
                                 make_pipeline(
-                                    DictExtractor("bug_reporter"),
+                                    DictExtractor("Bug reporter"),
                                     MissingOrdinalEncoder(),
                                 ),
                                 "data",

--- a/bugbug/nn.py
+++ b/bugbug/nn.py
@@ -22,6 +22,7 @@ except ImportError:
 class KerasTextToSequences(BaseEstimator, TransformerMixin):
     def __init__(self, maxlen, vocab_size):
         self.maxlen = maxlen
+        self.vocab_size = vocab_size
         self.tokenizer = Tokenizer(num_words=vocab_size)
 
     def fit(self, x, y=None):


### PR DESCRIPTION
Small nits to remove errors while running the NN component model (`bugbug-train component --classifier=nn`). However, I run oom (`Killed`) even with a very small `limit`, so there might be more issues.