### PR TITLE
Fixed pandas 2.1.1 dependency issue with numpy >= 1.23.21

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ matplotlib==3.8.0
 mercurial==6.5.2
 microannotate==0.0.24
 mozci==2.3.4
-numpy==1.22.4
+numpy==1.23.2 #numpy==1.22.4 had a conflict with pandas==2.1.1 (python 3.11) requiring numpy >= 1.23.2
 orjson==3.9.9
 ortools==9.7.2996
 pandas==2.1.1


### PR DESCRIPTION
numpy==1.22.4 had a conflict with pandas==2.1.1 (python 3.11) requiring numpy >= 1.23.2.

So, updated the numpy version to 1.23.2 in the requirements.txt after which the installation worked fine.