### PR TITLE
Calculate the time to burn down all the defects backlog

### DIFF
--- a/scripts/generate_landings_risk_report.py
+++ b/scripts/generate_landings_risk_report.py
@@ -1786,12 +1786,16 @@ List of revisions that have been waiting for a review for longer than 3 days:
                     2,
                 )
 
+            def format_maintenance_effectiveness(period):
+                me = calculate_maintenance_effectiveness(period)
+                return ", ".join(f"{factor}: {value}" for factor, value in me.items())
+
             maintenance_effectiveness_section = f"""<b>MAINTENANCE EFFECTIVENESS</b>
 <br />
 
-Last week: {calculate_maintenance_effectiveness(relativedelta(weeks=1))}
-Last month: {calculate_maintenance_effectiveness(relativedelta(months=1))}
-Last year: {calculate_maintenance_effectiveness(relativedelta(years=1))}
+Last week: {format_maintenance_effectiveness(relativedelta(weeks=1))}
+Last month: {format_maintenance_effectiveness(relativedelta(months=1))}
+Last year: {format_maintenance_effectiveness(relativedelta(years=1))}
 """
 
             sections = [

--- a/scripts/maintenance_effectiveness_indicator.py
+++ b/scripts/maintenance_effectiveness_indicator.py
@@ -4,6 +4,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import argparse
+import math
 from logging import INFO, basicConfig, getLogger
 
 import dateutil.parser
@@ -45,17 +46,15 @@ def main():
             "If you want to include security bugs too, please set the BUGBUG_BUGZILLA_TOKEN environment variable to your Bugzilla API key."
         )
 
-    logger.info(
-        round(
-            bugzilla.calculate_maintenance_effectiveness_indicator(
-                args.team,
-                dateutil.parser.parse(args.start_date),
-                dateutil.parser.parse(args.end_date),
-                args.components,
-            ),
-            2,
-        )
+    result = bugzilla.calculate_maintenance_effectiveness_indicator(
+        args.team,
+        dateutil.parser.parse(args.start_date),
+        dateutil.parser.parse(args.end_date),
+        args.components,
     )
+
+    for factor, value in result.items():
+        logger.info(f"{factor}: {round(value, 2) if value != math.inf else value}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #3714

Example:
>Calculating maintenance effectiveness indicator for the DOM LWS team from 2023-10-01 00:00:00 to 2023-10-12 00:00:00
Before applying weights:
{'open': {'--': 20, 'S1': 0, 'S2': 2, 'S3': 842, 'S4': 241}, 'opened': {'--': 7, 'S1': 0, 'S2': 0, 'S3': 4, 'S4': 10}, 'closed': {'--': 0, 'S1': 0, 'S2': 1, 'S3': 7, 'S4': 20}}
After applying weights:
{'open': {'--': 60, 'S1': 0, 'S2': 10, 'S3': 1684, 'S4': 241}, 'opened': {'--': 21, 'S1': 0, 'S2': 0, 'S3': 8, 'S4': 10}, 'closed': {'--': 0, 'S1': 0, 'S2': 5, 'S3': 14, 'S4': 20}}
ME%: 100.0
BDTime: 1736.43
WBDTime: inf

@jensstutte could you r?