### PR TITLE
Include `comment_tag` and `commenter` in `COMMENT_INCLUDE_FIELDS`

### DIFF
--- a/bugbug/bugzilla.py
+++ b/bugbug/bugzilla.py
@@ -69,8 +69,8 @@ COMMENT_INCLUDE_FIELDS = [
     "count",
     "text",
     "creation_time",
-    "comment_tag",
-    "commenter",
+    "tags",
+    "creator",
 ]
 
 PRODUCT_COMPONENT_CSV_REPORT_URL = "https://bugzilla.mozilla.org/report.cgi"

--- a/bugbug/bugzilla.py
+++ b/bugbug/bugzilla.py
@@ -64,7 +64,14 @@ ATTACHMENT_INCLUDE_FIELDS = [
     "file_name",
 ]
 
-COMMENT_INCLUDE_FIELDS = ["id", "count", "text", "creation_time"]
+COMMENT_INCLUDE_FIELDS = [
+    "id",
+    "count",
+    "text",
+    "creation_time",
+    "comment_tag",
+    "commenter",
+]
 
 PRODUCT_COMPONENT_CSV_REPORT_URL = "https://bugzilla.mozilla.org/report.cgi"
 

--- a/bugbug/bugzilla.py
+++ b/bugbug/bugzilla.py
@@ -27,7 +27,7 @@ BUGS_DB = "data/bugs.json"
 db.register(
     BUGS_DB,
     "https://community-tc.services.mozilla.com/api/index/v1/task/project.bugbug.data_bugs.latest/artifacts/public/bugs.json.zst",
-    9,
+    10,
 )
 
 PRODUCTS = (


### PR DESCRIPTION
**Issue**:
Closes #3967 

**Comments**:
This PR includes the `comment_tag` and `commenter` fields as part of the `comment` fields retrieved from Bugzilla.