### PR TITLE
When the count is 0, consider as the component doesn't exist

### DIFF
--- a/bugbug/bugzilla.py
+++ b/bugbug/bugzilla.py
@@ -326,6 +326,9 @@ def get_product_component_count(months: int = 12) -> dict[str, int]:
                 continue
 
             value = int(raw_value)
+            # If there are no bugs, the product/component pair doesn't exist.
+            if value == 0:
+                continue
 
             full_comp = f"{product}::{component}"
             bugs_number[full_comp] = value


### PR DESCRIPTION
The report API returns a matrix where each cell is the number of bugs belonging to a given product and a given component. The bug retriever script currently considers all product/component pairs from the report as active product/components.
Unfortunately, if a component is removed from a product but a component with the same name still exists in another product, the bug retriever script will fail to realize that the component was removed. E.g. this is the case for Firefox::Preferences (renamed to Settings UI) and Toolkit::Preferences.

The fix is to ignore product/components pairs where the count of bugs is 0.

Fixes #3157