### PR TITLE
refactor count_bugs to use libmozdata (#3676)

### DIFF
--- a/bugbug/bugzilla.py
+++ b/bugbug/bugzilla.py
@@ -282,13 +282,14 @@ def delete_bugs(match):
 def count_bugs(bug_query_params):
     bug_query_params["count_only"] = 1
 
-    r = utils.get_session("bugzilla").get(
-        "https://bugzilla.mozilla.org/rest/bug", params=bug_query_params
-    )
-    r.raise_for_status()
-    count = r.json()["bug_count"]
+    counts = []
 
-    return count
+    def handler(bug):
+        counts.append(bug["bug_count"])
+
+    Bugzilla(bug_query_params, bughandler=handler).get_data().wait()
+
+    return sum(counts)
 
 
 def get_product_component_count(months: int = 12) -> dict[str, int]:


### PR DESCRIPTION
Closes #3676

Refactored the `count_bugs` function in bugbug/bugzilla.py to utilize the `Bugzilla` class from `libmozdata.bugzilla` instead of making a direct request.


The previous approach involved sending a direct GET request to Bugzilla's REST API. This approach might not be sustainable and consistent in the long run, especially if there are updates or changes to the API.

By using the `libmozdata.bugzilla` library, we aim for a more maintainable and robust method of counting bugs. It also keeps our codebase consistent with other parts where the `Bugzilla` class is used.