### PR TITLE
Optimize fileref cleanup regex by grouping extensions

### DIFF
--- a/bugbug/feature_cleanup.py
+++ b/bugbug/feature_cleanup.py
@@ -21,9 +21,7 @@ class url(object):
 
 class fileref(object):
     def __init__(self):
-        self.pattern = re.compile(
-            r"\w+\.py\b|\w+\.json\b|\w+\.js\b|\w+\.jsm\b|\w+\.mjs\b|\w+\.jsx\b|\w+\.html\b|\w+\.css\b|\w+\.c\b|\w+\.cpp\b|\w+\.h\b"
-        )
+        self.pattern = re.compile(r"\w+\.(py|json|js|jsm|mjs|jsx|html|css|c|cpp|h)\b")
 
     def __call__(self, text):
         return self.pattern.sub("__FILE_REFERENCE__", text)


### PR DESCRIPTION
This goes from 26 seconds to 2 seconds on a subset of 7000 bugs.