### PR TITLE
Include `accessibility` model in `http_service` and infra `data_pipeline`

### DIFF
--- a/http_service/bugbug_http/models.py
+++ b/http_service/bugbug_http/models.py
@@ -34,6 +34,7 @@ MODELS_NAMES = [
     "spambug",
     "testlabelselect",
     "testgroupselect",
+    "accessibility",
 ]
 
 DEFAULT_EXPIRATION_TTL = 7 * 24 * 3600  # A week

--- a/infra/data-pipeline.yml
+++ b/infra/data-pipeline.yml
@@ -1253,7 +1253,7 @@ tasks:
         - train-test-group-select
         - train-test-failure
         - train-needsdiagnosis
-        - train-accessiblity
+        - train-accessibility
       payload:
         maxRunTime: 3600
         image: mozilla/bugbug-base:${version}

--- a/infra/data-pipeline.yml
+++ b/infra/data-pipeline.yml
@@ -1003,6 +1003,44 @@ tasks:
         owner: release-mgmt-analysis@mozilla.com
         source: ${repository}/raw/master/data-pipeline.yml
 
+    - ID: train-accessibility
+      created: { $fromNow: "" }
+      deadline: { $fromNow: "3 days" }
+      expires: { $fromNow: "1 year" }
+      provisionerId: proj-bugbug
+      workerType: compute-smaller
+      dependencies:
+        - bugs-retrieval
+      payload:
+        maxRunTime: 25200
+        image: mozilla/bugbug-base:${version}
+        command:
+          - bugbug-train
+          - accessibility
+
+        artifacts:
+          public/accessibilitymodel.tar.zst:
+            expires: { $fromNow: "1 month" }
+            path: /accessibilitymodel.tar.zst
+            type: file
+          public/metrics.json:
+            expires: { $fromNow: "1 year" }
+            path: /metrics.json
+            type: file
+
+      routes:
+        - notify.email.release-mgmt-analysis@mozilla.com.on-failed
+        - notify.irc-channel.#bugbug.on-failed
+        - index.project.bugbug.train_accessibility.${version}
+        - index.project.bugbug.train_accessibility.per_version.${version}.${year}.${month}.${day}.${hour}.${minute}.${second}
+        - index.project.bugbug.train_accessibility.per_date.${year}.${month}.${day}.${hour}.${minute}.${second}.${version}
+        - index.project.bugbug.train_accessibility.latest
+      metadata:
+        name: bugbug train accessibility model
+        description: bugbug train accessibility model
+        owner: release-mgmt-analysis@mozilla.com
+        source: ${repository}/raw/master/data-pipeline.yml
+
     - ID: train-test-label-select
       created: { $fromNow: "" }
       deadline: { $fromNow: "5 days" }
@@ -1215,6 +1253,7 @@ tasks:
         - train-test-group-select
         - train-test-failure
         - train-needsdiagnosis
+        - train-accessiblity
       payload:
         maxRunTime: 3600
         image: mozilla/bugbug-base:${version}
@@ -1250,6 +1289,7 @@ tasks:
         - train-test-label-select
         - train-test-group-select
         - train-needsdiagnosis
+        - train-accessibility
       payload:
         capabilities:
           privileged: true


### PR DESCRIPTION
**Issue:**
Closes #3938

**Comments:**
This PR includes the `train-accessibility` task in the data pipeline as well the accessibility model name among the models in the `http_service`.