### PR TITLE
Update the readme file to require python 3.10+

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pip3 install -r requirements.txt
 
 You may also need `pip install -r test-requirements.txt`. Depending on the parts of bugbug you want to run, you might need to install dependencies from other requirement files (find them with `find . -name "*requirements*"`).
 
-Currently, Python 3.9+ is required. You can double check the version we use by looking at setup.py.
+Currently, Python 3.10+ is required. You can double check the version we use by looking at setup.py.
 
 Also, libgit2 (needs [v1.0.0](https://github.com/libgit2/libgit2/releases/tag/v1.0.0), only in [experimental on Debian](https://wiki.debian.org/DebianExperimental)), **might** be required (if you can't install it, skip this step).
 


### PR DESCRIPTION
This became required after #3691:

https://github.com/mozilla/bugbug/blob/b37623c74d092d9e69979d454cdb78f70b27c078/bugbug/test_scheduling.py#L347