### PR TITLE
Reduce `maxRunTime` to 45mins for Regression model when training on TaskCluster

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -220,7 +220,7 @@ tasks:
           provisionerId: proj-bugbug
           workerType: compute-large
           payload:
-            maxRunTime: 10800
+            maxRunTime: 2700
             image:
               type: task-image
               path: public/bugbug/bugbug-base.tar.zst

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -220,7 +220,10 @@ tasks:
           provisionerId: proj-bugbug
           workerType: compute-large
           payload:
-            maxRunTime: 2700
+            maxRunTime:
+              $switch:
+                '"Train on Taskcluster: regression" in pr_description': 2700
+                $default: 10800
             image:
               type: task-image
               path: public/bugbug/bugbug-base.tar.zst


### PR DESCRIPTION
**Issue:**
Closes #3809 

**Comments:**
This reduces the maximum time to 45 minutes (2700 seconds) when training the regression model in the train on TC task.