### PR TITLE
Upgrade to use the latest version of rust-code-analysis-web #3117

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -91,7 +91,7 @@ tasks:
             - "apt-get -qq update &&
               apt-get -qq install -y libhdf5-dev zstd &&
               git clone --quiet ${repository} &&
-              curl -L https://github.com/mozilla/rust-code-analysis/releases/download/v0.0.23/rust-code-analysis-linux-web-x86_64.tar.gz | tar -C /usr/bin -xzv &&
+              curl -L https://github.com/mozilla/rust-code-analysis/releases/download/v0.0.25/rust-code-analysis-linux-web-x86_64.tar.gz | tar -C /usr/bin -xzv &&
               cd bugbug &&
               git -c advice.detachedHead=false checkout ${head_rev} &&
               cp infra/hgrc /etc/mercurial/hgrc.d/bugbug.rc &&
@@ -122,7 +122,7 @@ tasks:
             - "/bin/bash"
             - "-lcx"
             - "git clone --quiet ${repository} &&
-              curl -L https://github.com/mozilla/rust-code-analysis/releases/download/v0.0.23/rust-code-analysis-linux-web-x86_64.tar.gz | tar -C /usr/bin -xzv &&
+              curl -L https://github.com/mozilla/rust-code-analysis/releases/download/v0.0.25/rust-code-analysis-linux-web-x86_64.tar.gz | tar -C /usr/bin -xzv &&
               cd bugbug &&
               git -c advice.detachedHead=false checkout ${head_rev} &&
               cp infra/hgrc /etc/mercurial/hgrc.d/bugbug.rc &&

--- a/bugbug/model.py
+++ b/bugbug/model.py
@@ -3,9 +3,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import logging
 import pickle
 from collections import defaultdict
-from logging import INFO, basicConfig, getLogger
 from typing import Any
 
 import matplotlib
@@ -30,8 +30,8 @@ from bugbug.github import Github
 from bugbug.nlp import SpacyVectorizer
 from bugbug.utils import split_tuple_generator, to_array
 
-basicConfig(level=INFO)
-logger = getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def classification_report_imbalanced_values(

--- a/bugbug/models/annotate_ignore.py
+++ b/bugbug/models/annotate_ignore.py
@@ -3,7 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from logging import INFO, basicConfig, getLogger
+import logging
 
 import xgboost
 from imblearn.under_sampling import RandomUnderSampler
@@ -14,8 +14,8 @@ from sklearn.pipeline import Pipeline
 from bugbug import bugzilla, commit_features, feature_cleanup, labels, repository, utils
 from bugbug.model import CommitModel
 
-basicConfig(level=INFO)
-logger = getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class AnnotateIgnoreModel(CommitModel):

--- a/bugbug/models/assignee.py
+++ b/bugbug/models/assignee.py
@@ -3,8 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import logging
 from collections import Counter
-from logging import INFO, basicConfig, getLogger
 
 import xgboost
 from sklearn.compose import ColumnTransformer
@@ -25,8 +25,8 @@ ADDRESSES_TO_EXCLUDE = [
     "nobody@t4b.me",
 ]
 
-basicConfig(level=INFO)
-logger = getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class AssigneeModel(BugModel):

--- a/bugbug/models/backout.py
+++ b/bugbug/models/backout.py
@@ -3,8 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import logging
 from datetime import datetime
-from logging import INFO, basicConfig, getLogger
 
 import dateutil.parser
 import xgboost
@@ -17,8 +17,8 @@ from sklearn.pipeline import Pipeline
 from bugbug import bug_features, commit_features, feature_cleanup, repository, utils
 from bugbug.model import CommitModel
 
-basicConfig(level=INFO)
-logger = getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class BackoutModel(CommitModel):

--- a/bugbug/models/component.py
+++ b/bugbug/models/component.py
@@ -3,9 +3,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import logging
 from collections import Counter
 from datetime import datetime, timezone
-from logging import INFO, basicConfig, getLogger
 
 import dateutil.parser
 import xgboost
@@ -18,8 +18,8 @@ from bugbug import bug_features, bugzilla, feature_cleanup, utils
 from bugbug.bugzilla import get_product_component_count
 from bugbug.model import BugModel
 
-basicConfig(level=INFO)
-logger = getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class ComponentModel(BugModel):

--- a/bugbug/models/defect.py
+++ b/bugbug/models/defect.py
@@ -4,7 +4,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import itertools
-from logging import INFO, basicConfig, getLogger
+import logging
 from typing import Any
 
 import xgboost
@@ -16,8 +16,8 @@ from sklearn.pipeline import Pipeline
 from bugbug import bug_features, bugzilla, feature_cleanup, labels, utils
 from bugbug.model import BugModel
 
-basicConfig(level=INFO)
-logger = getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class DefectModel(BugModel):

--- a/bugbug/models/defect_enhancement_task.py
+++ b/bugbug/models/defect_enhancement_task.py
@@ -3,13 +3,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from logging import INFO, basicConfig, getLogger
+import logging
 from typing import Any
 
 from bugbug.models.defect import DefectModel
 
-basicConfig(level=INFO)
-logger = getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class DefectEnhancementTaskModel(DefectModel):

--- a/bugbug/models/duplicate.py
+++ b/bugbug/models/duplicate.py
@@ -3,9 +3,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import logging
 import random
 from itertools import combinations
-from logging import INFO, basicConfig, getLogger
 
 from sklearn.compose import ColumnTransformer
 from sklearn.feature_extraction import DictVectorizer
@@ -17,8 +17,8 @@ from bugbug.model import BugCoupleModel
 
 REPORTERS_TO_IGNORE = {"intermittent-bug-filer@mozilla.bugs", "wptsync@mozilla.bugs"}
 
-basicConfig(level=INFO)
-logger = getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class DuplicateModel(BugCoupleModel):

--- a/bugbug/models/regression.py
+++ b/bugbug/models/regression.py
@@ -3,13 +3,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from logging import INFO, basicConfig, getLogger
+import logging
 from typing import Any
 
 from bugbug.models.defect import DefectModel
 
-basicConfig(level=INFO)
-logger = getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class RegressionModel(DefectModel):

--- a/bugbug/models/regressionrange.py
+++ b/bugbug/models/regressionrange.py
@@ -3,7 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from logging import INFO, basicConfig, getLogger
+import logging
 
 import xgboost
 from imblearn.under_sampling import RandomUnderSampler
@@ -14,8 +14,8 @@ from sklearn.pipeline import Pipeline
 from bugbug import bug_features, bugzilla, feature_cleanup, utils
 from bugbug.model import BugModel
 
-basicConfig(level=INFO)
-logger = getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class RegressionRangeModel(BugModel):

--- a/bugbug/models/regressor.py
+++ b/bugbug/models/regressor.py
@@ -4,8 +4,8 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import itertools
+import logging
 from datetime import datetime
-from logging import INFO, basicConfig, getLogger
 
 import dateutil.parser
 import numpy as np
@@ -19,8 +19,8 @@ from sklearn.pipeline import Pipeline
 from bugbug import bugzilla, commit_features, db, feature_cleanup, repository, utils
 from bugbug.model import CommitModel
 
-basicConfig(level=INFO)
-logger = getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 BUG_FIXING_COMMITS_DB = "data/bug_fixing_commits.json"
 db.register(

--- a/bugbug/models/spambug.py
+++ b/bugbug/models/spambug.py
@@ -3,7 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from logging import INFO, basicConfig, getLogger
+import logging
 
 import xgboost
 from imblearn.over_sampling import BorderlineSMOTE
@@ -14,8 +14,8 @@ from sklearn.pipeline import Pipeline
 from bugbug import bug_features, bugzilla, feature_cleanup, utils
 from bugbug.model import BugModel
 
-basicConfig(level=INFO)
-logger = getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class SpamBugModel(BugModel):

--- a/bugbug/models/stepstoreproduce.py
+++ b/bugbug/models/stepstoreproduce.py
@@ -3,7 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from logging import INFO, basicConfig, getLogger
+import logging
 
 import xgboost
 from imblearn.under_sampling import RandomUnderSampler
@@ -14,8 +14,8 @@ from sklearn.pipeline import Pipeline
 from bugbug import bug_features, bugzilla, feature_cleanup, utils
 from bugbug.model import BugModel
 
-basicConfig(level=INFO)
-logger = getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class StepsToReproduceModel(BugModel):

--- a/bugbug/models/testfailure.py
+++ b/bugbug/models/testfailure.py
@@ -3,7 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from logging import INFO, basicConfig, getLogger
+import logging
 
 import xgboost
 from imblearn.under_sampling import RandomUnderSampler
@@ -14,8 +14,8 @@ from sklearn.pipeline import Pipeline
 from bugbug import commit_features, repository, test_scheduling, utils
 from bugbug.model import CommitModel
 
-basicConfig(level=INFO)
-logger = getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class TestFailureModel(CommitModel):


### PR DESCRIPTION
> **references** #3117 

- While the dependencies have been updated to version v.0.0.25 successfully, I'm still working on making the necessary changes to `repository.py.`

- I'm submitting this draft pull request to keep track of the work in progress and to get early feedback from the team on the direction of the changes. I'm open to suggestions and guidance on how to best approach this task and make sure the changes are correctly implemented.
