### PR TITLE
Fix formatting parameter when logging confidence

### DIFF
--- a/bugbug/test_scheduling.py
+++ b/bugbug/test_scheduling.py
@@ -535,7 +535,7 @@ def generate_failing_together_probabilities(
             failing_together[couple[0]][couple[1]] = (support, confidence)
 
     for percentage, count in count_redundancies.most_common():
-        logger.info("%d with %f%% confidence", count, percentage)
+        logger.info("%d with %s confidence", count, percentage)
 
     failing_together_db = get_failing_together_db(granularity, False)
 


### PR DESCRIPTION
```
--- Logging error ---
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1100, in emit
    msg = self.format(record)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 943, in format
    return fmt.format(record)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 678, in format
    record.message = record.getMessage()
  File "/usr/local/lib/python3.10/logging/__init__.py", line 368, in getMessage
    msg = msg % self.args
TypeError: must be real number, not str
Call stack:
  File "/usr/local/bin/bugbug-data-test-scheduling-history", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/site-packages/scripts/test_scheduling_history_retriever.py", line 387, in main
    retriever.generate_test_scheduling_history(
  File "/usr/local/lib/python3.10/site-packages/scripts/test_scheduling_history_retriever.py", line 221, in generate_test_scheduling_history
    test_scheduling.generate_failing_together_probabilities(
  File "/usr/local/lib/python3.10/site-packages/bugbug/test_scheduling.py", line 538, in generate_failing_together_probabilities
    logger.info("%d with %f%% confidence", count, percentage)
Message: '%d with %f%% confidence'
Arguments: (14384, '0%')
```