### PR TITLE
Fix: #3695 Dropped definition of bug model

### DIFF
--- a/bugbug/models/__init__.py
+++ b/bugbug/models/__init__.py
@@ -13,7 +13,6 @@ MODELS = {
     "assignee": "bugbug.models.assignee.AssigneeModel",
     "backout": "bugbug.models.backout.BackoutModel",
     "browsername": "bugbug.models.browsername.BrowserNameModel",
-    "bug": "bugbug.model.BugModel",
     "bugtype": "bugbug.models.bugtype.BugTypeModel",
     "component": "bugbug.models.component.ComponentModel",
     "component_nn": "bugbug.models.component_nn.ComponentNNModel",


### PR DESCRIPTION
Dropped the unnecessary definition of bug model as the implementations were deleted.
Closes #3695.