### PR TITLE
[model:component] Add initial product and component as features

### DIFF
--- a/bugbug/bug_features.py
+++ b/bugbug/bug_features.py
@@ -913,7 +913,10 @@ class InitialProduct(SingleBugFeature):
         if history:
             for entry in history:
                 for change in entry["changes"]:
-                    if change["field_name"] == "product":
+                    if (
+                        change["field_name"] == "product"
+                        and change["removed"] != bug["product"]
+                    ):
                         return change["removed"]
         return None
 
@@ -924,6 +927,9 @@ class InitialComponent(SingleBugFeature):
         if history:
             for entry in history:
                 for change in entry["changes"]:
-                    if change["field_name"] == "component":
+                    if (
+                        change["field_name"] == "component"
+                        and change["removed"] != bug["component"]
+                    ):
                         return change["removed"]
         return None

--- a/bugbug/bug_features.py
+++ b/bugbug/bug_features.py
@@ -915,7 +915,7 @@ class InitialProduct(SingleBugFeature):
                 for change in entry["changes"]:
                     if change["field_name"] == "product":
                         return change["removed"]
-        return bug["product"]
+        return None
 
 
 class InitialComponent(SingleBugFeature):
@@ -926,4 +926,4 @@ class InitialComponent(SingleBugFeature):
                 for change in entry["changes"]:
                     if change["field_name"] == "component":
                         return change["removed"]
-        return bug["component"]
+        return None

--- a/bugbug/bug_features.py
+++ b/bugbug/bug_features.py
@@ -905,3 +905,24 @@ class BugType(SingleBugFeature):
 
     def __call__(self, bug, **kwargs):
         return bug["type"]
+
+class InitialProduct(SingleBugFeature):
+    def __call__(self, bug, **kwargs):
+        history = bug.get("history", [])
+        if history:
+            for entry in history:
+                for change in entry["changes"]:
+                    if change["field_name"] == "product":
+                        return change["removed"]
+        return bug["product"]
+
+
+class InitialComponent(SingleBugFeature):
+    def __call__(self, bug, **kwargs):
+        history = bug.get("history", [])
+        if history:
+            for entry in history:
+                for change in entry["changes"]:
+                    if change["field_name"] == "component":
+                        return change["removed"]
+        return bug["component"]

--- a/bugbug/bug_features.py
+++ b/bugbug/bug_features.py
@@ -906,6 +906,7 @@ class BugType(SingleBugFeature):
     def __call__(self, bug, **kwargs):
         return bug["type"]
 
+
 class InitialProduct(SingleBugFeature):
     def __call__(self, bug, **kwargs):
         history = bug.get("history", [])

--- a/bugbug/models/component.py
+++ b/bugbug/models/component.py
@@ -84,8 +84,8 @@ class ComponentModel(BugModel):
             bug_features.Whiteboard(),
             bug_features.Patches(),
             bug_features.Landings(),
-            bug_features.Product(),
-            bug_features.Component(),
+            bug_features.InitialProduct(),
+            bug_features.InitialComponent(),
         ]
 
         cleanup_functions = [

--- a/bugbug/models/component.py
+++ b/bugbug/models/component.py
@@ -84,6 +84,8 @@ class ComponentModel(BugModel):
             bug_features.Whiteboard(),
             bug_features.Patches(),
             bug_features.Landings(),
+            bug_features.Product(),
+            bug_features.Component(),
         ]
 
         cleanup_functions = [


### PR DESCRIPTION
Resolves #4297.

Includes the initial manually classified product and component of a bug as features.