### PR TITLE
Issue #2499 - Skip issues with empty body or title for the needsdiagnosis model

### DIFF
--- a/bugbug/models/needsdiagnosis.py
+++ b/bugbug/models/needsdiagnosis.py
@@ -60,6 +60,9 @@ class NeedsDiagnosisModel(IssueModel):
         classes = {}
 
         for issue in github.get_issues():
+            # Skip issues with empty title or body
+            if issue["title"] is None or issue["body"] is None:
+                continue
             # Skip issues that are not moderated yet as they don't have a meaningful title or body
             if issue["title"] == "In the moderation queue.":
                 continue


### PR DESCRIPTION
This PR fixes an issue with failing training for needsdiagnosis model