### PR TITLE
Enforce the process start method to be `fork`

### DIFF
--- a/bugbug/models/testselect.py
+++ b/bugbug/models/testselect.py
@@ -837,6 +837,7 @@ class TestSelectModel(Model):
 
         with concurrent.futures.ProcessPoolExecutor(
             max_workers=utils.get_physical_cpu_count(),
+            # Fixing https://github.com/mozilla/bugbug/issues/3131
             mp_context=mp.get_context("fork"),
         ) as executor:
             scenarios = [

--- a/bugbug/models/testselect.py
+++ b/bugbug/models/testselect.py
@@ -7,6 +7,7 @@ import collections
 import concurrent.futures
 import logging
 import math
+import multiprocessing as mp
 import pickle
 import statistics
 from functools import reduce
@@ -835,7 +836,8 @@ class TestSelectModel(Model):
             print(message)
 
         with concurrent.futures.ProcessPoolExecutor(
-            max_workers=utils.get_physical_cpu_count()
+            max_workers=utils.get_physical_cpu_count(),
+            mp_context=mp.get_context("fork"),
         ) as executor:
             scenarios = [
                 (None, None, None),

--- a/bugbug/repository.py
+++ b/bugbug/repository.py
@@ -10,6 +10,7 @@ import itertools
 import json
 import logging
 import math
+import multiprocessing as mp
 import os
 import pickle
 import re
@@ -1354,7 +1355,9 @@ def download_commits(
             code_analysis_server = rust_code_analysis_server.RustCodeAnalysisServer()
 
             with concurrent.futures.ProcessPoolExecutor(
-                initializer=_init_process, initargs=(repo_dir,)
+                initializer=_init_process,
+                initargs=(repo_dir,),
+                mp_context=mp.get_context("fork"),
             ) as executor:
                 commits_iter = executor.map(_transform, commits, chunksize=64)
                 commits_iter = tqdm(commits_iter, total=commits_num)

--- a/bugbug/repository.py
+++ b/bugbug/repository.py
@@ -1357,6 +1357,7 @@ def download_commits(
             with concurrent.futures.ProcessPoolExecutor(
                 initializer=_init_process,
                 initargs=(repo_dir,),
+                # Fixing https://github.com/mozilla/bugbug/issues/3131
                 mp_context=mp.get_context("fork"),
             ) as executor:
                 commits_iter = executor.map(_transform, commits, chunksize=64)


### PR DESCRIPTION
Workaround to fix #3131