### PR TITLE
Revert "Bump python from 3.10.7-slim to 3.11.7-slim in /infra (#4020)"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,4 +93,4 @@ repos:
     hooks:
       - id: check-useless-excludes
 default_language_version:
-  python: python3.11
+  python: python3.10

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -41,7 +41,7 @@ tasks:
         workerType: batch
         payload:
           maxRunTime: 3600
-          image: python:3.11
+          image: python:3.10
         metadata:
           owner: mcastelluccio@mozilla.com
           source: ${repository}/raw/${head_rev}/.taskcluster.yml

--- a/infra/dockerfile.base
+++ b/infra/dockerfile.base
@@ -1,4 +1,4 @@
-FROM python:3.11.7-slim
+FROM python:3.10.7-slim
 
 # Setup dependencies in a cacheable step
 RUN --mount=type=bind,source=requirements.txt,target=/requirements.txt \

--- a/infra/dockerfile.spawn_pipeline
+++ b/infra/dockerfile.spawn_pipeline
@@ -1,4 +1,4 @@
-FROM python:3.11.7-slim
+FROM python:3.10.7-slim
 
 # Setup dependencies in a cacheable step
 ADD spawn_pipeline_requirements.txt /code/


### PR DESCRIPTION
This reverts commit 2d15ed0c123c395bb308d00bc84a6d8a3526d3f2.

This should fix #4032 until https://github.com/scikit-learn/scikit-learn/issues/28191 is fixed, which will allow us to upgrade to the latest scikit-learn version.