### PR TITLE
Calculate `classified_num`  of test set samples differently for  multi-label models

### DIFF
--- a/bugbug/model.py
+++ b/bugbug/model.py
@@ -540,7 +540,12 @@ class Model:
                     np.array(y_pred_filter[classified_indices], dtype=int)
                 )
 
-            classified_num = sum(1 for v in y_pred_filter if v != "__NOT_CLASSIFIED__")
+            if is_multilabel:
+                classified_num = len(classified_indices)
+            else:
+                classified_num = sum(
+                    1 for v in y_pred_filter if v != "__NOT_CLASSIFIED__"
+                )
 
             logger.info(
                 f"\nConfidence threshold > {confidence_threshold} - {classified_num} classified"


### PR DESCRIPTION
**Issue**:
Closes #3962

**Comments**:
This PR fixes a bug that was checking for number of classified samples in multi-label cases the same way as binary label cases. It uses the length of the list of the classified indices to know the number of classified samples from the test set.

Train on Taskcluster: bugtype