### PR TITLE
Create a workflow to add new issues to the team project

### DIFF
--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -1,0 +1,16 @@
+name: Add new issues to the team project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/mozilla/projects/214
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Similar to https://github.com/mozilla/bugbot/pull/1960

@marco-c could you please add a [repository secret](https://github.com/mozilla/bugbug/settings/secrets/actions) and call it `ADD_TO_PROJECT_PAT`? You need to create a new [personal access token](https://github.com/settings/tokens/new) with `project` scope. You could use your personal account or ideally a bot account.