### PR TITLE
Revert "Bump tar from 6.1.1 to 6.1.5 in /ui/changes"

### DIFF
--- a/ui/changes/package-lock.json
+++ b/ui/changes/package-lock.json
@@ -3435,9 +3435,9 @@
       }
     },
     "tar": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.5.tgz",
-      "integrity": "sha512-FiK6MQyyaqd5vHuUjbg/NpO8BuEGeSXcmlH7Pt/JkugWS8s0w8nKybWjHDJiwzCAIKZ66uof4ghm4tBADjcqRA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.1.tgz",
+      "integrity": "sha512-GG0R7yt/CQkvG4fueXDi52Zskqxe2AyRJ+Wm54yqarnBgcX3qRIWh10qLVAAN+mlPFGTfP5UxvD3Fbi11UOTUQ==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",


### PR DESCRIPTION
Reverts mozilla/bugbug#2458