### PR TITLE
Revert "Bump pydriller from 1.12 to 2.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ orjson==3.6.7
 ortools==9.3.10459
 pandas==1.4.1
 psutil==5.9.0
-pydriller==2.1
+pydriller==1.12
 pyOpenSSL>=0.14  # Could not find a version that satisfies the requirement pyOpenSSL>=0.14; extra == "security" (from requests[security]>=2.7.0->libmozdata==0.1.43)
 python-dateutil==2.8.2
 python-hglib==2.6.2


### PR DESCRIPTION
Reverts mozilla/bugbug#2769

There are some breaking API changes.