### PR TITLE
Resolve `IndexError` in `code_review.py`

### DIFF
--- a/bugbug/tools/code_review.py
+++ b/bugbug/tools/code_review.py
@@ -332,6 +332,7 @@ class PhabricatorReviewData(ReviewData):
                         "Unexpected number of comments in transaction %s",
                         transaction["id"],
                     )
+                    continue
 
                 transaction_comment = transaction["comments"][0]
                 comment_id = transaction_comment["id"]


### PR DESCRIPTION
Resolves #4265.

Added `continue` after logging warning when transactions have an unexpected number of comments (!= 1).