### PR TITLE
Use Python 3.12.3 in Taskcluster tasks

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -41,7 +41,7 @@ tasks:
         workerType: batch
         payload:
           maxRunTime: 3600
-          image: python:3.12
+          image: python:3.12.3
         metadata:
           owner: mcastelluccio@mozilla.com
           source: ${repository}/raw/${head_rev}/.taskcluster.yml


### PR DESCRIPTION
Works around an issue with Pydantic, and it's good in its own right to match the version used in the Docker files

Fixes #4249