### PR TITLE
Show a useful error message when missing the model name

### DIFF
--- a/scripts/trainer.py
+++ b/scripts/trainer.py
@@ -104,7 +104,7 @@ def parse_args(args):
         default="default",
     )
 
-    subparsers = main_parser.add_subparsers(title="model", dest="model")
+    subparsers = main_parser.add_subparsers(title="model", dest="model", required=True)
 
     for model_name in MODELS:
         subparser = subparsers.add_parser(


### PR DESCRIPTION
Currently, not providing the model name to `python3 -m scripts.trainer` will rais the following error:
```sh
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.9/3.9.12/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/homebrew/Cellar/python@3.9/3.9.12/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/smujahid/repos/mozilla/bugbug/scripts/trainer.py", line 161, in <module>
    main()
  File "/Users/smujahid/repos/mozilla/bugbug/scripts/trainer.py", line 157, in main
    retriever.go(args)
  File "/Users/smujahid/repos/mozilla/bugbug/scripts/trainer.py", line 25, in go
    if args.classifier != "default":
AttributeError: 'Namespace' object has no attribute 'classifier'
```

After the change in this PR, will get a more informative error:

```sh
usage: trainer.py [-h]
                  {annotateignore,assignee,backout,browsername,bug,bugtype,component,component_nn,defect,defectenhancementtask,devdocneeded,duplicate,fixtime,needsdiagnosis,qaneeded,rcatype,regression,regressionrange,regressor,spambug,stepstoreproduce,testlabelselect,testgroupselect,testconfiggroupselect,testfailure,tracking,uplift}
                  ...
trainer.py: error: the following arguments are required: model
```