### PR TITLE
Include Fenix in PRODUCTS for training `Component` Model

### DIFF
--- a/bugbug/models/component.py
+++ b/bugbug/models/component.py
@@ -27,6 +27,7 @@ class ComponentModel(BugModel):
         "Core",
         "External Software Affecting Firefox",
         "DevTools",
+        "Fenix",
         "Firefox",
         "Toolkit",
         "WebExtensions",

--- a/bugbug/models/component.py
+++ b/bugbug/models/component.py
@@ -53,6 +53,7 @@ class ComponentModel(BugModel):
         "External Software Affecting Firefox",
         "WebExtensions",
         "Firefox Build System",
+        "Fenix",
     ]
 
     CONFLATED_COMPONENTS_MAPPING = {
@@ -63,6 +64,7 @@ class ComponentModel(BugModel):
         "External Software Affecting Firefox": "External Software Affecting Firefox::Other",
         "WebExtensions": "WebExtensions::Untriaged",
         "Firefox Build System": "Firefox Build System::General",
+        "Fenix": "Fenix::General",
     }
 
     def __init__(self, lemmatization=False):


### PR DESCRIPTION
Issue:
Closes #3882 

Comments:
This PR adds the newly added Bugzilla product Fenix to the list of products whose components will be used it to train the `Component` model. (It becomes a meaningful product)

Train on Taskcluster: component