### PR TITLE
Use `zstdmt` binary instead of `zstd` binary when compressing

### DIFF
--- a/bugbug/utils.py
+++ b/bugbug/utils.py
@@ -272,7 +272,7 @@ def create_tar_zst(path: str) -> None:
     if not os.path.exists(inner_path):
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), inner_path)
 
-    subprocess.run(["tar", "-I", "zstd", "-cf", path, inner_path], check=True)
+    subprocess.run(["tar", "-I", "zstdmt", "-cf", path, inner_path], check=True)
 
 
 def extract_tar_zst(path: str) -> None:

--- a/bugbug/utils.py
+++ b/bugbug/utils.py
@@ -237,7 +237,7 @@ def zstd_compress(path: str) -> None:
     if not os.path.exists(path):
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), path)
 
-    subprocess.run(["zstd", "-f", path], check=True)
+    subprocess.run(["zstdmt", "-f", path], check=True)
 
 
 def zstd_decompress(path: str) -> None:


### PR DESCRIPTION
Closes: #3722

**Tests**

```bash
pytest -vk "test_zstd_compress_decompress"
```
You can find the test results in [test_zstd_compress_decompress.txt](https://github.com/mozilla/bugbug/files/12909685/test_zstd_compress_decompress.txt)

As there were no tests for the `create_tar_zst` function, I executed the function and checked for the presence of the resulting file:

```bash
python -c "from bugbug.utils import create_tar_zst; create_tar_zst('data.tar.zst')" && (test -f data.tar.zst && echo "File exists") || echo "File does not exist"
```