### PR TITLE
Restrict the training set of the RegressionRange model only to regressions

### DIFF
--- a/bugbug/models/regressionrange.py
+++ b/bugbug/models/regressionrange.py
@@ -69,7 +69,7 @@ class RegressionRangeModel(BugModel):
         classes = {}
 
         for bug_data in bugzilla.get_bugs():
-            if not bug_data["regressions"]:
+            if "regression" not in bug_data["keywords"]:
                 continue
 
             bug_id = int(bug_data["id"])

--- a/bugbug/models/regressionrange.py
+++ b/bugbug/models/regressionrange.py
@@ -69,6 +69,9 @@ class RegressionRangeModel(BugModel):
         classes = {}
 
         for bug_data in bugzilla.get_bugs():
+            if not bug_data["regressions"]:
+                continue
+
             bug_id = int(bug_data["id"])
             if "regressionwindow-wanted" in bug_data["keywords"]:
                 classes[bug_id] = 0


### PR DESCRIPTION
Closes: #793

Hello @suhaibmujahid @marco-c,

I executed the trainer:

```bash
python scripts/trainer.py regressionrange
```

Here are the outputs before and after the changes:

[regressionrange_before.txt](https://github.com/mozilla/bugbug/files/13068242/regressionrange_before.txt)
[regressionrange_after.txt](https://github.com/mozilla/bugbug/files/13068244/regressionrange_after.txt)

However, I keep getting the error:

```bash
ValueError: The target 'y' needs to have more than 1 class. Got 1 class instead.
```

I would appreciate any assistance or insights on it. 🙏