### PR TITLE
Install git from Debian stable

### DIFF
--- a/infra/dockerfile.commit_retrieval
+++ b/infra/dockerfile.commit_retrieval
@@ -1,17 +1,12 @@
 FROM mozilla/bugbug-base:latest
 
-# Activate testing for git
-COPY infra/testing.pinning /etc/apt/preferences.d/00testing
-RUN echo 'deb http://deb.debian.org/debian testing main non-free contrib' > /etc/apt/sources.list.d/testing.list
-
 ENV PATH="${PATH}:/git-cinnabar"
 
 # git is required by the annotate pipeline.
 # libcurl4 is required by git-cinnabar.
 # patch is required by the commit classifier script.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends -o APT::Immediate-Configure=false -t testing git && \
-    apt-get install -y --no-install-recommends xz-utils curl patch libcurl4 && \
+    apt-get install -y --no-install-recommends git xz-utils curl patch libcurl4 && \
     hg clone -r 534f9ee2ff2b9c12df802fb14f0fed7c16dd5b6c https://hg.mozilla.org/hgcustom/version-control-tools /version-control-tools/ && \
     rm -r /version-control-tools/.hg /version-control-tools/ansible /version-control-tools/docs /version-control-tools/testing && \
     git clone https://github.com/glandium/git-cinnabar.git /git-cinnabar && \

--- a/infra/testing.pinning
+++ b/infra/testing.pinning
@@ -1,7 +1,0 @@
-Package: *
-Pin: release a=buster
-Pin-Priority: 700
-
-Package: *
-Pin: release a=testing
-Pin-Priority: 650


### PR DESCRIPTION
We were installing it from testing since 83c8908433b44b44a26cc21a209ab30ff05f2dd0 because we needed git > 2.23, but 2.30 is in stable now.