### PR TITLE
Refactor the pipelines to avoid fitting before splitting

### DIFF
--- a/bugbug/model.py
+++ b/bugbug/model.py
@@ -348,7 +348,7 @@ class Model:
         X_gen, y = split_tuple_generator(lambda: self.items_gen(classes))
 
         # Extract features from the items.
-        X = self.extraction_pipeline.fit_transform(X_gen)
+        X = self.extraction_pipeline.transform(X_gen)
 
         # Calculate labels.
         y = np.array(y)

--- a/bugbug/model.py
+++ b/bugbug/model.py
@@ -194,6 +194,8 @@ class Model:
                 feature_name = f"Comments contain '{feature_name}'"
             elif type_ == "text":
                 feature_name = f"Combined text contains '{feature_name}'"
+            elif type_ == "files":
+                feature_name = f"File '{feature_name}'"
             elif type_ not in ("data", "couple_data"):
                 raise ValueError(f"Unexpected feature type for: {full_feature_name}")
 

--- a/bugbug/model.py
+++ b/bugbug/model.py
@@ -393,6 +393,7 @@ class Model:
         logger.info(f"X_test: {X_test.shape}, y_test: {y_test.shape}")
 
         self.clf.fit(X_train, self.le.transform(y_train))
+        logger.info("Number of features: %d", self.clf.steps[-1][1].n_features_in_)
 
         logger.info("Model trained")
 

--- a/bugbug/models/annotate_ignore.py
+++ b/bugbug/models/annotate_ignore.py
@@ -6,6 +6,7 @@
 import logging
 
 import xgboost
+from imblearn.pipeline import Pipeline as ImblearnPipeline
 from imblearn.under_sampling import RandomUnderSampler
 from sklearn.compose import ColumnTransformer
 from sklearn.feature_extraction import DictVectorizer
@@ -25,8 +26,6 @@ class AnnotateIgnoreModel(CommitModel):
         self.calculate_importance = False
 
         self.training_dbs += [bugzilla.BUGS_DB]
-
-        self.sampler = RandomUnderSampler(random_state=0)
 
         feature_extractors = [
             commit_features.SourceCodeFileSize(),
@@ -71,7 +70,7 @@ class AnnotateIgnoreModel(CommitModel):
         )
 
         self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = Pipeline(
+        self.clf = ImblearnPipeline(
             [
                 (
                     "union",
@@ -82,6 +81,7 @@ class AnnotateIgnoreModel(CommitModel):
                         ]
                     ),
                 ),
+                ("sampler", RandomUnderSampler(random_state=0)),
                 (
                     "estimator",
                     xgboost.XGBClassifier(**self.hyperparameter),

--- a/bugbug/models/annotate_ignore.py
+++ b/bugbug/models/annotate_ignore.py
@@ -10,6 +10,7 @@ from imblearn.pipeline import Pipeline as ImblearnPipeline
 from imblearn.under_sampling import RandomUnderSampler
 from sklearn.compose import ColumnTransformer
 from sklearn.feature_extraction import DictVectorizer
+from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.pipeline import Pipeline
 
 from bugbug import bugzilla, commit_features, feature_cleanup, labels, repository, utils
@@ -24,6 +25,7 @@ class AnnotateIgnoreModel(CommitModel):
         CommitModel.__init__(self, lemmatization)
 
         self.calculate_importance = False
+        self.cross_validation_enabled = False
 
         self.training_dbs += [bugzilla.BUGS_DB]
 
@@ -78,6 +80,15 @@ class AnnotateIgnoreModel(CommitModel):
                         [
                             ("data", DictVectorizer(), "data"),
                             ("desc", self.text_vectorizer(min_df=0.0001), "desc"),
+                            (
+                                "files",
+                                CountVectorizer(
+                                    analyzer=utils.keep_as_is,
+                                    lowercase=False,
+                                    min_df=0.0014,
+                                ),
+                                "files",
+                            ),
                         ]
                     ),
                 ),

--- a/bugbug/models/annotate_ignore.py
+++ b/bugbug/models/annotate_ignore.py
@@ -67,6 +67,12 @@ class AnnotateIgnoreModel(CommitModel):
                         feature_extractors, cleanup_functions
                     ),
                 ),
+            ]
+        )
+
+        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
+        self.clf = Pipeline(
+            [
                 (
                     "union",
                     ColumnTransformer(
@@ -76,11 +82,12 @@ class AnnotateIgnoreModel(CommitModel):
                         ]
                     ),
                 ),
+                (
+                    "estimator",
+                    xgboost.XGBClassifier(**self.hyperparameter),
+                ),
             ]
         )
-
-        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = xgboost.XGBClassifier(**self.hyperparameter)
 
     def get_labels(self):
         classes = {}
@@ -123,4 +130,4 @@ class AnnotateIgnoreModel(CommitModel):
         return classes, [0, 1]
 
     def get_feature_names(self):
-        return self.extraction_pipeline.named_steps["union"].get_feature_names_out()
+        return self.clf.named_steps["union"].get_feature_names_out()

--- a/bugbug/models/backout.py
+++ b/bugbug/models/backout.py
@@ -9,6 +9,7 @@ from datetime import datetime
 import dateutil.parser
 import xgboost
 from dateutil.relativedelta import relativedelta
+from imblearn.pipeline import Pipeline as ImblearnPipeline
 from imblearn.under_sampling import RandomUnderSampler
 from sklearn.compose import ColumnTransformer
 from sklearn.feature_extraction import DictVectorizer
@@ -26,8 +27,6 @@ class BackoutModel(CommitModel):
         CommitModel.__init__(self, lemmatization, bug_data)
 
         self.calculate_importance = False
-
-        self.sampler = RandomUnderSampler(random_state=0)
 
         feature_extractors = [
             commit_features.SourceCodeFilesModifiedNum(),
@@ -74,7 +73,7 @@ class BackoutModel(CommitModel):
             feature_cleanup.synonyms(),
         ]
 
-        self.extraction_pipeline = Pipeline(
+        self.extraction_pipeline = ImblearnPipeline(
             [
                 (
                     "commit_extractor",
@@ -97,6 +96,7 @@ class BackoutModel(CommitModel):
                         ]
                     ),
                 ),
+                ("sampler", RandomUnderSampler(random_state=0)),
                 (
                     "estimator",
                     xgboost.XGBClassifier(**self.hyperparameter),

--- a/bugbug/models/backout.py
+++ b/bugbug/models/backout.py
@@ -13,6 +13,7 @@ from imblearn.pipeline import Pipeline as ImblearnPipeline
 from imblearn.under_sampling import RandomUnderSampler
 from sklearn.compose import ColumnTransformer
 from sklearn.feature_extraction import DictVectorizer
+from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.pipeline import Pipeline
 
 from bugbug import bug_features, commit_features, feature_cleanup, repository, utils
@@ -93,6 +94,15 @@ class BackoutModel(CommitModel):
                         [
                             ("data", DictVectorizer(), "data"),
                             ("desc", self.text_vectorizer(), "desc"),
+                            (
+                                "files",
+                                CountVectorizer(
+                                    analyzer=utils.keep_as_is,
+                                    lowercase=False,
+                                    min_df=0.0014,
+                                ),
+                                "files",
+                            ),
                         ]
                     ),
                 ),

--- a/bugbug/models/backout.py
+++ b/bugbug/models/backout.py
@@ -82,6 +82,12 @@ class BackoutModel(CommitModel):
                         feature_extractors, cleanup_functions
                     ),
                 ),
+            ]
+        )
+
+        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
+        self.clf = Pipeline(
+            [
                 (
                     "union",
                     ColumnTransformer(
@@ -91,11 +97,12 @@ class BackoutModel(CommitModel):
                         ]
                     ),
                 ),
+                (
+                    "estimator",
+                    xgboost.XGBClassifier(**self.hyperparameter),
+                ),
             ]
         )
-
-        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = xgboost.XGBClassifier(**self.hyperparameter)
 
     def get_labels(self):
         classes = {}
@@ -123,4 +130,4 @@ class BackoutModel(CommitModel):
         return classes, [0, 1]
 
     def get_feature_names(self):
-        return self.extraction_pipeline.named_steps["union"].get_feature_names_out()
+        return self.clf.named_steps["union"].get_feature_names_out()

--- a/bugbug/models/browsername.py
+++ b/bugbug/models/browsername.py
@@ -38,6 +38,12 @@ class BrowserNameModel(IssueModel):
                         feature_extractors, cleanup_functions
                     ),
                 ),
+            ]
+        )
+
+        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
+        self.clf = Pipeline(
+            [
                 (
                     "union",
                     ColumnTransformer(
@@ -52,11 +58,12 @@ class BrowserNameModel(IssueModel):
                         ]
                     ),
                 ),
+                (
+                    "estimator",
+                    xgboost.XGBClassifier(**self.hyperparameter),
+                ),
             ]
         )
-
-        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = xgboost.XGBClassifier(**self.hyperparameter)
 
     def get_labels(self):
         classes = {}
@@ -81,4 +88,4 @@ class BrowserNameModel(IssueModel):
         return classes, [0, 1]
 
     def get_feature_names(self):
-        return self.extraction_pipeline.named_steps["union"].get_feature_names_out()
+        return self.clf.named_steps["union"].get_feature_names_out()

--- a/bugbug/models/component.py
+++ b/bugbug/models/component.py
@@ -97,6 +97,12 @@ class ComponentModel(BugModel):
                         feature_extractors, cleanup_functions, rollback=True
                     ),
                 ),
+            ]
+        )
+
+        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
+        self.clf = Pipeline(
+            [
                 (
                     "union",
                     ColumnTransformer(
@@ -111,11 +117,12 @@ class ComponentModel(BugModel):
                         ]
                     ),
                 ),
+                (
+                    "estimator",
+                    xgboost.XGBClassifier(**self.hyperparameter),
+                ),
             ]
         )
-
-        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = xgboost.XGBClassifier(**self.hyperparameter)
 
         self.CONFLATED_COMPONENTS_INVERSE_MAPPING = {
             v: k for k, v in self.CONFLATED_COMPONENTS_MAPPING.items()
@@ -231,7 +238,7 @@ class ComponentModel(BugModel):
         )
 
     def get_feature_names(self):
-        return self.extraction_pipeline.named_steps["union"].get_feature_names_out()
+        return self.clf.named_steps["union"].get_feature_names_out()
 
     def check(self):
         success = super().check()

--- a/bugbug/models/defect.py
+++ b/bugbug/models/defect.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import xgboost
 from imblearn.over_sampling import BorderlineSMOTE
+from imblearn.pipeline import Pipeline as ImblearnPipeline
 from sklearn.compose import ColumnTransformer
 from sklearn.feature_extraction import DictVectorizer
 from sklearn.pipeline import Pipeline
@@ -23,8 +24,6 @@ logger = logging.getLogger(__name__)
 class DefectModel(BugModel):
     def __init__(self, lemmatization=False, historical=False):
         BugModel.__init__(self, lemmatization)
-
-        self.sampler = BorderlineSMOTE(random_state=0)
 
         feature_extractors = [
             bug_features.HasSTR(),
@@ -68,7 +67,7 @@ class DefectModel(BugModel):
         )
 
         self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = Pipeline(
+        self.clf = ImblearnPipeline(
             [
                 (
                     "union",
@@ -89,6 +88,7 @@ class DefectModel(BugModel):
                         ]
                     ),
                 ),
+                ("sampler", BorderlineSMOTE(random_state=0)),
                 (
                     "estimator",
                     xgboost.XGBClassifier(**self.hyperparameter),

--- a/bugbug/models/devdocneeded.py
+++ b/bugbug/models/devdocneeded.py
@@ -59,6 +59,12 @@ class DevDocNeededModel(BugModel):
                         commit_data=True,
                     ),
                 ),
+            ]
+        )
+
+        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
+        self.clf = Pipeline(
+            [
                 (
                     "union",
                     ColumnTransformer(
@@ -69,11 +75,12 @@ class DevDocNeededModel(BugModel):
                         ]
                     ),
                 ),
+                (
+                    "estimator",
+                    xgboost.XGBClassifier(**self.hyperparameter),
+                ),
             ]
         )
-
-        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = xgboost.XGBClassifier(**self.hyperparameter)
 
     def rollback(self, change):
         return change["field_name"] == "keywords" and any(
@@ -121,4 +128,4 @@ class DevDocNeededModel(BugModel):
         return classes, [0, 1]
 
     def get_feature_names(self):
-        return self.extraction_pipeline.named_steps["union"].get_feature_names_out()
+        return self.clf.named_steps["union"].get_feature_names_out()

--- a/bugbug/models/devdocneeded.py
+++ b/bugbug/models/devdocneeded.py
@@ -4,6 +4,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import xgboost
+from imblearn.pipeline import Pipeline as ImblearnPipeline
 from imblearn.under_sampling import RandomUnderSampler
 from sklearn.compose import ColumnTransformer
 from sklearn.feature_extraction import DictVectorizer
@@ -18,8 +19,6 @@ class DevDocNeededModel(BugModel):
         BugModel.__init__(self, lemmatization, commit_data=True)
 
         self.cross_validation_enabled = False
-
-        self.sampler = RandomUnderSampler(random_state=0)
 
         feature_extractors = [
             bug_features.HasSTR(),
@@ -63,7 +62,7 @@ class DevDocNeededModel(BugModel):
         )
 
         self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = Pipeline(
+        self.clf = ImblearnPipeline(
             [
                 (
                     "union",
@@ -75,6 +74,7 @@ class DevDocNeededModel(BugModel):
                         ]
                     ),
                 ),
+                ("sampler", RandomUnderSampler(random_state=0)),
                 (
                     "estimator",
                     xgboost.XGBClassifier(**self.hyperparameter),

--- a/bugbug/models/fixtime.py
+++ b/bugbug/models/fixtime.py
@@ -54,6 +54,12 @@ class FixTimeModel(BugModel):
                         feature_extractors, cleanup_functions, rollback=True
                     ),
                 ),
+            ]
+        )
+
+        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
+        self.clf = Pipeline(
+            [
                 (
                     "union",
                     ColumnTransformer(
@@ -68,11 +74,12 @@ class FixTimeModel(BugModel):
                         ]
                     ),
                 ),
+                (
+                    "estimator",
+                    xgboost.XGBClassifier(**self.hyperparameter),
+                ),
             ]
         )
-
-        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = xgboost.XGBClassifier(**self.hyperparameter)
 
     def get_labels(self):
         bug_fix_times = []
@@ -118,4 +125,4 @@ class FixTimeModel(BugModel):
         return classes, list(range(len(quantiles) + 1))
 
     def get_feature_names(self):
-        return self.extraction_pipeline.named_steps["union"].get_feature_names_out()
+        return self.clf.named_steps["union"].get_feature_names_out()

--- a/bugbug/models/invalid_compatibility_report.py
+++ b/bugbug/models/invalid_compatibility_report.py
@@ -35,6 +35,12 @@ class InvalidCompatibilityReportModel(IssueModel):
                         feature_extractors, cleanup_functions, rollback=False
                     ),
                 ),
+            ]
+        )
+
+        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
+        self.clf = Pipeline(
+            [
                 (
                     "union",
                     ColumnTransformer(
@@ -47,11 +53,12 @@ class InvalidCompatibilityReportModel(IssueModel):
                         ]
                     ),
                 ),
+                (
+                    "estimator",
+                    xgboost.XGBClassifier(**self.hyperparameter),
+                ),
             ]
         )
-
-        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = xgboost.XGBClassifier(**self.hyperparameter)
 
     def items_gen(self, classes):
         # Do cleanup separately from extraction pipeline to
@@ -103,4 +110,4 @@ class InvalidCompatibilityReportModel(IssueModel):
         return classes, [0, 1]
 
     def get_feature_names(self):
-        return self.extraction_pipeline.named_steps["union"].get_feature_names_out()
+        return self.clf.named_steps["union"].get_feature_names_out()

--- a/bugbug/models/needsdiagnosis.py
+++ b/bugbug/models/needsdiagnosis.py
@@ -39,6 +39,12 @@ class NeedsDiagnosisModel(IssueModel):
                         feature_extractors, cleanup_functions, rollback=True
                     ),
                 ),
+            ]
+        )
+
+        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
+        self.clf = Pipeline(
+            [
                 (
                     "union",
                     ColumnTransformer(
@@ -52,11 +58,12 @@ class NeedsDiagnosisModel(IssueModel):
                         ]
                     ),
                 ),
+                (
+                    "estimator",
+                    xgboost.XGBClassifier(**self.hyperparameter),
+                ),
             ]
         )
-
-        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = xgboost.XGBClassifier(**self.hyperparameter)
 
     def get_labels(self):
         classes = {}
@@ -92,4 +99,4 @@ class NeedsDiagnosisModel(IssueModel):
         return classes, [0, 1]
 
     def get_feature_names(self):
-        return self.extraction_pipeline.named_steps["union"].get_feature_names_out()
+        return self.clf.named_steps["union"].get_feature_names_out()

--- a/bugbug/models/qaneeded.py
+++ b/bugbug/models/qaneeded.py
@@ -4,6 +4,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import xgboost
+from imblearn.pipeline import Pipeline as ImblearnPipeline
 from imblearn.under_sampling import RandomUnderSampler
 from sklearn.compose import ColumnTransformer
 from sklearn.feature_extraction import DictVectorizer
@@ -16,8 +17,6 @@ from bugbug.model import BugModel
 class QANeededModel(BugModel):
     def __init__(self, lemmatization=False):
         BugModel.__init__(self, lemmatization)
-
-        self.sampler = RandomUnderSampler(random_state=0)
 
         feature_extractors = [
             bug_features.HasSTR(),
@@ -55,7 +54,7 @@ class QANeededModel(BugModel):
         )
 
         self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = Pipeline(
+        self.clf = ImblearnPipeline(
             [
                 (
                     "union",
@@ -67,6 +66,7 @@ class QANeededModel(BugModel):
                         ]
                     ),
                 ),
+                ("sampler", RandomUnderSampler(random_state=0)),
                 (
                     "estimator",
                     xgboost.XGBClassifier(**self.hyperparameter),

--- a/bugbug/models/qaneeded.py
+++ b/bugbug/models/qaneeded.py
@@ -51,6 +51,12 @@ class QANeededModel(BugModel):
                         rollback_when=self.rollback,
                     ),
                 ),
+            ]
+        )
+
+        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
+        self.clf = Pipeline(
+            [
                 (
                     "union",
                     ColumnTransformer(
@@ -61,11 +67,12 @@ class QANeededModel(BugModel):
                         ]
                     ),
                 ),
+                (
+                    "estimator",
+                    xgboost.XGBClassifier(**self.hyperparameter),
+                ),
             ]
         )
-
-        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = xgboost.XGBClassifier(**self.hyperparameter)
 
     def rollback(self, change):
         return any(
@@ -109,4 +116,4 @@ class QANeededModel(BugModel):
         return classes, [0, 1]
 
     def get_feature_names(self):
-        return self.extraction_pipeline.named_steps["union"].get_feature_names_out()
+        return self.clf.named_steps["union"].get_feature_names_out()

--- a/bugbug/models/regressionrange.py
+++ b/bugbug/models/regressionrange.py
@@ -50,6 +50,12 @@ class RegressionRangeModel(BugModel):
                     "bug_extractor",
                     bug_features.BugExtractor(feature_extractors, cleanup_functions),
                 ),
+            ]
+        )
+
+        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
+        self.clf = Pipeline(
+            [
                 (
                     "union",
                     ColumnTransformer(
@@ -60,11 +66,12 @@ class RegressionRangeModel(BugModel):
                         ]
                     ),
                 ),
+                (
+                    "estimator",
+                    xgboost.XGBClassifier(**self.hyperparameter),
+                ),
             ]
         )
-
-        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = xgboost.XGBClassifier(**self.hyperparameter)
 
     def get_labels(self):
         classes = {}
@@ -93,4 +100,4 @@ class RegressionRangeModel(BugModel):
         return classes, [0, 1]
 
     def get_feature_names(self):
-        return self.extraction_pipeline.named_steps["union"].get_feature_names_out()
+        return self.clf.named_steps["union"].get_feature_names_out()

--- a/bugbug/models/regressionrange.py
+++ b/bugbug/models/regressionrange.py
@@ -6,6 +6,7 @@
 import logging
 
 import xgboost
+from imblearn.pipeline import Pipeline as ImblearnPipeline
 from imblearn.under_sampling import RandomUnderSampler
 from sklearn.compose import ColumnTransformer
 from sklearn.feature_extraction import DictVectorizer
@@ -21,8 +22,6 @@ logger = logging.getLogger(__name__)
 class RegressionRangeModel(BugModel):
     def __init__(self, lemmatization=False):
         BugModel.__init__(self, lemmatization)
-
-        self.sampler = RandomUnderSampler(random_state=0)
 
         feature_extractors = [
             bug_features.HasSTR(),
@@ -54,7 +53,7 @@ class RegressionRangeModel(BugModel):
         )
 
         self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = Pipeline(
+        self.clf = ImblearnPipeline(
             [
                 (
                     "union",
@@ -66,6 +65,7 @@ class RegressionRangeModel(BugModel):
                         ]
                     ),
                 ),
+                ("sampler", RandomUnderSampler(random_state=0)),
                 (
                     "estimator",
                     xgboost.XGBClassifier(**self.hyperparameter),

--- a/bugbug/models/regressor.py
+++ b/bugbug/models/regressor.py
@@ -11,6 +11,7 @@ import dateutil.parser
 import numpy as np
 import xgboost
 from dateutil.relativedelta import relativedelta
+from imblearn.pipeline import Pipeline as ImblearnPipeline
 from imblearn.under_sampling import RandomUnderSampler
 from sklearn.compose import ColumnTransformer
 from sklearn.feature_extraction import DictVectorizer
@@ -66,7 +67,6 @@ class RegressorModel(CommitModel):
             self.training_dbs.append(BUG_FIXING_COMMITS_DB)
 
         self.store_dataset = True
-        self.sampler = RandomUnderSampler(random_state=0)
 
         self.use_finder = use_finder
         self.exclude_finder = exclude_finder
@@ -134,9 +134,10 @@ class RegressorModel(CommitModel):
             estimator = IsotonicRegressionCalibrator(estimator)
             # This is a temporary workaround for the error : "Model type not yet supported by TreeExplainer"
             self.calculate_importance = False
-        self.clf = Pipeline(
+        self.clf = ImblearnPipeline(
             [
                 ("union", ColumnTransformer(column_transformers)),
+                ("sampler", RandomUnderSampler(random_state=0)),
                 ("estimator", estimator),
             ]
         )

--- a/bugbug/models/regressor.py
+++ b/bugbug/models/regressor.py
@@ -15,6 +15,7 @@ from imblearn.pipeline import Pipeline as ImblearnPipeline
 from imblearn.under_sampling import RandomUnderSampler
 from sklearn.compose import ColumnTransformer
 from sklearn.feature_extraction import DictVectorizer
+from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.pipeline import Pipeline
 
 from bugbug import bugzilla, commit_features, db, feature_cleanup, repository, utils
@@ -111,7 +112,18 @@ class RegressorModel(CommitModel):
             feature_cleanup.synonyms(),
         ]
 
-        column_transformers = [("data", DictVectorizer(), "data")]
+        column_transformers = [
+            ("data", DictVectorizer(), "data"),
+            (
+                "files",
+                CountVectorizer(
+                    analyzer=utils.keep_as_is,
+                    lowercase=False,
+                    min_df=0.0014,
+                ),
+                "files",
+            ),
+        ]
 
         if not interpretable:
             column_transformers.append(

--- a/bugbug/models/spambug.py
+++ b/bugbug/models/spambug.py
@@ -7,6 +7,7 @@ import logging
 
 import xgboost
 from imblearn.over_sampling import BorderlineSMOTE
+from imblearn.pipeline import Pipeline as ImblearnPipeline
 from sklearn.compose import ColumnTransformer
 from sklearn.feature_extraction import DictVectorizer
 from sklearn.pipeline import Pipeline
@@ -22,7 +23,6 @@ class SpamBugModel(BugModel):
     def __init__(self, lemmatization=False):
         BugModel.__init__(self, lemmatization)
 
-        self.sampler = BorderlineSMOTE(random_state=0)
         self.calculate_importance = False
 
         feature_extractors = [
@@ -67,7 +67,7 @@ class SpamBugModel(BugModel):
         )
 
         self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = Pipeline(
+        self.clf = ImblearnPipeline(
             [
                 (
                     "union",
@@ -83,6 +83,7 @@ class SpamBugModel(BugModel):
                         ]
                     ),
                 ),
+                ("sampler", BorderlineSMOTE(random_state=0)),
                 (
                     "estimator",
                     xgboost.XGBClassifier(**self.hyperparameter),

--- a/bugbug/models/spambug.py
+++ b/bugbug/models/spambug.py
@@ -63,6 +63,12 @@ class SpamBugModel(BugModel):
                         feature_extractors, cleanup_functions, rollback=True
                     ),
                 ),
+            ]
+        )
+
+        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
+        self.clf = Pipeline(
+            [
                 (
                     "union",
                     ColumnTransformer(
@@ -77,11 +83,12 @@ class SpamBugModel(BugModel):
                         ]
                     ),
                 ),
+                (
+                    "estimator",
+                    xgboost.XGBClassifier(**self.hyperparameter),
+                ),
             ]
         )
-
-        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = xgboost.XGBClassifier(**self.hyperparameter)
 
     def get_labels(self):
         classes = {}
@@ -131,7 +138,7 @@ class SpamBugModel(BugModel):
         )
 
     def get_feature_names(self):
-        return self.extraction_pipeline.named_steps["union"].get_feature_names_out()
+        return self.clf.named_steps["union"].get_feature_names_out()
 
     def overwrite_classes(self, bugs, classes, probabilities):
         for i, bug in enumerate(bugs):

--- a/bugbug/models/stepstoreproduce.py
+++ b/bugbug/models/stepstoreproduce.py
@@ -50,6 +50,12 @@ class StepsToReproduceModel(BugModel):
                     "bug_extractor",
                     bug_features.BugExtractor(feature_extractors, cleanup_functions),
                 ),
+            ]
+        )
+
+        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
+        self.clf = Pipeline(
+            [
                 (
                     "union",
                     ColumnTransformer(
@@ -60,11 +66,12 @@ class StepsToReproduceModel(BugModel):
                         ]
                     ),
                 ),
+                (
+                    "estimator",
+                    xgboost.XGBClassifier(**self.hyperparameter),
+                ),
             ]
         )
-
-        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = xgboost.XGBClassifier(**self.hyperparameter)
 
     def get_labels(self):
         classes = {}
@@ -106,4 +113,4 @@ class StepsToReproduceModel(BugModel):
         return classes
 
     def get_feature_names(self):
-        return self.extraction_pipeline.named_steps["union"].get_feature_names_out()
+        return self.clf.named_steps["union"].get_feature_names_out()

--- a/bugbug/models/stepstoreproduce.py
+++ b/bugbug/models/stepstoreproduce.py
@@ -6,6 +6,7 @@
 import logging
 
 import xgboost
+from imblearn.pipeline import Pipeline as ImblearnPipeline
 from imblearn.under_sampling import RandomUnderSampler
 from sklearn.compose import ColumnTransformer
 from sklearn.feature_extraction import DictVectorizer
@@ -21,8 +22,6 @@ logger = logging.getLogger(__name__)
 class StepsToReproduceModel(BugModel):
     def __init__(self, lemmatization=False):
         BugModel.__init__(self, lemmatization)
-
-        self.sampler = RandomUnderSampler(random_state=0)
 
         feature_extractors = [
             bug_features.HasRegressionRange(),
@@ -54,7 +53,7 @@ class StepsToReproduceModel(BugModel):
         )
 
         self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = Pipeline(
+        self.clf = ImblearnPipeline(
             [
                 (
                     "union",
@@ -66,6 +65,7 @@ class StepsToReproduceModel(BugModel):
                         ]
                     ),
                 ),
+                ("sampler", RandomUnderSampler(random_state=0)),
                 (
                     "estimator",
                     xgboost.XGBClassifier(**self.hyperparameter),

--- a/bugbug/models/testfailure.py
+++ b/bugbug/models/testfailure.py
@@ -10,6 +10,7 @@ from imblearn.pipeline import Pipeline as ImblearnPipeline
 from imblearn.under_sampling import RandomUnderSampler
 from sklearn.compose import ColumnTransformer
 from sklearn.feature_extraction import DictVectorizer
+from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.pipeline import Pipeline
 
 from bugbug import commit_features, repository, test_scheduling, utils
@@ -64,7 +65,23 @@ class TestFailureModel(CommitModel):
         self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
         self.clf = ImblearnPipeline(
             [
-                ("union", ColumnTransformer([("data", DictVectorizer(), "data")])),
+                (
+                    "union",
+                    ColumnTransformer(
+                        [
+                            ("data", DictVectorizer(), "data"),
+                            (
+                                "files",
+                                CountVectorizer(
+                                    analyzer=utils.keep_as_is,
+                                    lowercase=False,
+                                    min_df=0.0014,
+                                ),
+                                "files",
+                            ),
+                        ]
+                    ),
+                ),
                 ("sampler", RandomUnderSampler(random_state=0)),
                 (
                     "estimator",

--- a/bugbug/models/testfailure.py
+++ b/bugbug/models/testfailure.py
@@ -6,6 +6,7 @@
 import logging
 
 import xgboost
+from imblearn.pipeline import Pipeline as ImblearnPipeline
 from imblearn.under_sampling import RandomUnderSampler
 from sklearn.compose import ColumnTransformer
 from sklearn.feature_extraction import DictVectorizer
@@ -23,8 +24,6 @@ class TestFailureModel(CommitModel):
         CommitModel.__init__(self, lemmatization)
 
         self.training_dbs.append(test_scheduling.TEST_LABEL_SCHEDULING_DB)
-
-        self.sampler = RandomUnderSampler(random_state=0)
 
         feature_extractors = [
             commit_features.SourceCodeFileSize(),
@@ -63,9 +62,10 @@ class TestFailureModel(CommitModel):
         )
 
         self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = Pipeline(
+        self.clf = ImblearnPipeline(
             [
                 ("union", ColumnTransformer([("data", DictVectorizer(), "data")])),
+                ("sampler", RandomUnderSampler(random_state=0)),
                 (
                     "estimator",
                     xgboost.XGBClassifier(**self.hyperparameter),

--- a/bugbug/models/testfailure.py
+++ b/bugbug/models/testfailure.py
@@ -59,12 +59,19 @@ class TestFailureModel(CommitModel):
                     "commit_extractor",
                     commit_features.CommitExtractor(feature_extractors, []),
                 ),
-                ("union", ColumnTransformer([("data", DictVectorizer(), "data")])),
             ]
         )
 
         self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = xgboost.XGBClassifier(**self.hyperparameter)
+        self.clf = Pipeline(
+            [
+                ("union", ColumnTransformer([("data", DictVectorizer(), "data")])),
+                (
+                    "estimator",
+                    xgboost.XGBClassifier(**self.hyperparameter),
+                ),
+            ]
+        )
 
     def items_gen(self, classes):
         commit_map = {}
@@ -110,4 +117,4 @@ class TestFailureModel(CommitModel):
         return classes, [0, 1]
 
     def get_feature_names(self):
-        return self.extraction_pipeline.named_steps["union"].get_feature_names_out()
+        return self.clf.named_steps["union"].get_feature_names_out()

--- a/bugbug/models/testselect.py
+++ b/bugbug/models/testselect.py
@@ -448,12 +448,19 @@ class TestSelectModel(Model):
                     "commit_extractor",
                     commit_features.CommitExtractor(feature_extractors, []),
                 ),
-                ("union", ColumnTransformer([("data", DictVectorizer(), "data")])),
             ]
         )
 
         self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = xgboost.XGBClassifier(**self.hyperparameter)
+        self.clf = Pipeline(
+            [
+                ("union", ColumnTransformer([("data", DictVectorizer(), "data")])),
+                (
+                    "estimator",
+                    xgboost.XGBClassifier(**self.hyperparameter),
+                ),
+            ]
+        )
 
     def get_pushes(
         self, apply_filters: bool = False
@@ -859,7 +866,7 @@ class TestSelectModel(Model):
                     do_eval(executor, confidence_threshold, reduction, cap, minimum)
 
     def get_feature_names(self):
-        return self.extraction_pipeline.named_steps["union"].get_feature_names_out()
+        return self.clf.named_steps["union"].get_feature_names_out()
 
 
 class TestLabelSelectModel(TestSelectModel):

--- a/bugbug/models/testselect.py
+++ b/bugbug/models/testselect.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Collection, Iterable, Optional, Sequence, Set
 
 import numpy as np
 import xgboost
+from imblearn.pipeline import Pipeline as ImblearnPipeline
 from imblearn.under_sampling import RandomUnderSampler
 from ortools.linear_solver import pywraplp
 from sklearn.compose import ColumnTransformer
@@ -423,8 +424,6 @@ class TestSelectModel(Model):
 
         self.entire_dataset_training = True
 
-        self.sampler = RandomUnderSampler(random_state=0)
-
         feature_extractors = [
             test_scheduling_features.PrevFailures(),
         ]
@@ -452,9 +451,10 @@ class TestSelectModel(Model):
         )
 
         self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = Pipeline(
+        self.clf = ImblearnPipeline(
             [
                 ("union", ColumnTransformer([("data", DictVectorizer(), "data")])),
+                ("sampler", RandomUnderSampler(random_state=0)),
                 (
                     "estimator",
                     xgboost.XGBClassifier(**self.hyperparameter),

--- a/bugbug/models/tracking.py
+++ b/bugbug/models/tracking.py
@@ -4,6 +4,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import xgboost
+from imblearn.pipeline import Pipeline as ImblearnPipeline
 from imblearn.under_sampling import InstanceHardnessThreshold
 from sklearn.compose import ColumnTransformer
 from sklearn.feature_extraction import DictVectorizer
@@ -18,8 +19,6 @@ class TrackingModel(BugModel):
         BugModel.__init__(self, lemmatization)
 
         self.calculate_importance = False
-
-        self.sampler = InstanceHardnessThreshold(random_state=0)
 
         feature_extractors = [
             bug_features.HasSTR(),
@@ -71,7 +70,7 @@ class TrackingModel(BugModel):
         )
 
         self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = Pipeline(
+        self.clf = ImblearnPipeline(
             [
                 (
                     "union",
@@ -87,6 +86,7 @@ class TrackingModel(BugModel):
                         ]
                     ),
                 ),
+                ("sampler", InstanceHardnessThreshold(random_state=0)),
                 (
                     "estimator",
                     xgboost.XGBClassifier(**self.hyperparameter),

--- a/bugbug/models/uplift.py
+++ b/bugbug/models/uplift.py
@@ -51,6 +51,12 @@ class UpliftModel(BugModel):
                         rollback_when=self.rollback,
                     ),
                 ),
+            ]
+        )
+
+        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
+        self.clf = Pipeline(
+            [
                 (
                     "union",
                     ColumnTransformer(
@@ -61,11 +67,12 @@ class UpliftModel(BugModel):
                         ]
                     ),
                 ),
+                (
+                    "estimator",
+                    xgboost.XGBClassifier(**self.hyperparameter),
+                ),
             ]
         )
-
-        self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = xgboost.XGBClassifier(**self.hyperparameter)
 
     def rollback(self, change):
         return (
@@ -95,4 +102,4 @@ class UpliftModel(BugModel):
         return classes, [0, 1]
 
     def get_feature_names(self):
-        return self.extraction_pipeline.named_steps["union"].get_feature_names_out()
+        return self.clf.named_steps["union"].get_feature_names_out()

--- a/bugbug/models/uplift.py
+++ b/bugbug/models/uplift.py
@@ -4,6 +4,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import xgboost
+from imblearn.pipeline import Pipeline as ImblearnPipeline
 from imblearn.under_sampling import RandomUnderSampler
 from sklearn.compose import ColumnTransformer
 from sklearn.feature_extraction import DictVectorizer
@@ -16,8 +17,6 @@ from bugbug.model import BugModel
 class UpliftModel(BugModel):
     def __init__(self, lemmatization=False):
         BugModel.__init__(self, lemmatization)
-
-        self.sampler = RandomUnderSampler(random_state=0)
 
         feature_extractors = [
             bug_features.HasSTR(),
@@ -55,7 +54,7 @@ class UpliftModel(BugModel):
         )
 
         self.hyperparameter = {"n_jobs": utils.get_physical_cpu_count()}
-        self.clf = Pipeline(
+        self.clf = ImblearnPipeline(
             [
                 (
                     "union",
@@ -67,6 +66,7 @@ class UpliftModel(BugModel):
                         ]
                     ),
                 ),
+                ("sampler", RandomUnderSampler(random_state=0)),
                 (
                     "estimator",
                     xgboost.XGBClassifier(**self.hyperparameter),

--- a/bugbug/utils.py
+++ b/bugbug/utils.py
@@ -553,3 +553,8 @@ def escape_markdown(text: str) -> str:
         .replace(")", "\\)")
         .replace("|", "\\|")
     )
+
+
+def keep_as_is(x):
+    """A tokenizer that does nothing."""
+    return x


### PR DESCRIPTION
Resolves #3818 

> **Note**
> The changes will be clearer if each commit is reviewed separately

- Converted `clf` to a pipeline and moved the union step to it (the step that requires fitting)
    -  Refactored the sampler to be part of the `clf` pipeline
       - The sampler requires `X` to be vectors, not dicts
       - The model train method became cleaner
- The `Files` feature is the only feature that requires `fit()`
    - Moved the part that requires fitting to the `clf` pipeline
- Replaced `fit_transform()` with `transform()`
- Adjusted the model saving process since the xgboost model now is part of a pipeline


Train on Taskcluster: annotateignore