### PR TITLE
Update python version in document

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pip3 install -r requirements.txt
 
 You may also need `pip install -r test-requirements.txt`. Depending on the parts of bugbug you want to run, you might need to install dependencies from other requirement files (find them with `find . -name "*requirements*"`).
 
-Currently, Python 3.7+ is required. You can double check the version we use by looking at setup.py.
+Currently, Python 3.9+ is required. You can double check the version we use by looking at setup.py.
 
 Also, libgit2 (needs [v1.0.0](https://github.com/libgit2/libgit2/releases/tag/v1.0.0), only in [experimental on Debian](https://wiki.debian.org/DebianExperimental)), **might** be required (if you can't install it, skip this step).
 

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,6 @@ setup(
         ]
     },
     classifiers=[
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3 :: Only",
         "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",


### PR DESCRIPTION
Fixes #2634 

Replacing typing.Dict to dict requires Python 3.9+ version without using `from __future__ import annotations`

On using Python 3.7 or newer, we need to start the module with `from __future__ import annotations` to use `dict` as a generic type. And as of Python 3.9, `dict` supports being used as generic type.
