### PR TITLE
Deleted "bug_features.severity()" from component.py

### DIFF
--- a/bugbug/models/component.py
+++ b/bugbug/models/component.py
@@ -72,7 +72,6 @@ class ComponentModel(BugModel):
 
         feature_extractors = [
             bug_features.has_str(),
-            bug_features.severity(),
             bug_features.keywords(),
             bug_features.is_coverity_issue(),
             bug_features.has_crash_signature(),


### PR DESCRIPTION
From "Test if any features in the component model can be removed without impacting performance https://github.com/mozilla/bugbug/issues/3677" issue, component model had the best performance when "bug_features.severity()" feature was removed from "component.py". 