### PR TITLE
Handle `None` values from `rust-code-analysis` while mining commits

### DIFF
--- a/bugbug/repository.py
+++ b/bugbug/repository.py
@@ -464,34 +464,41 @@ def get_summary_metrics(obj, metrics_space):
         obj["halstead_length_max"] = max(
             obj["halstead_length_max"], metrics["halstead"]["length"]
         )
-        obj["halstead_estimated_program_length_max"] = max(
-            obj["halstead_estimated_program_length_max"],
-            metrics["halstead"]["estimated_program_length"],
-        )
-        obj["halstead_purity_ratio_max"] = max(
-            obj["halstead_purity_ratio_max"], metrics["halstead"]["purity_ratio"]
-        )
+        if metrics["halstead"]["estimated_program_length"] is not None:
+            obj["halstead_estimated_program_length_max"] = max(
+                obj["halstead_estimated_program_length_max"],
+                metrics["halstead"]["estimated_program_length"],
+            )
+        if metrics["halstead"]["purity_ratio"] is not None:
+            obj["halstead_purity_ratio_max"] = max(
+                obj["halstead_purity_ratio_max"], metrics["halstead"]["purity_ratio"]
+            )
         obj["halstead_vocabulary_max"] = max(
             obj["halstead_vocabulary_max"], metrics["halstead"]["vocabulary"]
         )
         obj["halstead_volume_max"] = max(
             obj["halstead_volume_max"], metrics["halstead"]["volume"]
         )
-        obj["halstead_difficulty_max"] = max(
-            obj["halstead_difficulty_max"], metrics["halstead"]["difficulty"]
-        )
-        obj["halstead_level_max"] = max(
-            obj["halstead_level_max"], metrics["halstead"]["level"]
-        )
-        obj["halstead_effort_max"] = max(
-            obj["halstead_effort_max"], metrics["halstead"]["effort"]
-        )
-        obj["halstead_time_max"] = max(
-            obj["halstead_time_max"], metrics["halstead"]["time"]
-        )
-        obj["halstead_bugs_max"] = max(
-            obj["halstead_bugs_max"], metrics["halstead"]["bugs"]
-        )
+        if metrics["halstead"]["difficulty"] is not None:
+            obj["halstead_difficulty_max"] = max(
+                obj["halstead_difficulty_max"], metrics["halstead"]["difficulty"]
+            )
+        if metrics["halstead"]["level"] is not None:
+            obj["halstead_level_max"] = max(
+                obj["halstead_level_max"], metrics["halstead"]["level"]
+            )
+        if metrics["halstead"]["effort"] is not None:
+            obj["halstead_effort_max"] = max(
+                obj["halstead_effort_max"], metrics["halstead"]["effort"]
+            )
+        if metrics["halstead"]["time"] is not None:
+            obj["halstead_time_max"] = max(
+                obj["halstead_time_max"], metrics["halstead"]["time"]
+            )
+        if metrics["halstead"]["bugs"] is not None:
+            obj["halstead_bugs_max"] = max(
+                obj["halstead_bugs_max"], metrics["halstead"]["bugs"]
+            )
         obj["functions_max"] = max(obj["functions_max"], metrics["nom"]["functions"])
         obj["closures_max"] = max(obj["closures_max"], metrics["nom"]["closures"])
         obj["sloc_max"] = max(obj["sloc_max"], metrics["loc"]["sloc"])
@@ -523,34 +530,41 @@ def get_summary_metrics(obj, metrics_space):
         obj["halstead_length_min"] = min(
             obj["halstead_length_min"], metrics["halstead"]["length"]
         )
-        obj["halstead_estimated_program_length_min"] = min(
-            obj["halstead_estimated_program_length_min"],
-            metrics["halstead"]["estimated_program_length"],
-        )
-        obj["halstead_purity_ratio_min"] = min(
-            obj["halstead_purity_ratio_min"], metrics["halstead"]["purity_ratio"]
-        )
+        if metrics["halstead"]["estimated_program_length"] is not None:
+            obj["halstead_estimated_program_length_min"] = min(
+                obj["halstead_estimated_program_length_min"],
+                metrics["halstead"]["estimated_program_length"],
+            )
+        if metrics["halstead"]["purity_ratio"] is not None:
+            obj["halstead_purity_ratio_min"] = min(
+                obj["halstead_purity_ratio_min"], metrics["halstead"]["purity_ratio"]
+            )
         obj["halstead_vocabulary_min"] = min(
             obj["halstead_vocabulary_min"], metrics["halstead"]["vocabulary"]
         )
         obj["halstead_volume_min"] = min(
             obj["halstead_volume_min"], metrics["halstead"]["volume"]
         )
-        obj["halstead_difficulty_min"] = min(
-            obj["halstead_difficulty_min"], metrics["halstead"]["difficulty"]
-        )
-        obj["halstead_level_min"] = min(
-            obj["halstead_level_min"], metrics["halstead"]["level"]
-        )
-        obj["halstead_effort_min"] = min(
-            obj["halstead_effort_min"], metrics["halstead"]["effort"]
-        )
-        obj["halstead_time_min"] = min(
-            obj["halstead_time_min"], metrics["halstead"]["time"]
-        )
-        obj["halstead_bugs_min"] = min(
-            obj["halstead_bugs_min"], metrics["halstead"]["bugs"]
-        )
+        if metrics["halstead"]["difficulty"] is not None:
+            obj["halstead_difficulty_min"] = min(
+                obj["halstead_difficulty_min"], metrics["halstead"]["difficulty"]
+            )
+        if metrics["halstead"]["level"] is not None:
+            obj["halstead_level_min"] = min(
+                obj["halstead_level_min"], metrics["halstead"]["level"]
+            )
+        if metrics["halstead"]["effort"] is not None:
+            obj["halstead_effort_min"] = min(
+                obj["halstead_effort_min"], metrics["halstead"]["effort"]
+            )
+        if metrics["halstead"]["time"] is not None:
+            obj["halstead_time_min"] = min(
+                obj["halstead_time_min"], metrics["halstead"]["time"]
+            )
+        if metrics["halstead"]["bugs"] is not None:
+            obj["halstead_bugs_min"] = min(
+                obj["halstead_bugs_min"], metrics["halstead"]["bugs"]
+            )
         obj["functions_min"] = min(obj["functions_min"], metrics["nom"]["functions"])
         obj["closures_min"] = min(obj["closures_min"], metrics["nom"]["closures"])
         obj["sloc_min"] = min(obj["sloc_min"], metrics["loc"]["sloc"])
@@ -592,17 +606,24 @@ def get_space_metrics(
     obj["halstead_n1_total"] += metrics["halstead"]["n1"]
     obj["halstead_N1_total"] += metrics["halstead"]["N1"]
     obj["halstead_length_total"] += metrics["halstead"]["length"]
-    obj["halstead_estimated_program_length_total"] += metrics["halstead"][
-        "estimated_program_length"
-    ]
-    obj["halstead_purity_ratio_total"] += metrics["halstead"]["purity_ratio"]
+    if metrics["halstead"]["estimated_program_length"] is not None:
+        obj["halstead_estimated_program_length_total"] += metrics["halstead"][
+            "estimated_program_length"
+        ]
+    if metrics["halstead"]["purity_ratio"] is not None:
+        obj["halstead_purity_ratio_total"] += metrics["halstead"]["purity_ratio"]
     obj["halstead_vocabulary_total"] += metrics["halstead"]["vocabulary"]
     obj["halstead_volume_total"] += metrics["halstead"]["volume"]
-    obj["halstead_difficulty_total"] += metrics["halstead"]["difficulty"]
-    obj["halstead_level_total"] += metrics["halstead"]["level"]
-    obj["halstead_effort_total"] += metrics["halstead"]["effort"]
-    obj["halstead_time_total"] += metrics["halstead"]["time"]
-    obj["halstead_bugs_total"] += metrics["halstead"]["bugs"]
+    if metrics["halstead"]["difficulty"] is not None:
+        obj["halstead_difficulty_total"] += metrics["halstead"]["difficulty"]
+    if metrics["halstead"]["level"] is not None:
+        obj["halstead_level_total"] += metrics["halstead"]["level"]
+    if metrics["halstead"]["effort"] is not None:
+        obj["halstead_effort_total"] += metrics["halstead"]["effort"]
+    if metrics["halstead"]["time"] is not None:
+        obj["halstead_time_total"] += metrics["halstead"]["time"]
+    if metrics["halstead"]["bugs"] is not None:
+        obj["halstead_bugs_total"] += metrics["halstead"]["bugs"]
     obj["functions_total"] += metrics["nom"]["functions"]
     obj["closures_total"] += metrics["nom"]["closures"]
     obj["sloc_total"] += metrics["loc"]["sloc"]


### PR DESCRIPTION
Workaround to fix #3128. This should be reverted after https://github.com/mozilla/rust-code-analysis/issues/528 is fixed.