### PR TITLE
Include `filed_via` feature in `spambug` model

### DIFF
--- a/bugbug/models/spambug.py
+++ b/bugbug/models/spambug.py
@@ -41,6 +41,7 @@ class SpamBugModel(BugModel):
             bug_features.has_attachment(),
             bug_features.platform(),
             bug_features.op_sys(),
+            bug_features.filed_via(),
         ]
 
         cleanup_functions = [


### PR DESCRIPTION
#### Issue
Closes #1783 

#### Details

- This PR includes the new feature `filed_via` for training the `spambug` model.
- I trained the model with the new feature and obtained the preliminary results shown below.

#### Results Before Training without the `filed_via` feature
<details><summary>Click to see the classification report before</summary>

```
Cross Validation scores:
Accuracy: f0.9916186835110556 (+/- 0.0016367409335637459)
Precision: f0.9693747262630239 (+/- 0.005946616160129177)
Recall: f0.934351145038168 (+/- 0.0156524748083763)
X_train: (44623, 25400), y_train: (44623,)
resampled X_train: (81386, 25400), y_train: (81386,)
X_test: (4959, 25400), y_test: (4959,)
Model trained
Training Set scores:
                   pre       rec       spe        f1       geo       iba       sup

          1       1.00      1.00      1.00      1.00      1.00      1.00     40693
          0       1.00      1.00      1.00      1.00      1.00      1.00     40693

avg / total       1.00      1.00      1.00      1.00      1.00      1.00     81386

Test Set scores:
No confidence threshold - 4959 classified
                   pre       rec       spe        f1       geo       iba       sup

          1       0.97      0.94      1.00      0.95      0.97      0.93       481
          0       0.99      1.00      0.94      1.00      0.97      0.94      4478

avg / total       0.99      0.99      0.94      0.99      0.97      0.94      4959

╒════════════╤═════════════════╤═════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │
╞════════════╪═════════════════╪═════════════════╡
│ 1 (Actual) │             450 │              31 │
├────────────┼─────────────────┼─────────────────┤
│ 0 (Actual) │              12 │            4466 │
╘════════════╧═════════════════╧═════════════════╛


Confidence threshold &gt; 0.1 - 4959 classified
Precision and F-score are ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.
Recall and F-score are ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.91      0.98      0.99      0.95      0.99      0.97       481
                 0       1.00      0.99      0.98      0.99      0.99      0.97      4478
__NOT_CLASSIFIED__       0.00      0.00      1.00      0.00      0.00      0.00         0

       avg / total       0.99      0.99      0.98      0.99      0.99      0.97      4959

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             472 │               9 │                0 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │              45 │            4433 │                0 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛


Confidence threshold &gt; 0.2 - 4959 classified
Precision and F-score are ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.
Recall and F-score are ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.94      0.97      0.99      0.96      0.98      0.96       481
                 0       1.00      0.99      0.97      1.00      0.98      0.97      4478
__NOT_CLASSIFIED__       0.00      0.00      1.00      0.00      0.00      0.00         0

       avg / total       0.99      0.99      0.97      0.99      0.98      0.97      4959

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             468 │              13 │                0 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │              29 │            4449 │                0 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛


Confidence threshold &gt; 0.3 - 4959 classified
Precision and F-score are ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.
Recall and F-score are ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.96      0.97      1.00      0.96      0.98      0.96       481
                 0       1.00      1.00      0.97      1.00      0.98      0.97      4478
__NOT_CLASSIFIED__       0.00      0.00      1.00      0.00      0.00      0.00         0

       avg / total       0.99      0.99      0.97      0.99      0.98      0.96      4959

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             465 │              16 │                0 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │              20 │            4458 │                0 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛


Confidence threshold &gt; 0.4 - 4959 classified
Precision and F-score are ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.
Recall and F-score are ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.96      0.95      1.00      0.96      0.97      0.94       481
                 0       0.99      1.00      0.95      1.00      0.97      0.95      4478
__NOT_CLASSIFIED__       0.00      0.00      1.00      0.00      0.00      0.00         0

       avg / total       0.99      0.99      0.95      0.99      0.97      0.95      4959

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             457 │              24 │                0 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │              18 │            4460 │                0 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛


Confidence threshold &gt; 0.6 - 4938 classified
Recall and F-score are ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.98      0.92      1.00      0.95      0.96      0.91       481
                 0       0.99      1.00      0.95      1.00      0.97      0.95      4478
__NOT_CLASSIFIED__       0.00      0.00      1.00      0.00      0.00      0.00         0

       avg / total       0.99      0.99      0.95      0.99      0.97      0.95      4959

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             444 │              24 │               13 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │              10 │            4460 │                8 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛


Confidence threshold &gt; 0.7 - 4920 classified
Recall and F-score are ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.98      0.91      1.00      0.94      0.95      0.90       481
                 0       1.00      1.00      0.97      1.00      0.98      0.97      4478
__NOT_CLASSIFIED__       0.00      0.00      0.99      0.00      0.00      0.00         0

       avg / total       0.99      0.99      0.97      0.99      0.98      0.96      4959

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             437 │              16 │               28 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │               9 │            4458 │               11 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛


Confidence threshold &gt; 0.8 - 4896 classified
Recall and F-score are ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.98      0.89      1.00      0.93      0.94      0.88       481
                 0       1.00      0.99      0.97      1.00      0.98      0.97      4478
__NOT_CLASSIFIED__       0.00      0.00      0.99      0.00      0.00      0.00         0

       avg / total       1.00      0.98      0.98      0.99      0.98      0.96      4959

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             427 │              13 │               41 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │               7 │            4449 │               22 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛


Confidence threshold &gt; 0.9 - 4852 classified
Recall and F-score are ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.99      0.84      1.00      0.91      0.92      0.83       481
                 0       1.00      0.99      0.98      0.99      0.99      0.97      4478
__NOT_CLASSIFIED__       0.00      0.00      0.98      0.00      0.00      0.00         0

       avg / total       1.00      0.98      0.98      0.99      0.98      0.96      4959

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             406 │               9 │               66 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │               4 │            4433 │               41 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛

2023-03-08 17:54:00,225:INFO:__main__:Training done
spambugmodel         : 64.23%   (39257809 =&gt; 25215938 bytes, spambugmodel.zst) 
2023-03-08 17:54:00,884:INFO:__main__:Model compressed
```
</details>

#### Results After Training
<details><summary>Click to see the classification reports</summary>

```
X: (49582, 25405), y: (49582,)
Cross Validation scores:
Accuracy: f0.9922013366529938 (+/- 0.0009673582514736585)
Precision: f0.9695929314439267 (+/- 0.002708373219398583)
Recall: f0.9409669211195928 (+/- 0.012732820359487872)
X_train: (44623, 25405), y_train: (44623,)
resampled X_train: (81386, 25405), y_train: (81386,)
X_test: (4959, 25405), y_test: (4959,)
Model trained
Training Set scores:
                   pre       rec       spe        f1       geo       iba       sup

          1       1.00      1.00      1.00      1.00      1.00      1.00     40693
          0       1.00      1.00      1.00      1.00      1.00      1.00     40693

avg / total       1.00      1.00      1.00      1.00      1.00      1.00     81386

Test Set scores:
No confidence threshold - 4959 classified
                   pre       rec       spe        f1       geo       iba       sup

          1       0.97      0.95      1.00      0.96      0.97      0.94       481
          0       0.99      1.00      0.95      1.00      0.97      0.95      4478

avg / total       0.99      0.99      0.95      0.99      0.97      0.95      4959

╒════════════╤═════════════════╤═════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │
╞════════════╪═════════════════╪═════════════════╡
│ 1 (Actual) │             457 │              24 │
├────────────┼─────────────────┼─────────────────┤
│ 0 (Actual) │              12 │            4466 │
╘════════════╧═════════════════╧═════════════════╛


Confidence threshold &gt; 0.1 - 4959 classified
Precision and F-score are ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.
Recall and F-score are ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.90      0.99      0.99      0.95      0.99      0.98       481
                 0       1.00      0.99      0.99      0.99      0.99      0.98      4478
__NOT_CLASSIFIED__       0.00      0.00      1.00      0.00      0.00      0.00         0

       avg / total       0.99      0.99      0.99      0.99      0.99      0.98      4959

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             476 │               5 │                0 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │              50 │            4428 │                0 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛


Confidence threshold &gt; 0.2 - 4959 classified
Precision and F-score are ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.
Recall and F-score are ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.95      0.98      0.99      0.96      0.99      0.97       481
                 0       1.00      0.99      0.98      1.00      0.99      0.97      4478
__NOT_CLASSIFIED__       0.00      0.00      1.00      0.00      0.00      0.00         0

       avg / total       0.99      0.99      0.98      0.99      0.99      0.97      4959

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             471 │              10 │                0 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │              26 │            4452 │                0 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛


Confidence threshold &gt; 0.3 - 4959 classified
Precision and F-score are ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.
Recall and F-score are ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.97      0.98      1.00      0.97      0.99      0.97       481
                 0       1.00      1.00      0.98      1.00      0.99      0.97      4478
__NOT_CLASSIFIED__       0.00      0.00      1.00      0.00      0.00      0.00         0

       avg / total       0.99      0.99      0.98      0.99      0.99      0.97      4959

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             469 │              12 │                0 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │              17 │            4461 │                0 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛


Confidence threshold &gt; 0.4 - 4959 classified
Precision and F-score are ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.
Recall and F-score are ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.97      0.96      1.00      0.97      0.98      0.95       481
                 0       1.00      1.00      0.96      1.00      0.98      0.96      4478
__NOT_CLASSIFIED__       0.00      0.00      1.00      0.00      0.00      0.00         0

       avg / total       0.99      0.99      0.96      0.99      0.98      0.96      4959

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             462 │              19 │                0 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │              14 │            4464 │                0 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛


Confidence threshold &gt; 0.6 - 4942 classified
Recall and F-score are ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.98      0.94      1.00      0.96      0.97      0.93       481
                 0       1.00      1.00      0.96      1.00      0.98      0.96      4478
__NOT_CLASSIFIED__       0.00      0.00      1.00      0.00      0.00      0.00         0

       avg / total       0.99      0.99      0.96      0.99      0.98      0.96      4959

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             450 │              19 │               12 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │               9 │            4464 │                5 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛


Confidence threshold &gt; 0.7 - 4926 classified
Recall and F-score are ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.98      0.92      1.00      0.95      0.96      0.91       481
                 0       1.00      1.00      0.98      1.00      0.99      0.97      4478
__NOT_CLASSIFIED__       0.00      0.00      0.99      0.00      0.00      0.00         0

       avg / total       1.00      0.99      0.98      0.99      0.98      0.97      4959

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             444 │              12 │               25 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │               9 │            4461 │                8 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛


Confidence threshold &gt; 0.8 - 4898 classified
Recall and F-score are ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.99      0.90      1.00      0.94      0.95      0.89       481
                 0       1.00      0.99      0.98      1.00      0.99      0.97      4478
__NOT_CLASSIFIED__       0.00      0.00      0.99      0.00      0.00      0.00         0

       avg / total       1.00      0.98      0.98      0.99      0.98      0.97      4959

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             431 │              10 │               40 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │               5 │            4452 │               21 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛


Confidence threshold &gt; 0.9 - 4841 classified
Recall and F-score are ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.99      0.84      1.00      0.91      0.91      0.82       481
                 0       1.00      0.99      0.99      0.99      0.99      0.98      4478
__NOT_CLASSIFIED__       0.00      0.00      0.98      0.00      0.00      0.00         0

       avg / total       1.00      0.97      0.99      0.99      0.98      0.96      4959

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             403 │               5 │               73 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │               5 │            4428 │               45 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛

2023-03-07 22:23:47,416:INFO:__main__:Training done
spambugmodel         : 63.49%   (39842101 =&gt; 25296473 bytes, spambugmodel.zst) 
2023-03-07 22:23:47,893:INFO:__main__:Model compressed

```

</details>


