### PR TITLE
Add generic-worker:cache scopes for dw deprecation work

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -200,6 +200,7 @@ tasks:
         scopes:
           - docker-worker:capability:privileged
           - docker-worker:cache:bugbug-build
+          - generic-worker:cache:bugbug-build
         metadata:
           name: bugbug docker build
           description: bugbug docker build
@@ -316,6 +317,7 @@ tasks:
           scopes:
             - secrets:get:project/bugbug/integration
             - "docker-worker:cache:bugbug-mercurial-repository"
+            - "generic-worker:cache:bugbug-mercurial-repository"
           payload:
             features:
               taskclusterProxy: true

--- a/infra/data-pipeline.yml
+++ b/infra/data-pipeline.yml
@@ -32,6 +32,7 @@ tasks:
           taskclusterProxy: true
       scopes:
         - "docker-worker:cache:bugbug-mercurial-repository"
+        - "generic-worker:cache:bugbug-mercurial-repository"
         - "secrets:get:project/bugbug/production"
         - "auth:aws-s3:read-write:communitytc-bugbug/*"
       routes:
@@ -67,6 +68,7 @@ tasks:
           taskclusterProxy: true
       scopes:
         - "docker-worker:cache:bugbug-mercurial-repository"
+        - "generic-worker:cache:bugbug-mercurial-repository"
         - "secrets:get:project/bugbug/production"
         - "auth:aws-s3:read-write:communitytc-bugbug/*"
       routes:
@@ -103,6 +105,7 @@ tasks:
           taskclusterProxy: true
       scopes:
         - "docker-worker:cache:bugbug-mercurial-repository"
+        - "generic-worker:cache:bugbug-mercurial-repository"
         - "secrets:get:project/bugbug/production"
         - "auth:aws-s3:read-write:communitytc-bugbug/*"
       routes:
@@ -140,6 +143,7 @@ tasks:
           bugbug-mercurial-repository: /cache
       scopes:
         - "docker-worker:cache:bugbug-mercurial-repository"
+        - "generic-worker:cache:bugbug-mercurial-repository"
       routes:
         - notify.email.release-mgmt-analysis@mozilla.com.on-failed
         - notify.irc-channel.#bugbug.on-failed
@@ -1346,6 +1350,7 @@ tasks:
       scopes:
         - secrets:get:project/bugbug/integration
         - "docker-worker:cache:bugbug-mercurial-repository"
+        - "generic-worker:cache:bugbug-mercurial-repository"
       payload:
         features:
           taskclusterProxy: true

--- a/infra/landings-pipeline.yml
+++ b/infra/landings-pipeline.yml
@@ -41,6 +41,7 @@ tasks:
           bugbug-mercurial-repository: /cache
       scopes:
         - docker-worker:cache:bugbug-mercurial-repository
+        - generic-worker:cache:bugbug-mercurial-repository
         - secrets:get:project/bugbug/production
       routes:
         - notify.email.release-mgmt-analysis@mozilla.com.on-failed


### PR DESCRIPTION
Related to https://github.com/mozilla/community-tc-config/pull/644.