### PR TITLE
Change `workerType` for `accessibility` and `performancebug` training tasks in data-pipeline

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -218,7 +218,7 @@ tasks:
           created: { $fromNow: "" }
           deadline: { $fromNow: "1 day" }
           provisionerId: proj-bugbug
-          workerType: compute-large
+          workerType: compute-small
           payload:
             maxRunTime:
               $switch:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -218,7 +218,7 @@ tasks:
           created: { $fromNow: "" }
           deadline: { $fromNow: "1 day" }
           provisionerId: proj-bugbug
-          workerType: compute-small
+          workerType: compute-large
           payload:
             maxRunTime:
               $switch:

--- a/infra/data-pipeline.yml
+++ b/infra/data-pipeline.yml
@@ -1008,7 +1008,7 @@ tasks:
       deadline: { $fromNow: "3 days" }
       expires: { $fromNow: "1 year" }
       provisionerId: proj-bugbug
-      workerType: compute-smaller
+      workerType: compute-small
       dependencies:
         - bugs-retrieval
       payload:

--- a/infra/data-pipeline.yml
+++ b/infra/data-pipeline.yml
@@ -1242,7 +1242,7 @@ tasks:
       deadline: { $fromNow: "3 days" }
       expires: { $fromNow: "1 year" }
       provisionerId: proj-bugbug
-      workerType: compute-smaller
+      workerType: compute-small
       dependencies:
         - bugs-retrieval
       payload:


### PR DESCRIPTION
This PR tests if changing the `workerType` to `compute-small` for the `accessibility` and `performancebug` models Fixes #3992
Task List:

- [x] Test with `Accessibility` Model on `compute-small`
- [x] Test with `Performancebug` Model on `compute-small`

Train on Taskcluster: performancebug