### PR TITLE
Change `workerType` used in `stepstoreproduce` training task to `compute-small`

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -218,7 +218,7 @@ tasks:
           created: { $fromNow: "" }
           deadline: { $fromNow: "1 day" }
           provisionerId: proj-bugbug
-          workerType: compute-large
+          workerType: compute-small
           payload:
             maxRunTime:
               $switch:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -218,7 +218,7 @@ tasks:
           created: { $fromNow: "" }
           deadline: { $fromNow: "1 day" }
           provisionerId: proj-bugbug
-          workerType: compute-small
+          workerType: compute-large
           payload:
             maxRunTime:
               $switch:

--- a/infra/data-pipeline.yml
+++ b/infra/data-pipeline.yml
@@ -928,7 +928,7 @@ tasks:
       deadline: { $fromNow: "3 days" }
       expires: { $fromNow: "1 year" }
       provisionerId: proj-bugbug
-      workerType: compute-smaller
+      workerType: compute-small
       dependencies:
         - bugs-retrieval
       payload:


### PR DESCRIPTION
**Issue**:
Closes #3906 

**Comments**:
This PR changes the `workerType` used in the pipeline task to train the `stepstoreproduce` model. The switch is from `compute-small` from `compute-smaller`. 