### PR TITLE
Train general component model on a single Fenix class

### DIFF
--- a/bugbug/models/component.py
+++ b/bugbug/models/component.py
@@ -132,6 +132,8 @@ class ComponentModel(BugModel):
 
     def filter_component(self, product, component):
         full_comp = f"{product}::{component}"
+        if product == "Fenix":
+            return "Fenix"
 
         if full_comp in self.CONFLATED_COMPONENTS_INVERSE_MAPPING:
             return self.CONFLATED_COMPONENTS_INVERSE_MAPPING[full_comp]

--- a/bugbug/models/component.py
+++ b/bugbug/models/component.py
@@ -131,9 +131,9 @@ class ComponentModel(BugModel):
         }
 
     def filter_component(self, product, component):
-        full_comp = f"{product}::{component}"
         if product == "Fenix":
             return "Fenix"
+        full_comp = f"{product}::{component}"
 
         if full_comp in self.CONFLATED_COMPONENTS_INVERSE_MAPPING:
             return self.CONFLATED_COMPONENTS_INVERSE_MAPPING[full_comp]


### PR DESCRIPTION
Resolves #4229.

Groups all Fenix components into a single Fenix class (i.e. label all Fenix bugs as `Fenix`).