### PR TITLE
Bump python from 3.10.7-slim to 3.11.7-slim in /infra

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,4 +93,4 @@ repos:
     hooks:
       - id: check-useless-excludes
 default_language_version:
-  python: python3.10
+  python: python3.11

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -41,7 +41,7 @@ tasks:
         workerType: batch
         payload:
           maxRunTime: 3600
-          image: python:3.10
+          image: python:3.11
         metadata:
           owner: mcastelluccio@mozilla.com
           source: ${repository}/raw/${head_rev}/.taskcluster.yml

--- a/infra/dockerfile.base
+++ b/infra/dockerfile.base
@@ -1,4 +1,4 @@
-FROM python:3.10.7-slim
+FROM python:3.11.7-slim
 
 # Setup dependencies in a cacheable step
 RUN --mount=type=bind,source=requirements.txt,target=/requirements.txt \

--- a/infra/dockerfile.spawn_pipeline
+++ b/infra/dockerfile.spawn_pipeline
@@ -1,4 +1,4 @@
-FROM python:3.10.7-slim
+FROM python:3.11.7-slim
 
 # Setup dependencies in a cacheable step
 ADD spawn_pipeline_requirements.txt /code/


### PR DESCRIPTION
Bumps python from 3.10.7-slim to 3.11.7-slim.

---
updated-dependencies:
- dependency-name: python dependency-type: direct:production update-type: version-update:semver-minor