### PR TITLE
Include `n_features_in` attribute in `IsotonicRegressionCalibrator` class

### DIFF
--- a/bugbug/model_calibration.py
+++ b/bugbug/model_calibration.py
@@ -14,6 +14,7 @@ class IsotonicRegressionCalibrator(BaseEstimator, ClassifierMixin):
         self.calibrated_clf = CalibratedClassifierCV(
             base_clf, cv="prefit", method="isotonic"
         )
+        self.n_features_in_ = None
 
     def fit(self, X_train, y_train):
         X_train, X_val, y_train, y_val = train_test_split(
@@ -21,6 +22,7 @@ class IsotonicRegressionCalibrator(BaseEstimator, ClassifierMixin):
         )
         self.base_clf.fit(X_train, y_train)
         self.calibrated_clf.fit(X_val, y_val)
+        self.n_features_in_ = self.base_clf.n_features_in_
 
     def predict(self, X):
         return self.calibrated_clf.predict(X)


### PR DESCRIPTION
**Issue**:
Closes #3909

**Comments**:
This PR includes the `n_features_in_` attribute  in the IsotonicRegressionCalibrator' class. It uses the value from the fitted base classifier.

Train on Taskcluster: regressor