### PR TITLE
Issue #3692: Modified methods to use `zstdmt` binary

### DIFF
--- a/bugbug/utils.py
+++ b/bugbug/utils.py
@@ -279,7 +279,7 @@ def extract_tar_zst(path: str) -> None:
     if not os.path.exists(path):
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), path)
 
-    subprocess.run(["tar", "-I", "zstd", "-xf", path], check=True)
+    subprocess.run(["tar", "-I", "zstdmt", "-xf", path], check=True)
 
 
 def extract_file(path: str) -> None:

--- a/bugbug/utils.py
+++ b/bugbug/utils.py
@@ -244,7 +244,7 @@ def zstd_decompress(path: str) -> None:
     if not os.path.exists(f"{path}.zst"):
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), path)
 
-    subprocess.run(["zstd", "-df", f"{path}.zst"], check=True)
+    subprocess.run(["zstdmt", "-df", f"{path}.zst"], check=True)
 
 
 @contextmanager

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -302,6 +302,29 @@ def test_zstd_compress_not_existing(tmp_path, mock_zst):
     assert not os.path.exists(compressed_path)
 
 
+def test_create_extract_tar_zst(tmp_path):
+    path = tmp_path / "prova"
+    tar_zst_path = "prova.tar.zst"
+
+    with open(path, "w") as f:
+        json.dump({"Hello": "World"}, f)
+
+    utils.create_tar_zst(tar_zst_path)
+
+    assert os.path.exists(tar_zst_path)
+
+    os.remove(path)
+
+    utils.extract_tar_zst(tar_zst_path)
+
+    assert os.path.exists(path)
+
+    with open(path, "r") as f:
+        file_decomp = json.load(f)
+
+    assert file_decomp == {"Hello": "World"}
+
+
 def test_extract_db_zst(tmp_path, mock_zst):
     path = tmp_path / "prova.zst"
 


### PR DESCRIPTION
Closes #3692

Hello @marco-c @suhaibmujahid,

I've made changes to the `zstd_decompress` and `extract_tar_zst` methods. They now use the `zstdmt` binary instead of the `zstd` binary for decompression tasks. 

Please, I wish to find out if this change is needed just for decompression tasks, or should I update other methods like `zstd_compress` and `create_tar_zst` that use the `zstd` binary for compression.

Additionally, I noticed the presence of the `zstandard` Python library, alongside the use of the `zstd` binary for certain tasks. I'm curious about why both are used when they seem to perform similar tasks.