### PR TITLE
[regressionrange] Use `regressed_by` instead of `cf_has_regression_range`

### DIFF
--- a/bugbug/models/regressionrange.py
+++ b/bugbug/models/regressionrange.py
@@ -75,12 +75,6 @@ class RegressionRangeModel(BugModel):
             bug_id = int(bug_data["id"])
             if "regressionwindow-wanted" in bug_data["keywords"]:
                 classes[bug_id] = 0
-            elif "cf_has_regression_range" in bug_data:
-                if bug_data["cf_has_regression_range"] == "yes":
-                    classes[bug_id] = 1
-                elif bug_data["cf_has_regression_range"] == "no":
-                    classes[bug_id] = 0
-            # Check the regressed_by field
             elif "regressed_by" in bug_data and bug_data["regressed_by"]:
                 classes[bug_id] = 1
             else:

--- a/bugbug/models/regressionrange.py
+++ b/bugbug/models/regressionrange.py
@@ -73,8 +73,9 @@ class RegressionRangeModel(BugModel):
                 continue
 
             bug_id = int(bug_data["id"])
-            if "regressionwindow-wanted" in bug_data["keywords"] or (
-                "regressed_by" in bug_data and bug_data["regressed_by"]
+            if (
+                bug_data.get("regressed_by")
+                or "regressionwindow-wanted" in bug_data["keywords"]
             ):
                 classes[bug_id] = 1
             else:

--- a/bugbug/models/regressionrange.py
+++ b/bugbug/models/regressionrange.py
@@ -73,12 +73,13 @@ class RegressionRangeModel(BugModel):
                 continue
 
             bug_id = int(bug_data["id"])
-            if "regressionwindow-wanted" in bug_data["keywords"]:
-                classes[bug_id] = 1
-            elif "regressed_by" in bug_data and bug_data["regressed_by"]:
+            if "regressionwindow-wanted" in bug_data["keywords"] or (
+                "regressed_by" in bug_data and bug_data["regressed_by"]
+            ):
                 classes[bug_id] = 1
             else:
                 classes[bug_id] = 0
+
         logger.info(
             "%d bugs have regression range",
             sum(1 for label in classes.values() if label == 1),

--- a/bugbug/models/regressionrange.py
+++ b/bugbug/models/regressionrange.py
@@ -74,7 +74,7 @@ class RegressionRangeModel(BugModel):
 
             bug_id = int(bug_data["id"])
             if "regressionwindow-wanted" in bug_data["keywords"]:
-                classes[bug_id] = 0
+                classes[bug_id] = 1
             elif "regressed_by" in bug_data and bug_data["regressed_by"]:
                 classes[bug_id] = 1
             else:

--- a/bugbug/models/regressionrange.py
+++ b/bugbug/models/regressionrange.py
@@ -80,6 +80,11 @@ class RegressionRangeModel(BugModel):
                     classes[bug_id] = 1
                 elif bug_data["cf_has_regression_range"] == "no":
                     classes[bug_id] = 0
+            # Check the regressed_by field
+            elif "regressed_by" in bug_data and bug_data["regressed_by"]:
+                classes[bug_id] = 1
+            else:
+                classes[bug_id] = 0
         logger.info(
             "%d bugs have regression range",
             sum(1 for label in classes.values() if label == 1),

--- a/test_suite_analysis/metadata.json
+++ b/test_suite_analysis/metadata.json
@@ -1,1 +1,0 @@
-{ "current_schema_version": "0.0.1" }

--- a/test_suite_analysis/metadata.json
+++ b/test_suite_analysis/metadata.json
@@ -1,0 +1,1 @@
+{ "current_schema_version": "0.0.1" }


### PR DESCRIPTION
the "regressed_by" field is now being used as a factor in the categorization of regression ranges
 Fixes: #3759 

Train on Taskcluster: regressionrange