### PR TITLE
Support calculate feature importance on clf pipelines

### DIFF
--- a/scripts/commit_classifier.py
+++ b/scripts/commit_classifier.py
@@ -26,7 +26,7 @@ from libmozdata.phabricator import PhabricatorAPI
 from scipy.stats import spearmanr
 
 from bugbug import db, repository, test_scheduling
-from bugbug.model import Model
+from bugbug.model import Model, get_transformer_pipeline
 from bugbug.models.regressor import RegressorModel
 from bugbug.models.testfailure import TestFailureModel
 from bugbug.utils import (
@@ -402,7 +402,10 @@ class CommitClassifier(object):
             )
 
     def generate_feature_importance_data(self, probs, importance):
-        X_shap_values = shap.TreeExplainer(self.model.clf).shap_values(self.X)
+        _X = get_transformer_pipeline(self.clf).transform(self.X)
+        X_shap_values = shap.TreeExplainer(
+            self.clf.named_steps["estimator"]
+        ).shap_values(_X)
 
         pred_class = self.model.le.inverse_transform([probs[0].argmax()])[0]
 
@@ -414,8 +417,8 @@ class CommitClassifier(object):
             value = importance["importances"]["values"][0, int(feature_index)]
 
             shap.summary_plot(
-                X_shap_values[:, int(feature_index)].reshape(self.X.shape[0], 1),
-                self.X[:, int(feature_index)].reshape(self.X.shape[0], 1),
+                X_shap_values[:, int(feature_index)].reshape(_X.shape[0], 1),
+                _X[:, int(feature_index)].reshape(_X.shape[0], 1),
                 feature_names=[""],
                 plot_type="layered_violin",
                 show=False,
@@ -427,7 +430,7 @@ class CommitClassifier(object):
             img.seek(0)
             base64_img = base64.b64encode(img.read()).decode("ascii")
 
-            X = self.X[:, int(feature_index)]
+            X = _X[:, int(feature_index)]
             y = self.y[X != 0]
             X = X[X != 0]
             spearman = spearmanr(X, y)


### PR DESCRIPTION
Fixes #3880 

With this fix, the `TreeExplainer` is applied to the original dataset, not the resampled one, which is better in the context of interpretability and understanding of feature importance.

Train on Taskcluster: stepstoreproduce