### PR TITLE
Added zstd==1.5.5.1 library to the requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-amqp==5.1.1
 beautifulsoup4==4.12.2
 boto3==1.28.66
 imbalanced-learn==0.11.0
@@ -9,7 +8,7 @@ matplotlib==3.8.0
 mercurial==6.5.2
 microannotate==0.0.24
 mozci==2.3.4
-numpy==1.22.4
+numpy==1.26.1
 orjson==3.9.9
 ortools==9.7.2996
 pandas==2.1.1
@@ -31,3 +30,6 @@ tenacity==8.2.3
 tqdm==4.66.1
 xgboost==2.0.0
 zstandard==0.21.0
+zstd==1.5.5.1
+﻿amqp==5.1.1
+


### PR DESCRIPTION
I was running the following command in the visual studio community console:

`python3 -m scripts.trainer defect
`

I was expecting to find the trained model as an answer.
But I found this error:


```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\EyL\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\bugbug-0.0.519-py3.11.egg\scripts\trainer.py", line 161, in <module>
    main()
  File "C:\Users\EyL\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\bugbug-0.0.519-py3.11.egg\scripts\trainer.py", line 157, in main
    retriever.go(args)
  File "C:\Users\EyL\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\bugbug-0.0.519-py3.11.egg\scripts\trainer.py", line 43, in go
    assert db.download(required_db)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\EyL\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\bugbug-0.0.519-py3.11.egg\bugbug\db.py", line 99, in download
    utils.extract_file(zst_path)
  File "C:\Users\EyL\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\bugbug-0.0.519-py3.11.egg\bugbug\utils.py", line 299, in extract_file
  File "C:\Users\EyL\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-  File "C:\Users\EyL\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-  File "C:\Users\EyL\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-  File "C:\Users\EyL\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-    subprocess.run(["zstdmt", "-df", f"{path}.zst"], check=True)
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.11_3.11.1776.0_x64__qbz5n2kfra8p0\Lib\subprocess.py", line 548, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.11_3.11.1776.0_x64__qbz5n2kfra8p0\Lib\subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.11_3.11.1776.0_x64__qbz5n2kfra8p0\Lib\subprocess.py", line 1538, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

It seems that zstdmt should be installed directly on the local system, and it can be done by directly installing the package on your computer, but that would mean that the person must also install it. The idea is to keep it on the remote system.
Zstandard (zstd) and Zstandard Multi-Threaded (zstdmt) are two implementations of the same compression library, but they have differences in their operation and purpose
zstd is the basic implementation of Zstandard that runs on a single thread, while zstdmt is an enhanced version that takes advantage of multi-threaded processing capability to achieve higher performance on multiprocessor systems. 
To install zstdmt directly into Python without using the console, you can use the zstandard library which provides an interface to work with the Zstandard compression algorithm (including zstdmt). 

however, zstandard is already installed in the requirements.txt
And the error still persists.
An alternative is to install zstd which is a specific version of Zstandard, whose latest version is v1.5.5.1 (according to its [official page](https://github.com/facebook/zstd/wiki) )

Adding zstd==1.5.5.1 to the requirements.txt fixes bug #3708

To run the requirements.txt it was necessary to upgrade the version of numpy, which is why that change also appears. However, there is already a PR with that change, that's why I didn't upload it.
There is also a change in the order, moving the amqp from the beginning of the file to the last line, this is due to a pre-commit correction, since it did not allow me to commit without that change.

