### PR TITLE
Revert "Bump pandas from 2.1.0 to 2.1.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ mozci==2.3.4
 numpy==1.22.4
 orjson==3.9.9
 ortools==9.7.2996
-pandas==2.1.1
+pandas==2.1.0
 psutil==5.9.6
 pydriller==1.12
 pyOpenSSL>=0.14  # Could not find a version that satisfies the requirement pyOpenSSL>=0.14; extra == "security" (from requests[security]>=2.7.0->libmozdata==0.1.43)


### PR DESCRIPTION
This reverts commit 31b45c90fc070280945e637f074559900874777c. Regressed by #3672.

When depending on pandas v2.1.1, it requires a newer version of `numpy` on Python 11+[^1], which causes a dependency conflict[^2]. 




[^1]: https://github.com/pandas-dev/pandas/blob/v2.1.1/pyproject.toml#L32-L34
[^2]: https://github.com/mozilla/bugbug/pull/3752#issuecomment-1776315221
