### PR TITLE
get_bugbug_labels no longer adds nobug type to regression training data

### DIFF
--- a/bugbug/models/defect.py
+++ b/bugbug/models/defect.py
@@ -98,9 +98,9 @@ class DefectModel(BugModel):
             assert category in ["True", "False"], f"unexpected category {category}"
             if kind == "bug":
                 classes[int(bug_id)] = 1 if category == "True" else 0
+            # do not include nobug in regression classifier training data 
             elif kind == "regression":
-                if category == "False":
-                    classes[int(bug_id)] = 0
+                continue
             elif kind == "defect_enhancement_task":
                 if category == "True":
                     classes[int(bug_id)] = "defect"
@@ -115,9 +115,9 @@ class DefectModel(BugModel):
             if kind == "bug":
                 classes[int(bug_id)] = 1 if category != "nobug" else 0
             elif kind == "regression":
-                if category == "bug_unknown_regression":
+                # regression classifier to classify between regression and bug_no_regression only
+                if category == "bug_unknown_regression" or category == "nobug":
                     continue
-
                 classes[int(bug_id)] = 1 if category == "regression" else 0
             elif kind == "defect_enhancement_task":
                 if category != "nobug":


### PR DESCRIPTION
#539 

Modified `get_bugbug_labels` in `defect.py` to include only those data points that are labelled either `regression` or `bug_no_regression` in the training set.

Training the model without changes

72486 non-regression bugs

Cross Validation scores:
Accuracy: f0.9731263445549161 (+/- 0.0012810455820845609)
Precision: f0.9560802008310938 (+/- 0.006503421458310747)
Recall: f0.9316432362619518 (+/- 0.0042866900183067425)

Training the model after changes

71597 non-regression bugs (889 dropped)

Cross Validation scores:
Accuracy: f0.9739072259525028 (+/- 0.0019480324611321944)
Precision: f0.9561803892880535 (+/- 0.006928496874119621)
Recall: f0.9358629670750973 (+/- 0.0045683573571298)

Minor improvement in precision and recall.

Should categories `task`, `enhancement`, `feature` also be removed from the training data for regression?

Please let me know if I have misunderstood the task.
