### PR TITLE
Increase the time limitation for the revision retriever script

### DIFF
--- a/scripts/revision_retriever.py
+++ b/scripts/revision_retriever.py
@@ -15,7 +15,20 @@ logger = getLogger(__name__)
 
 
 class Retriever(object):
-    def retrieve_revisions(self, limit: Optional[int] = None) -> None:
+    def retrieve_revisions(
+        self,
+        limit_months: int = 2,
+        limit_count: Optional[int] = None,
+    ) -> None:
+        """Retrieve revisions from Phabricator.
+
+        Args:
+            limit_months: The number of months to go back in time to retrieve
+                revisions. The limit is based on bugs last activity date and
+                commits push date.
+            limit_count: Only download the N oldest revisions, used mainly for
+                integration tests.
+        """
         phabricator.set_api_key(
             get_secret("PHABRICATOR_URL"), get_secret("PHABRICATOR_TOKEN")
         )
@@ -30,8 +43,8 @@ class Retriever(object):
 
         phabricator.download_modified_revisions()
 
-        # Get IDs of revisions linked to commits since a year ago.
-        start_date = datetime.now(timezone.utc) - relativedelta(years=1)
+        # Get IDs of revisions linked to commits.
+        start_date = datetime.now(timezone.utc) - relativedelta(months=limit_months)
         revision_ids = list(
             (
                 filter(
@@ -48,15 +61,15 @@ class Retriever(object):
             )
         )
 
-        # Get IDs of revisions linked to bugs since a year ago.
+        # Get IDs of revisions linked to bugs.
         for bug in bugzilla.get_bugs():
             if dateutil.parser.parse(bug["last_change_time"]) < start_date:
                 continue
 
             revision_ids += bugzilla.get_revision_ids(bug)
 
-        if limit is not None:
-            revision_ids = revision_ids[-limit:]
+        if limit_count is not None:
+            revision_ids = revision_ids[-limit_count:]
 
         phabricator.download_revisions(revision_ids)
 
@@ -67,6 +80,12 @@ def main() -> None:
     description = "Retrieve revisions from Phabricator"
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
+        "--limit-months",
+        type=int,
+        default=24,
+        help="The number of months to go back in time to retrieve revisions.",
+    )
+    parser.add_argument(
         "--limit",
         type=int,
         help="Only download the N oldest revisions, used mainly for integration tests",
@@ -76,7 +95,7 @@ def main() -> None:
     args = parser.parse_args()
 
     retriever = Retriever()
-    retriever.retrieve_revisions(args.limit)
+    retriever.retrieve_revisions(args.limit_months, args.limit)
 
 
 if __name__ == "__main__":

--- a/scripts/revision_retriever.py
+++ b/scripts/revision_retriever.py
@@ -47,8 +47,6 @@ class Retriever(object):
                 )
             )
         )
-        if limit is not None:
-            revision_ids = revision_ids[-limit:]
 
         # Get IDs of revisions linked to bugs since a year ago.
         for bug in bugzilla.get_bugs():
@@ -56,6 +54,9 @@ class Retriever(object):
                 continue
 
             revision_ids += bugzilla.get_revision_ids(bug)
+
+        if limit is not None:
+            revision_ids = revision_ids[-limit:]
 
         phabricator.download_revisions(revision_ids)
 


### PR DESCRIPTION
This will make the limit dynamic with a default value of 2 years.