### PR TITLE
Use `performance` instead of `perf` for bug type

### DIFF
--- a/bugbug/models/bugtype.py
+++ b/bugbug/models/bugtype.py
@@ -56,10 +56,10 @@ def bug_to_types(
             "pdfjs-performance",
         )
     ):
-        types.add("perf")
+        types.add("performance")
 
     if "cf_performance" in bug and bug["cf_performance"] not in ("---", "?"):
-        types.add("perf")
+        types.add("performance")
 
     if "cf_crash_signature" in bug and bug["cf_crash_signature"] not in ("", "---"):
         types.add("crash")


### PR DESCRIPTION
This will fix the following error in the `bugtype` model:

```sh
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.9/3.9.12/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/homebrew/Cellar/python@3.9/3.9.12/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/smujahid/repos/mozilla/bugbug/scripts/trainer.py", line 161, in <module>
    main()
  File "/Users/smujahid/repos/mozilla/bugbug/scripts/trainer.py", line 157, in main
    retriever.go(args)
  File "/Users/smujahid/repos/mozilla/bugbug/scripts/trainer.py", line 51, in go
    metrics = model_obj.train(limit=args.limit)
  File "/Users/smujahid/repos/mozilla/bugbug/bugbug/model.py", line 342, in train
    classes, self.class_names = self.get_labels()
  File "/Users/smujahid/repos/mozilla/bugbug/bugbug/models/bugtype.py", line 156, in get_labels
    target[TYPE_LIST.index(type_)] = 1
ValueError: 'perf' is not in list
```

I'm not sure if this fix will have side effects somewhere else.  We are modifying the behaviour of `bug_to_types()`, which is used in `generate_landings_risk_report.py`:
https://github.com/mozilla/bugbug/blob/cc1860bf433e3000ae73fd23eb7036e909bed160/scripts/generate_landings_risk_report.py#L683