### PR TITLE
change python-igraph to igraph

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,9 +1,9 @@
 coverage==7.2.7
 hypothesis==6.81.2
+igraph==0.10.6
 jsonschema==4.17.3
 pre-commit==3.3.3
 pytest==7.4.0
 pytest-cov==4.1.0
 pytest-responses==0.5.1
-igraph==0.10.6
 responses==0.21.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,5 +5,5 @@ pre-commit==3.3.3
 pytest==7.4.0
 pytest-cov==4.1.0
 pytest-responses==0.5.1
-python-igraph==0.10.5
+igraph==0.10.6
 responses==0.21.0


### PR DESCRIPTION
The package was renamed on PyPI, and support was scheduled to be stopped on Sep 1st, 2022. See https://pypi.org/project/python-igraph/