### PR TITLE
Issue #2747 - Fix an error in the issue retrieval for private github issues

### DIFF
--- a/tests/test_github_issue_retriever.py
+++ b/tests/test_github_issue_retriever.py
@@ -5,6 +5,8 @@
 
 from unittest import mock
 
+import pytest
+import requests
 import responses
 
 from bugbug.github import IssueDict
@@ -92,3 +94,83 @@ def test_replace_missing_private() -> None:
     assert len(updated_issues) == 0
     assert len(data) == 2
     assert data[0] == expected
+
+
+def test_public_issues_with_deleted_private() -> None:
+    public_closed_issue = IssueDict(
+        {"title": "Issue closed.", "body": PUBLIC_BODY, "id": 3456}
+    )
+
+    public_closed_issue2 = IssueDict(
+        {
+            "title": "Issue closed.",
+            "body": "<!-- @private_url: https://github.com/webcompat/web-bugs-private/issues/12346 -->",
+            "id": 3457,
+        }
+    )
+
+    data = [
+        public_closed_issue,
+        public_closed_issue2,
+    ]
+
+    private_issue = IssueDict(
+        {
+            "title": "www.example.com - actual title",
+            "body": "<p>Actual body</p>",
+            "id": 1,
+        }
+    )
+    # Mock failed private issue request
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/webcompat/web-bugs-private/issues/12345",
+        status=410,
+    )
+
+    # Mock successful private issue request
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/webcompat/web-bugs-private/issues/12346",
+        json=private_issue,
+        status=200,
+    )
+
+    expected = IssueDict(public_closed_issue.copy())
+
+    expected2 = IssueDict(public_closed_issue2.copy())
+    expected2["title"] = private_issue["title"]
+    expected2["body"] = private_issue["body"]
+
+    (
+        updated_issues,
+        updated_ids,
+    ) = github_issue_retriever.replace_with_private(data)
+
+    assert len(updated_ids) == 1
+    assert len(updated_issues) == 1
+    assert len(data) == 2
+
+    assert public_closed_issue2["id"] in updated_ids
+    # assert that public issue in the original list is unchanged
+    assert data[0] == expected
+    # assert that updated list contains an issue with private content
+    assert updated_issues[0] == expected2
+
+
+def test_public_issues_with_random_error() -> None:
+    public_closed_issue = IssueDict(
+        {"title": "Issue closed.", "body": PUBLIC_BODY, "id": 3456}
+    )
+
+    data = [public_closed_issue]
+
+    # Mock failed private issue request
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/webcompat/web-bugs-private/issues/12345",
+        status=500,
+    )
+
+    with pytest.raises(requests.HTTPError):
+        github_issue_retriever.replace_with_private(data)


### PR DESCRIPTION
The PR addresses the error while fetching private issue contents. The error happens in cases where a private issue is deleted, but a public issue still has a reference to it in the body.