### PR TITLE
Include documentation on how to use training on Taskcluster in a Pull Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,23 @@ To use a model to classify a given bug, you can run `python -m scripts.bug_class
 
 **testing** To use the model to classify a given bug, you can run `python -m scripts.bug_classifier defect --bug-id ID_OF_A_BUG_FROM_BUGZILLA`.
 
+### Training using Taskcluster (Mozilla's resources)
+
+In some situations, it is necessary to test and train a model on bigger resources (using Taskcluster), this is currently only supported in Github Pull requests. To do this, simply include the model's name after the keyword **Train on Taskcluster:** in the Pull request's description.
+
+## Example with the `spambug` model
+
+The following statement would need to be included somewhere in the Pull request description, ideally at the bottom:
+
+```
+Train on Taskcluster: spambug
+```
+
+There are a few things to consider when training a model on Taskcluster on a GitHub Pull Request:
+
+- The training task will be re-run every time you push to the branch linked to the Pull Request. It is wise to limit the number of times you push to avoid unnecessary training and wastage of resources.
+- Currently, the training task extracts only the model's name and does not consider arguments.
+
 ### Running the repository mining script
 
 Note: This section is only necessary if you want to perform changes to the repository mining script. Otherwise, you can simply use the commits data we generate automatically.


### PR DESCRIPTION
Fixes:
#3843 

Comments:
This PR includes documentation on how to train a model on Taskcluster in a Github Pull Request. It also includes a few considerations for anyone who may want to invoke this later in a PR.