### PR TITLE
Dataset creation for inline comments with their resolutions

### DIFF
--- a/bugbug/tools/code_review.py
+++ b/bugbug/tools/code_review.py
@@ -537,10 +537,6 @@ class PhabricatorReviewData(ReviewData):
                 if transaction["authorPHID"] == "PHID-USER-cje4weq32o3xyuegalpj":
                     continue
 
-                # No comments
-                if not transaction["comments"]:
-                    continue
-
                 if len(transaction["comments"]) != 1:
                     # Follow up: https://github.com/mozilla/bugbug/issues/4218
                     logger.warning(

--- a/bugbug/tools/code_review.py
+++ b/bugbug/tools/code_review.py
@@ -537,6 +537,10 @@ class PhabricatorReviewData(ReviewData):
                 if transaction["authorPHID"] == "PHID-USER-cje4weq32o3xyuegalpj":
                     continue
 
+                # No comments
+                if not transaction["comments"]:
+                    continue
+
                 if len(transaction["comments"]) != 1:
                     # Follow up: https://github.com/mozilla/bugbug/issues/4218
                     logger.warning(

--- a/bugbug/tools/code_review.py
+++ b/bugbug/tools/code_review.py
@@ -42,6 +42,8 @@ class InlineComment:
     on_removed_code: bool | None
     id: int | None = None
     date_created: int | None = None
+    date_modified: int | None = None
+    is_done: bool | None = None
 
 
 class ModelResultError(Exception):
@@ -560,6 +562,10 @@ class PhabricatorReviewData(ReviewData):
                     # in Phabricator's API.
                     on_removed_code = None
 
+                    # store the last modified date and if the comments have been marked as done
+                    date_modified = transaction_comment["dateModified"]
+                    is_done = transaction["fields"]["isDone"]
+
                     # TODO: we could create an extended dataclass for this
                     # instead of adding optional fields.
                     comment = InlineComment(
@@ -570,6 +576,8 @@ class PhabricatorReviewData(ReviewData):
                         on_removed_code,
                         comment_id,
                         date_created,
+                        date_modified,
+                        is_done,
                     )
                     continue
 

--- a/bugbug/tools/code_review.py
+++ b/bugbug/tools/code_review.py
@@ -525,70 +525,64 @@ class PhabricatorReviewData(ReviewData):
         for revision in tqdm(phabricator.get_revisions(), total=revision_count):
             diff_comments: dict[int, list[InlineComment]] = defaultdict(list)
 
-            try:
-                for transaction in revision["transactions"]:
-                    if transaction["type"] != "inline":
-                        continue
+            for transaction in revision["transactions"]:
+                if transaction["type"] != "inline":
+                    continue
 
-                    # Ignore replies
-                    if transaction["fields"]["replyToCommentPHID"] is not None:
-                        continue
+                # Ignore replies
+                if transaction["fields"]["replyToCommentPHID"] is not None:
+                    continue
 
-                    # Ignore bot comments
-                    if transaction["authorPHID"] == "PHID-USER-cje4weq32o3xyuegalpj":
-                        continue
+                # Ignore bot comments
+                if transaction["authorPHID"] == "PHID-USER-cje4weq32o3xyuegalpj":
+                    continue
 
-                    if len(transaction["comments"]) != 1:
-                        # Follow up: https://github.com/mozilla/bugbug/issues/4218
-                        logger.warning(
-                            "Unexpected number of comments in transaction %s",
-                            transaction["id"],
-                        )
-
-                    transaction_comment = transaction["comments"][0]
-                    comment_id = transaction_comment["id"]
-                    date_created = transaction_comment["dateCreated"]
-                    comment_content = transaction_comment["content"]["raw"]
-
-                    diff_id = transaction["fields"]["diff"]["id"]
-                    filename = transaction["fields"]["path"]
-                    start_line = transaction["fields"]["line"]
-                    end_line = (
-                        transaction["fields"]["line"]
-                        + transaction["fields"]["length"]
-                        - 1
-                    )
-                    # Unfortunately, we do not have this information for a limitation
-                    # in Phabricator's API.
-                    on_removed_code = None
-
-                    # store the last modified date and if the comments have been marked as done
-                    date_modified = transaction_comment["dateModified"]
-                    is_done = transaction["fields"]["isDone"]
-
-                    # TODO: we could create an extended dataclass for this
-                    # instead of adding optional fields.
-                    comment = InlineComment(
-                        filename,
-                        start_line,
-                        end_line,
-                        comment_content,
-                        on_removed_code,
-                        comment_id,
-                        date_created,
-                        date_modified,
-                        is_done,
+                if len(transaction["comments"]) != 1:
+                    # Follow up: https://github.com/mozilla/bugbug/issues/4218
+                    logger.warning(
+                        "Unexpected number of comments in transaction %s",
+                        transaction["id"],
                     )
                     continue
 
-                    if not comment_filter(comment):
-                        continue
+                transaction_comment = transaction["comments"][0]
+                comment_id = transaction_comment["id"]
+                date_created = transaction_comment["dateCreated"]
+                comment_content = transaction_comment["content"]["raw"]
 
-                    diff_comments[diff_id].append(comment)
+                diff_id = transaction["fields"]["diff"]["id"]
+                filename = transaction["fields"]["path"]
+                start_line = transaction["fields"]["line"]
+                end_line = (
+                    transaction["fields"]["line"] + transaction["fields"]["length"] - 1
+                )
+                # Unfortunately, we do not have this information for a limitation
+                # in Phabricator's API.
+                on_removed_code = None
 
-            except Exception as e:
-                logger.error(f"Error processing revision {revision['id']}: {e}")
-                continue
+                # store the last modified date and if the comments have been marked as done
+                date_modified = transaction_comment["dateModified"]
+                is_done = transaction["fields"]["isDone"]
+
+                # TODO: we could create an extended dataclass for this
+                # instead of adding optional fields.
+                comment = InlineComment(
+                    filename,
+                    start_line,
+                    end_line,
+                    comment_content,
+                    on_removed_code,
+                    comment_id,
+                    date_created,
+                    date_modified,
+                    is_done,
+                )
+
+                if not comment_filter(comment):
+                    continue
+
+                diff_comments[diff_id].append(comment)
+
             for diff_id, comments in diff_comments.items():
                 yield diff_id, comments
 

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -89,15 +89,8 @@ def find_recent_update(transactions, comment_date_modified):
 
 def save_to_dataset(data):
     dataset_file = "dataset/inline_comment_dataset.json"
-    if os.path.exists(dataset_file):
-        with open(dataset_file, "r") as f:
-            dataset = json.load(f)
-    else:
-        dataset = []
-
-    dataset.append(data)
-    with open(dataset_file, "w") as f:
-        json.dump(dataset, f, indent=4)
+    with open(dataset_file, "a") as f:
+        f.write(json.dumps(data) + "\n")
 
 
 def to_int(value):

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -122,7 +122,6 @@ def fetch_diff_from_url(revision_id, vs_diff_id, fix_patch_id):
 
 
 def extract_relevant_diff(patch_diff, filename):
-    # Regular expression to capture the file diff section that matches the filename
     file_diff_pattern = rf"diff --git a/{re.escape(filename)} b/{re.escape(filename)}\n.*?(?=\ndiff --git|$)"
     match = re.search(file_diff_pattern, patch_diff, re.DOTALL)
 

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -73,13 +73,10 @@ def find_details_from_revision_phid(phid):
 
 
 def find_previous_patch_id(revision_phid, current_patch_id):
-    # Retrieve all diffs associated with the revision
     diffs = api.search_diffs(revision_phid=revision_phid)
 
-    # Sort the diffs by ID to ensure they are in the correct order
     sorted_diffs = sorted(diffs, key=lambda x: x["id"])
 
-    # Find the patch right before the current patch
     previous_patch_id = None
     for i, diff in enumerate(sorted_diffs):
         if diff["id"] == current_patch_id and i > 0:

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -14,9 +14,6 @@ review_data = PhabricatorReviewData()
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-os.makedirs("patches", exist_ok=True)
-os.makedirs("dataset", exist_ok=True)
-
 api = PhabricatorAPI(get_secret("PHABRICATOR_TOKEN"))
 
 
@@ -104,14 +101,6 @@ def find_recent_update(transactions, comment_date_modified):
     return most_recent_update
 
 
-def to_int(value):
-    if not value:
-        return None
-    if not isinstance(value, int):
-        return int(value)
-    return value
-
-
 def fetch_diff_from_url(revision_id, vs_diff_id, fix_patch_id):
     url = f"https://phabricator.services.mozilla.com/D{revision_id}?vs={vs_diff_id}&id={fix_patch_id}&download=true"
     response = requests.get(url)
@@ -179,12 +168,12 @@ def process_comments(patch_threshold, diff_length_threshold):
 
             if relevant_diff:
                 data = {
-                    "bug_id": to_int(bug_id),
-                    "revision_id": to_int(revision_id),
+                    "bug_id": bug_id,
+                    "revision_id": revision_id,
                     "revision_phid": revision_phid,
-                    "initial_patch_id": to_int(patch_id),
-                    "fix_patch_id": to_int(fix_patch_id),
-                    "previous_patch_id": to_int(previous_patch_id),
+                    "initial_patch_id": patch_id,
+                    "fix_patch_id": fix_patch_id,
+                    "previous_patch_id": previous_patch_id,
                     "comment": comment.__dict__,
                     "fix_patch_diff": relevant_diff,
                 }
@@ -196,6 +185,8 @@ def process_comments(patch_threshold, diff_length_threshold):
 
 
 def main():
+    os.makedirs("patches", exist_ok=True)
+    os.makedirs("dataset", exist_ok=True)
     dataset_file_path = "dataset/inline_comment_dataset2.json"
     with open(dataset_file_path, "a") as dataset_file_handle:
         for data in process_comments(patch_threshold=1000, diff_length_threshold=5000):

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -115,10 +115,8 @@ def save_to_dataset(data):
 
 def to_int(value):
     if not isinstance(value, int):
-        try:
-            return int(value)
-        except ValueError:
-            return None
+        return int(value)
+    return value
 
 
 def process_comments(patch_threshold):
@@ -171,4 +169,4 @@ def process_comments(patch_threshold):
 
 if __name__ == "__main__":
     download_inline_comments()
-    process_comments(patch_threshold=500)
+    process_comments(patch_threshold=250)

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -85,10 +85,6 @@ def find_recent_update(transactions, comment_date_modified):
     return most_recent_update
 
 
-def save_to_dataset(data, dataset_file_handle):
-    dataset_file_handle.write(json.dumps(data) + "\n")
-
-
 def to_int(value):
     if not value:
         return None
@@ -97,7 +93,7 @@ def to_int(value):
     return value
 
 
-def process_comments(patch_threshold, diff_length_threshold, dataset_file_handle):
+def process_comments(patch_threshold, diff_length_threshold):
     patch_count = 0
 
     for patch_id, comments in review_data.get_all_inline_comments(lambda c: True):
@@ -139,18 +135,19 @@ def process_comments(patch_threshold, diff_length_threshold, dataset_file_handle
                 "comment": comment.__dict__,
                 "fix_patch_diff": patch_diff,
             }
-            save_to_dataset(data, dataset_file_handle)
+            yield data
 
         patch_count += 1
         if patch_count >= patch_threshold:
             break
 
 
-if __name__ == "__main__":
+def main():
     dataset_file_path = "dataset/inline_comment_dataset.json"
     with open(dataset_file_path, "a") as dataset_file_handle:
-        process_comments(
-            patch_threshold=250,
-            diff_length_threshold=5000,
-            dataset_file_handle=dataset_file_handle,
-        )
+        for data in process_comments(patch_threshold=250, diff_length_threshold=5000):
+            dataset_file_handle.write(json.dumps(data) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -101,7 +101,7 @@ def to_int(value):
     return value
 
 
-def process_comments(patch_threshold):
+def process_comments(patch_threshold, diff_length_threshold):
     client = PhabricatorClient()
     comments_dir = "comments"
     patch_count = 0
@@ -134,6 +134,9 @@ def process_comments(patch_threshold):
                 with open(f"patches/{fix_patch_id}.patch", "r") as f:
                     patch_diff = f.read()
 
+                if len(patch_diff) > diff_length_threshold:
+                    continue
+
                 data = {
                     "bug_id": to_int(bug_id),
                     "revision_phid": revision_phid,
@@ -151,4 +154,4 @@ def process_comments(patch_threshold):
 
 if __name__ == "__main__":
     download_inline_comments()
-    process_comments(patch_threshold=250)
+    process_comments(patch_threshold=250, diff_length_threshold=1000)

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -93,12 +93,9 @@ def find_recent_update(transactions, comment_date_modified):
         if transaction["type"] == "update"
         and transaction["dateModified"] <= comment_date_modified
     ]
-    if not updates:
-        return None
-    most_recent_update = max(
-        updates, key=lambda transaction: transaction["dateModified"]
+    return max(
+        updates, key=lambda transaction: transaction["dateModified"], default=None
     )
-    return most_recent_update
 
 
 def fetch_diff_from_url(revision_id, vs_diff_id, fix_patch_id):

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -103,10 +103,8 @@ def find_recent_update(transactions, comment_date_modified):
     return most_recent_update
 
 
-def save_to_dataset(data):
-    dataset_file = "dataset/inline_comment_dataset.json"
-    with open(dataset_file, "a") as f:
-        f.write(json.dumps(data) + "\n")
+def save_to_dataset(data, dataset_file_handle):
+    dataset_file_handle.write(json.dumps(data) + "\n")
 
 
 def to_int(value):
@@ -117,7 +115,7 @@ def to_int(value):
     return value
 
 
-def process_comments(patch_threshold, diff_length_threshold):
+def process_comments(patch_threshold, diff_length_threshold, dataset_file_handle):
     comments_dir = "comments"
     patch_count = 0
     for file_name in os.listdir(comments_dir):
@@ -160,7 +158,7 @@ def process_comments(patch_threshold, diff_length_threshold):
                     "comment": comment,
                     "fix_patch_diff": patch_diff,
                 }
-                save_to_dataset(data)
+                save_to_dataset(data, dataset_file_handle)
 
         patch_count += 1
         if patch_count >= patch_threshold:
@@ -169,4 +167,11 @@ def process_comments(patch_threshold, diff_length_threshold):
 
 if __name__ == "__main__":
     download_inline_comments()
-    process_comments(patch_threshold=250, diff_length_threshold=5000)
+
+    dataset_file_path = "dataset/inline_comment_dataset.json"
+    with open(dataset_file_path, "a") as dataset_file_handle:
+        process_comments(
+            patch_threshold=250,
+            diff_length_threshold=5000,
+            dataset_file_handle=dataset_file_handle,
+        )

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -115,7 +115,6 @@ def process_comments():
                 print(json.dumps(most_recent_update, indent=4))
 
 
-# Example usage
 if __name__ == "__main__":
     download_inline_comments()
     process_comments()

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -101,6 +101,8 @@ def save_to_dataset(data):
 
 
 def to_int(value):
+    if not value:
+        return None
     if not isinstance(value, int):
         return int(value)
     return value

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -119,7 +119,7 @@ def process_comments(patch_threshold, diff_length_threshold):
                 continue
 
             bug_id = find_bugid_from_revision_phid(phid=revision_phid)
-            review_data.load_patch_by_id(fix_patch_id)
+            review_data.load_raw_diff_by_id(fix_patch_id)
 
             with open(f"patches/{fix_patch_id}.patch", "r") as f:
                 patch_diff = f.read()

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -13,7 +13,6 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 os.makedirs("patches", exist_ok=True)
-os.makedirs("comments", exist_ok=True)
 os.makedirs("dataset", exist_ok=True)
 
 api = PhabricatorAPI(get_secret("PHABRICATOR_TOKEN"))
@@ -69,23 +68,6 @@ def get_diff_info_from_phid(phid):
 def find_bugid_from_revision_phid(phid):
     revision = api.load_revision(rev_phid=phid)
     return revision["fields"]["bugzilla.bug-id"]
-
-
-def download_inline_comments():
-    for patch_id, comments in review_data.get_all_inline_comments(lambda c: True):
-        save_comments_to_file(patch_id, comments)
-    return
-
-
-def save_comments_to_file(patch_id, comments):
-    resolved_comments = [comment for comment in comments if comment.is_done]
-
-    file_path = f"comments/{patch_id}.json"
-    if os.path.exists(file_path) or not resolved_comments:
-        return
-
-    with open(file_path, "w") as f:
-        json.dump([comment.__dict__ for comment in resolved_comments], f, indent=4)
 
 
 def find_recent_update(transactions, comment_date_modified):

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -17,6 +17,30 @@ os.makedirs("comments", exist_ok=True)
 os.makedirs("dataset", exist_ok=True)
 
 
+class NoDiffsFoundException(Exception):
+    def __init__(self, patch_id):
+        super().__init__(f"No diffs found for the given patch ID: {patch_id}")
+        self.patch_id = patch_id
+
+
+class NoTransactionsFoundException(Exception):
+    def __init__(self, patch_id):
+        super().__init__(f"No transactions found for the given patch ID: {patch_id}")
+        self.patch_id = patch_id
+
+
+class NoDiffFoundForPHIDException(Exception):
+    def __init__(self, phid):
+        super().__init__(f"No diff found for PHID {phid}")
+        self.phid = phid
+
+
+class NoRevisionFoundException(Exception):
+    def __init__(self, phid):
+        super().__init__(f"No revision found for the given revision PHID: {phid}")
+        self.phid = phid
+
+
 class PhabricatorClient:
     def __init__(self):
         self.api = PhabricatorAPI(get_secret("PHABRICATOR_TOKEN"))
@@ -25,7 +49,7 @@ class PhabricatorClient:
         diffs = self.api.search_diffs(diff_id=patch_id)
 
         if not diffs:
-            raise Exception(f"No diffs found for the given patch ID: {patch_id}")
+            raise NoDiffsFoundException(patch_id)
 
         revision_phid = diffs[0]["revisionPHID"]
         return revision_phid
@@ -37,20 +61,20 @@ class PhabricatorClient:
         )["data"]
 
         if not transactions:
-            raise Exception(f"No transactions found for the given patch ID: {patch_id}")
+            raise NoTransactionsFoundException(patch_id)
 
         return transactions
 
     def get_diff_info_from_phid(self, phid):
         diffs = self.api.search_diffs(diff_phid=phid)
         if not diffs:
-            raise Exception(f"No diff found for PHID {phid}")
+            raise NoDiffFoundForPHIDException(phid)
         return diffs[0]["id"], diffs[0]["revisionPHID"]
 
     def find_bugid_from_revision_phid(self, phid):
         revision = self.api.load_revision(rev_phid=phid)
         if not revision:
-            raise Exception(f"No revision found for the given revision PHID: {phid}")
+            raise NoRevisionFoundException(phid)
 
         return revision["fields"]["bugzilla.bug-id"]
 

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -1,25 +1,126 @@
+# import logging
+# import json
+# import os
+# from bugbug.tools.code_review import PhabricatorReviewData
+
+# # Initialize the Phabricator review data
+# review_data = PhabricatorReviewData()
+
+# # Configure logging
+# logging.basicConfig(level=logging.INFO)
+# logger = logging.getLogger(__name__)
+
+# # Create necessary directories if they do not exist
+# os.makedirs("patches", exist_ok=True)
+# os.makedirs("comments", exist_ok=True)
+
+# # Save comments to a JSON file
+# def save_comments_to_file(patch_id, comments):
+#     file_path = f"comments/{patch_id}.json"
+#     if os.path.exists(file_path):
+#         #logger.info(f"Comments file for patch ID {patch_id} already exists.")
+#         return
+
+#     with open(file_path, 'w') as f:
+#         json.dump([comment.__dict__ for comment in comments], f, indent=4)
+#     #logger.info(f"Saved comments for patch ID {patch_id} to {file_path}")
+
+# # Download all patches and retrieve inline comments for the first patch
+# def download_and_retrieve_comments():
+#     for patch_id, comments in review_data.get_all_inline_comments(lambda c: True):
+#         try:
+#             review_data.load_patch_by_id(patch_id)
+#         except Exception as e:
+#             logger.error(f"Failed to load patch {patch_id}: {e}")
+#             continue
+#         save_comments_to_file(patch_id, comments)
+
+#     return patch_id, comments
+
+# # Get the inline comments
+# patch_id, comments = download_and_retrieve_comments()
+
+# --------------------------------------------------------- #
+# import json
+# from libmozdata.phabricator import PhabricatorAPI
+
+# class PhabricatorClient:
+#     def __init__(self, api_key):
+#         self.api = PhabricatorAPI(api_key)
+
+#     def find_bug_from_patch(self, patch_id):
+#         diffs = self.api.search_diffs(diff_id=patch_id)
+#         if not diffs:
+#             raise Exception("No diffs found for the given patch ID")
+#         revision_phid = diffs[0]['revisionPHID']
+#         return self.api.load_revision(rev_phid=revision_phid)
+
+#     def get_transactions_for_revision(self, revision_phid):
+#         transactions = self.api.request("transaction.search", objectIdentifier=revision_phid)
+#         return transactions['data']
+
+#     def get_full_details(self, patch_id):
+#         revision = self.find_bug_from_patch(patch_id)
+#         revision_phid = revision['phid']
+
+#         # Fetch all transactions for the revision
+#         transactions = self.get_transactions_for_revision(revision_phid)
+
+#         return {
+#             'transactions': transactions,
+#         }
+
+#     # TODO: 1. given a patch and its inline comments 2. find when the comments were last modified and if it was resolved 3. go through commit history, find the most recent patch 4. apply the original patch to parent of fix, get diff
+
+# --------------------------------------------------------- #
+
+# 1. Retrieve and store all inline comments locally for each patch X
+
+# 2. If the comments are marked as done, get the last time it was modified and go through transaction history
+
+# 3. Identify the patch that was landed most recent before the comment was marked as is done, get the diff and store that, also store diff of original patch
+
+# 4. apply cherry picking technique
+
+# 5. store the following in dataset: revision ID, bug ID, initial patch ID, comments, fix patch ID, diff between original and fix patch
+
+
+import json
 import logging
+import os
 
 from bugbug.tools.code_review import PhabricatorReviewData
 
-# Initialize the Phabricator review data
 review_data = PhabricatorReviewData()
 
-# Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# Create necessary directories if they do not exist
+os.makedirs("patches", exist_ok=True)
+os.makedirs("comments", exist_ok=True)
 
-# Download all patches and retrieve inline comments for the first 10 patches
-def download_and_retrieve_comments():
-    inline_comments = []
+# 1. Retrieve and store all inline comments locally for each patch X
+#    make changes to code_review.py to store extra metadata
 
+
+def download_inline_comments():
     for patch_id, comments in review_data.get_all_inline_comments(lambda c: True):
-        review_data.load_patch_by_id(patch_id)
-        inline_comments.extend(comments)
-
-    return inline_comments
+        save_comments_to_file(patch_id, comments)
+    return
 
 
-# Get the inline comments
-comments = download_and_retrieve_comments()
+def save_comments_to_file(patch_id, comments):
+    file_path = f"comments/{patch_id}.json"
+    if os.path.exists(file_path):
+        return
+
+    with open(file_path, "w") as f:
+        json.dump([comment.__dict__ for comment in comments], f, indent=4)
+
+
+# 2. If the comments are marked as done, get the last time it was modified and go through transaction history
+
+# Example usage
+if __name__ == "__main__":
+    download_inline_comments()

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -1,13 +1,9 @@
 # 1. Retrieve and store all inline comments that have been resolved locally for each patch X
 #    make changes to code_review.py to store extra metadata
 
-# 2. Iterate through comments, get the last time it was modified and go through transaction history
+# 2. Iterate through comments, get the last time it was modified and go through transaction history and find the most recent patch before the comment was resolved
 
-# 3. Identify the patch that was landed most recent before the comment was marked as is done, get the diff and store that, also store diff of original patch
-
-# 4. apply cherry picking technique
-
-# 5. store the following in dataset: revision ID, bug ID, initial patch ID, comments, fix patch ID, diff between original and fix patch
+# 3. Load diff of fix patch and store the following in dataset: revision ID, bug ID, initial patch ID, comments, fix patch ID, diff of the fix patch
 
 
 import json
@@ -24,12 +20,11 @@ review_data = PhabricatorReviewData()
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# Create necessary directories if they do not exist
 os.makedirs("patches", exist_ok=True)
 os.makedirs("comments", exist_ok=True)
+os.makedirs("dataset", exist_ok=True)
 
 
-# Define Phabricator client
 class PhabricatorClient:
     def __init__(self):
         self.api = PhabricatorAPI(get_secret("PHABRICATOR_TOKEN"))
@@ -54,11 +49,18 @@ class PhabricatorClient:
 
         return transactions
 
-    def get_diff_id_from_phid(self, phid):
+    def get_diff_info_from_phid(self, phid):
         diffs = self.api.search_diffs(diff_phid=phid)
         if not diffs:
             raise Exception(f"No diff found for PHID {phid}")
-        return diffs[0]["id"]
+        return diffs[0]["id"], diffs[0]["revisionPHID"]
+
+    def find_bugid_from_revision_phid(self, phid):
+        revision = self.api.load_revision(rev_phid=phid)
+        if not revision:
+            raise Exception(f"No revision found for the given revision PHID: {phid}")
+
+        return revision["fields"]["bugzilla.bug-id"]
 
 
 # 1. Retrieve and store all inline comments that have been resolved locally for each patch X
@@ -98,14 +100,31 @@ def find_recent_update(transactions, comment_date_modified):
     return most_recent_update
 
 
-# TODO: skip cases where the most recent patch is the original patch itself, so there were no changes made to address the comments
-# could be because of accidental comment
+def save_to_dataset(data):
+    dataset_file = "dataset/inline_comment_dataset.json"
+    if os.path.exists(dataset_file):
+        with open(dataset_file, "r") as f:
+            dataset = json.load(f)
+    else:
+        dataset = []
+
+    dataset.append(data)
+    with open(dataset_file, "w") as f:
+        json.dump(dataset, f, indent=4)
 
 
-def process_comments():
+def to_int(value):
+    if not isinstance(value, int):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+
+
+def process_comments(patch_threshold):
     client = PhabricatorClient()
     comments_dir = "comments"
-    count = 0
+    patch_count = 0
     for file_name in os.listdir(comments_dir):
         file_path = os.path.join(comments_dir, file_name)
         with open(file_path, "r") as f:
@@ -120,22 +139,36 @@ def process_comments():
                 )
                 if not most_recent_update:
                     continue
-                # If the most recent patch is the original patch itself, skip it
-                if (
-                    client.get_diff_id_from_phid(most_recent_update["fields"]["new"])
-                    == patch_id
-                ):
-                    continue
-                print(f"ORIGINAL PATCH >> {patch_id}")
-                print(
-                    f"FIX PATCH >> {client.get_diff_id_from_phid(most_recent_update['fields']['new'])}"
+
+                fix_patch_id, revision_phid = client.get_diff_info_from_phid(
+                    most_recent_update["fields"]["new"]
                 )
 
-        count += 1
-        if count >= 100:
+                # If the most recent patch is the original patch itself, skip it
+                if fix_patch_id == patch_id:
+                    continue
+
+                bug_id = client.find_bugid_from_revision_phid(phid=revision_phid)
+                review_data.load_patch_by_id(fix_patch_id)
+
+                with open(f"patches/{fix_patch_id}.patch", "r") as f:
+                    patch_diff = f.read()
+
+                data = {
+                    "bug_id": to_int(bug_id),
+                    "revision_phid": revision_phid,
+                    "initial_patch_id": to_int(patch_id),
+                    "fix_patch_id": to_int(fix_patch_id),
+                    "comment": comment,
+                    "fix_patch_diff": patch_diff,
+                }
+                save_to_dataset(data)
+
+        patch_count += 1
+        if patch_count >= patch_threshold:
             break
 
 
 if __name__ == "__main__":
     download_inline_comments()
-    process_comments()
+    process_comments(patch_threshold=500)

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -1,0 +1,25 @@
+import logging
+
+from bugbug.tools.code_review import PhabricatorReviewData
+
+# Initialize the Phabricator review data
+review_data = PhabricatorReviewData()
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+# Download all patches and retrieve inline comments for the first 10 patches
+def download_and_retrieve_comments():
+    inline_comments = []
+
+    for patch_id, comments in review_data.get_all_inline_comments(lambda c: True):
+        review_data.load_patch_by_id(patch_id)
+        inline_comments.extend(comments)
+
+    return inline_comments
+
+
+# Get the inline comments
+comments = download_and_retrieve_comments()

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -1,11 +1,3 @@
-# 1. Retrieve and store all inline comments that have been resolved locally for each patch X
-#    make changes to code_review.py to store extra metadata
-
-# 2. Iterate through comments, get the last time it was modified and go through transaction history and find the most recent patch before the comment was resolved
-
-# 3. Load diff of fix patch and store the following in dataset: revision ID, bug ID, initial patch ID, comments, fix patch ID, diff of the fix patch
-
-
 import json
 import logging
 import os
@@ -63,10 +55,6 @@ class PhabricatorClient:
         return revision["fields"]["bugzilla.bug-id"]
 
 
-# 1. Retrieve and store all inline comments that have been resolved locally for each patch X
-#    make changes to code_review.py to store extra metadata
-
-
 def download_inline_comments():
     for patch_id, comments in review_data.get_all_inline_comments(lambda c: True):
         save_comments_to_file(patch_id, comments)
@@ -84,7 +72,6 @@ def save_comments_to_file(patch_id, comments):
         json.dump([comment.__dict__ for comment in resolved_comments], f, indent=4)
 
 
-# 2. Iterate through comments, get the last time it was modified and go through transaction history and find the most recent patch before the comment was resolved
 def find_recent_update(transactions, comment_date_modified):
     updates = [
         transaction

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -35,12 +35,6 @@ class NoDiffFoundForPHIDException(Exception):
         self.phid = phid
 
 
-class NoRevisionFoundException(Exception):
-    def __init__(self, phid):
-        super().__init__(f"No revision found for the given revision PHID: {phid}")
-        self.phid = phid
-
-
 class PhabricatorClient:
     def __init__(self):
         self.api = PhabricatorAPI(get_secret("PHABRICATOR_TOKEN"))
@@ -73,9 +67,6 @@ class PhabricatorClient:
 
     def find_bugid_from_revision_phid(self, phid):
         revision = self.api.load_revision(rev_phid=phid)
-        if not revision:
-            raise NoRevisionFoundException(phid)
-
         return revision["fields"]["bugzilla.bug-id"]
 
 
@@ -178,4 +169,4 @@ def process_comments(patch_threshold, diff_length_threshold):
 
 if __name__ == "__main__":
     download_inline_comments()
-    process_comments(patch_threshold=250, diff_length_threshold=1000)
+    process_comments(patch_threshold=250, diff_length_threshold=5000)


### PR DESCRIPTION
Script to generate dataset of a patch, its inline comments, and the fix patch.

Intended to include:
- bug ID
- revision ID
- initial patch ID
- fix patch ID
- comments associated with initial patch
- diff between the initial patch and the  fix patch
