### PR TITLE
Downgrade scikit-learn to 1.1.3 from 1.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ python-hglib==2.6.2
 ratelimit==2.2.1
 requests==2.28.2
 rs_parsepatch==0.3.7
-scikit-learn==1.2.1
+scikit-learn==1.1.3
 scipy==1.10.1
 sendgrid==6.9.7
 shap[plots]==0.41.0


### PR DESCRIPTION
After updating scikit-learn learn to 1.2.1, some model training tasks started to hang.

Examples:
- `defectenhancementtask`:  https://community-tc.services.mozilla.com/tasks/MNkuIlssR1-x_iXHfFxQPw
- `regression`: https://community-tc.services.mozilla.com/tasks/K1Gqjd1OTXehbkMpiwC8Pw