### PR TITLE
Use `LabelBinarizer()`  instead of  `LabelEncoder()` when encoding in `bugtype`  and `rcatype` models.

### DIFF
--- a/bugbug/model.py
+++ b/bugbug/model.py
@@ -23,7 +23,7 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics import precision_recall_fscore_support
 from sklearn.model_selection import cross_validate, train_test_split
 from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import LabelBinarizer, LabelEncoder
+from sklearn.preprocessing import LabelEncoder
 from tabulate import tabulate
 from xgboost import XGBModel
 
@@ -372,14 +372,8 @@ class Model:
         # Extract features from the items.
         X = self.extraction_pipeline.transform(X_gen)
 
-        y = np.array(y)
-
-        is_multilabel = isinstance(y[0], np.ndarray)
-        is_binary = len(self.class_names) == 2
-
         # Calculate labels.
-        if is_multilabel:
-            self.le = LabelBinarizer()
+        y = np.array(y)
         self.le.fit(y)
 
         if limit:
@@ -387,6 +381,9 @@ class Model:
             y = y[:limit]
 
         logger.info(f"X: {X.shape}, y: {y.shape}")
+
+        is_multilabel = isinstance(y[0], np.ndarray)
+        is_binary = len(self.class_names) == 2
 
         # Split dataset in training and test.
         X_train, X_test, y_train, y_test = self.train_test_split(X, y)

--- a/bugbug/model.py
+++ b/bugbug/model.py
@@ -23,7 +23,7 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics import precision_recall_fscore_support
 from sklearn.model_selection import cross_validate, train_test_split
 from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import LabelEncoder
+from sklearn.preprocessing import LabelBinarizer, LabelEncoder
 from tabulate import tabulate
 from xgboost import XGBModel
 
@@ -372,8 +372,14 @@ class Model:
         # Extract features from the items.
         X = self.extraction_pipeline.transform(X_gen)
 
-        # Calculate labels.
         y = np.array(y)
+
+        is_multilabel = isinstance(y[0], np.ndarray)
+        is_binary = len(self.class_names) == 2
+
+        # Calculate labels.
+        if is_multilabel:
+            self.le = LabelBinarizer()
         self.le.fit(y)
 
         if limit:
@@ -381,9 +387,6 @@ class Model:
             y = y[:limit]
 
         logger.info(f"X: {X.shape}, y: {y.shape}")
-
-        is_multilabel = isinstance(y[0], np.ndarray)
-        is_binary = len(self.class_names) == 2
 
         # Split dataset in training and test.
         X_train, X_test, y_train, y_test = self.train_test_split(X, y)

--- a/bugbug/model.py
+++ b/bugbug/model.py
@@ -540,7 +540,12 @@ class Model:
                     np.array(y_pred_filter[classified_indices], dtype=int)
                 )
 
-            classified_num = sum(1 for v in y_pred_filter if v != "__NOT_CLASSIFIED__")
+            if is_multilabel:
+                classified_num = len(classified_indices)
+            else:
+                classified_num = sum(
+                    1 for v in y_pred_filter if v != "__NOT_CLASSIFIED__"
+                )
 
             logger.info(
                 f"\nConfidence threshold > {confidence_threshold} - {classified_num} classified"

--- a/bugbug/model.py
+++ b/bugbug/model.py
@@ -540,12 +540,7 @@ class Model:
                     np.array(y_pred_filter[classified_indices], dtype=int)
                 )
 
-            if is_multilabel:
-                classified_num = len(classified_indices)
-            else:
-                classified_num = sum(
-                    1 for v in y_pred_filter if v != "__NOT_CLASSIFIED__"
-                )
+            classified_num = sum(1 for v in y_pred_filter if v != "__NOT_CLASSIFIED__")
 
             logger.info(
                 f"\nConfidence threshold > {confidence_threshold} - {classified_num} classified"

--- a/bugbug/model.py
+++ b/bugbug/model.py
@@ -23,7 +23,7 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics import precision_recall_fscore_support
 from sklearn.model_selection import cross_validate, train_test_split
 from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import LabelBinarizer, LabelEncoder
+from sklearn.preprocessing import LabelEncoder
 from tabulate import tabulate
 from xgboost import XGBModel
 
@@ -180,6 +180,8 @@ class Model:
         self.training_dbs: list[str] = []
         # DBs and DB support files required at runtime.
         self.eval_dbs: dict[str, tuple[str, ...]] = {}
+
+        self.le = LabelEncoder()
 
     def download_eval_dbs(
         self, extract: bool = True, ensure_exist: bool = True
@@ -370,15 +372,8 @@ class Model:
         # Extract features from the items.
         X = self.extraction_pipeline.transform(X_gen)
 
-        y = np.array(y)
-        is_multilabel = isinstance(y[0], np.ndarray)
-        is_binary = len(self.class_names) == 2
-
         # Calculate labels.
-        if is_multilabel:
-            self.le = LabelBinarizer()
-        else:
-            self.le = LabelEncoder()
+        y = np.array(y)
         self.le.fit(y)
 
         if limit:
@@ -386,6 +381,9 @@ class Model:
             y = y[:limit]
 
         logger.info(f"X: {X.shape}, y: {y.shape}")
+
+        is_multilabel = isinstance(y[0], np.ndarray)
+        is_binary = len(self.class_names) == 2
 
         # Split dataset in training and test.
         X_train, X_test, y_train, y_test = self.train_test_split(X, y)

--- a/bugbug/models/bugtype.py
+++ b/bugbug/models/bugtype.py
@@ -12,6 +12,7 @@ from sklearn.compose import ColumnTransformer
 from sklearn.feature_extraction import DictVectorizer
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import LabelBinarizer
 
 from bugbug import bug_features, bugzilla, feature_cleanup, utils
 from bugbug.model import BugModel
@@ -24,6 +25,8 @@ class BugTypeModel(BugModel):
         BugModel.__init__(self, lemmatization)
 
         self.calculate_importance = False
+
+        self.le = LabelBinarizer()
 
         self.bug_type_extractors = bug_features.BugTypes.bug_type_extractors
 

--- a/bugbug/models/rcatype.py
+++ b/bugbug/models/rcatype.py
@@ -12,6 +12,7 @@ from sklearn.compose import ColumnTransformer
 from sklearn.feature_extraction import DictVectorizer
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import LabelBinarizer
 
 from bugbug import bug_features, bugzilla, feature_cleanup, utils
 from bugbug.model import BugModel
@@ -60,6 +61,8 @@ class RCATypeModel(BugModel):
 
         self.calculate_importance = False
         self.rca_subcategories_enabled = rca_subcategories_enabled
+
+        self.le = LabelBinarizer()
 
         # should we consider only the main category or all sub categories
         self.RCA_TYPES = (


### PR DESCRIPTION
Issue:
Closes #3956 

Comments:
This PR introduces using `LabelBinarizer` instead of `LabelEncoder` to encode in multi-label cases. It fixes the issue which caused a Value Error to be raised when using `LabelEncoder` on non 1d arrays. 

Train with Taskcluster: bugtype