### PR TITLE
[model:performancebug] Add `BugType` feature to model.

### DIFF
--- a/bugbug/bug_features.py
+++ b/bugbug/bug_features.py
@@ -896,3 +896,10 @@ class BugTypes(SingleBugFeature):
             for is_type in self.bug_type_extractors
             if is_type(bug, bug_map)
         ]
+
+
+class BugType(SingleBugFeature):
+    """Extracts the type of the bug."""
+
+    def __call__(self, bug, **kwargs):
+        return bug["type"]

--- a/bugbug/models/performancebug.py
+++ b/bugbug/models/performancebug.py
@@ -40,6 +40,7 @@ class PerformanceBugModel(BugModel):
             bug_features.HasCVEInAlias(),
             bug_features.HasAttachment(),
             bug_features.FiledVia(),
+            bug_features.BugType(),
         ]
 
         cleanup_functions = [


### PR DESCRIPTION
Resolves: #4107

<details>
<summary>Click to expand - Training before update</summary>

```bash
2024-07-11 17:56:43,818:INFO:__main__:Training *performancebug* model
2024-07-11 17:56:55,267:INFO:bugbug.models.performancebug:4013 performance bugs
2024-07-11 17:56:55,276:INFO:bugbug.models.performancebug:159720 non-performance bugs
```

---

```bash
2024-07-11 18:01:57,248:INFO:bugbug.model:X: (163733, 4), y: (163733,)
2024-07-11 18:12:25,533:INFO:bugbug.model:Cross Validation scores:
2024-07-11 18:12:25,533:INFO:bugbug.model:Accuracy: f0.9818266966355818 (+/- 0.0009129760740876034)
2024-07-11 18:12:25,533:INFO:bugbug.model:Precision: f0.7851735028306954 (+/- 0.023531853028122367)
2024-07-11 18:12:25,534:INFO:bugbug.model:Recall: f0.356569847856155 (+/- 0.03367109057748922)
2024-07-11 18:12:25,534:INFO:bugbug.model:X_train: (147359, 4), y_train: (147359,)
2024-07-11 18:12:25,534:INFO:bugbug.model:X_test: (16374, 4), y_test: (16374,)
2024-07-11 18:15:08,415:INFO:bugbug.model:Number of features: 32247
2024-07-11 18:15:08,416:INFO:bugbug.model:Model trained
2024-07-11 18:15:08,456:INFO:bugbug.model:Training Set scores:
                   pre       rec       spe        f1       geo       iba       sup

          1       0.97      0.54      1.00      0.69      0.73      0.52      3615
          0       0.99      1.00      0.54      0.99      0.73      0.56    143744

avg / total       0.99      0.99      0.55      0.99      0.73      0.56    147359

2024-07-11 18:15:30,849:INFO:bugbug.model:Test Set scores:
2024-07-11 18:15:33,460:INFO:bugbug.model:No confidence threshold - 16374 classified
                   pre       rec       spe        f1       geo       iba       sup

          1       0.83      0.36      1.00      0.50      0.60      0.34       398
          0       0.98      1.00      0.36      0.99      0.60      0.38     15976

avg / total       0.98      0.98      0.38      0.98      0.60      0.38     16374

╒════════════╤═════════════════╤═════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │
╞════════════╪═════════════════╪═════════════════╡
│ 1 (Actual) │             144 │             254 │
├────────────┼─────────────────┼─────────────────┤
│ 0 (Actual) │              30 │           15946 │
╘════════════╧═════════════════╧═════════════════╛

2024-07-11 18:15:36,141:INFO:bugbug.model:
Confidence threshold > 0.1 - 16374 classified
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: F-score is ill-defined and being set to 0.0 in labels with no true nor predicted samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.45      0.60      0.98      0.51      0.77      0.57       398
                 0       0.99      0.98      0.60      0.99      0.77      0.61     15976
__NOT_CLASSIFIED__       0.00      0.00      1.00      0.00      0.00      0.00         0

       avg / total       0.98      0.97      0.61      0.97      0.77      0.61     16374

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             239 │             159 │                0 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │             295 │           15681 │                0 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛

2024-07-11 18:15:39,080:INFO:bugbug.model:
Confidence threshold > 0.2 - 16374 classified
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: F-score is ill-defined and being set to 0.0 in labels with no true nor predicted samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.59      0.50      0.99      0.54      0.70      0.47       398
                 0       0.99      0.99      0.50      0.99      0.70      0.52     15976
__NOT_CLASSIFIED__       0.00      0.00      1.00      0.00      0.00      0.00         0

       avg / total       0.98      0.98      0.51      0.98      0.70      0.52     16374

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             199 │             199 │                0 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │             139 │           15837 │                0 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛

2024-07-11 18:15:41,956:INFO:bugbug.model:
Confidence threshold > 0.3 - 16374 classified
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: F-score is ill-defined and being set to 0.0 in labels with no true nor predicted samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.70      0.44      1.00      0.54      0.67      0.42       398
                 0       0.99      1.00      0.44      0.99      0.67      0.47     15976
__NOT_CLASSIFIED__       0.00      0.00      1.00      0.00      0.00      0.00         0

       avg / total       0.98      0.98      0.46      0.98      0.67      0.47     16374

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             177 │             221 │                0 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │              77 │           15899 │                0 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛

2024-07-11 18:15:44,810:INFO:bugbug.model:
Confidence threshold > 0.4 - 16374 classified
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: F-score is ill-defined and being set to 0.0 in labels with no true nor predicted samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.76      0.40      1.00      0.52      0.63      0.37       398
                 0       0.99      1.00      0.40      0.99      0.63      0.42     15976
__NOT_CLASSIFIED__       0.00      0.00      1.00      0.00      0.00      0.00         0

       avg / total       0.98      0.98      0.41      0.98      0.63      0.42     16374

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             159 │             239 │                0 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │              51 │           15925 │                0 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛

2024-07-11 18:15:47,581:INFO:bugbug.model:
Confidence threshold > 0.6 - 16321 classified
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.87      0.34      1.00      0.49      0.58      0.32       398
                 0       0.99      1.00      0.40      0.99      0.63      0.42     15976
__NOT_CLASSIFIED__       0.00      0.00      1.00      0.00      0.00      0.00         0

       avg / total       0.98      0.98      0.41      0.98      0.63      0.42     16374

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             136 │             239 │               23 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │              21 │           15925 │               30 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛

2024-07-11 18:15:50,401:INFO:bugbug.model:
Confidence threshold > 0.7 - 16260 classified
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.91      0.32      1.00      0.48      0.57      0.30       398
                 0       0.99      1.00      0.44      0.99      0.67      0.47     15976
__NOT_CLASSIFIED__       0.00      0.00      0.99      0.00      0.00      0.00         0

       avg / total       0.98      0.98      0.46      0.98      0.66      0.46     16374

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             128 │             221 │               49 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │              12 │           15899 │               65 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛

2024-07-11 18:15:53,124:INFO:bugbug.model:
Confidence threshold > 0.8 - 16161 classified
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.94      0.30      1.00      0.45      0.54      0.28       398
                 0       0.99      0.99      0.50      0.99      0.70      0.52     15976
__NOT_CLASSIFIED__       0.00      0.00      0.99      0.00      0.00      0.00         0

       avg / total       0.99      0.97      0.51      0.98      0.70      0.51     16374

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             118 │             199 │               81 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │               7 │           15837 │              132 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛

2024-07-11 18:15:55,855:INFO:bugbug.model:
Confidence threshold > 0.9 - 15951 classified
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.97      0.27      1.00      0.42      0.52      0.25       398
                 0       0.99      0.98      0.60      0.99      0.77      0.61     15976
__NOT_CLASSIFIED__       0.00      0.00      0.97      0.00      0.00      0.00         0

       avg / total       0.99      0.96      0.61      0.97      0.76      0.60     16374

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             108 │             159 │              131 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │               3 │           15681 │              292 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛

2024-07-11 18:15:56,273:INFO:__main__:Training done
2024-07-11 18:15:56,858:INFO:__main__:Model compressed
```
</details>

<details>
<summary>Click to expand - Training after update</summary>

```bash
2024-07-12 18:04:03,132:INFO:__main__:Training *performancebug* model
2024-07-12 18:04:14,760:INFO:bugbug.models.performancebug:4013 performance bugs
2024-07-12 18:04:14,769:INFO:bugbug.models.performancebug:159720 non-performance bugs
```

---

```bash
2024-07-12 18:09:09,892:INFO:bugbug.model:X: (163733, 4), y: (163733,)
2024-07-12 18:19:32,313:INFO:bugbug.model:Cross Validation scores:
2024-07-12 18:19:32,313:INFO:bugbug.model:Accuracy: f0.9818877676396655 (+/- 0.000549037408655161)
2024-07-12 18:19:32,314:INFO:bugbug.model:Precision: f0.7904803562057097 (+/- 0.04064071480693089)
2024-07-12 18:19:32,314:INFO:bugbug.model:Recall: f0.35684647302904565 (+/- 0.03085331893465822)
2024-07-12 18:19:32,314:INFO:bugbug.model:X_train: (147359, 4), y_train: (147359,)
2024-07-12 18:19:32,314:INFO:bugbug.model:X_test: (16374, 4), y_test: (16374,)
2024-07-12 18:21:58,300:INFO:bugbug.model:Number of features: 32252
2024-07-12 18:21:58,300:INFO:bugbug.model:Model trained
2024-07-12 18:21:58,337:INFO:bugbug.model:Training Set scores:
                   pre       rec       spe        f1       geo       iba       sup

          1       0.98      0.54      1.00      0.70      0.74      0.52      3615
          0       0.99      1.00      0.54      0.99      0.74      0.57    143744

avg / total       0.99      0.99      0.56      0.99      0.74      0.57    147359

2024-07-12 18:22:20,181:INFO:bugbug.model:Test Set scores:
2024-07-12 18:22:22,572:INFO:bugbug.model:No confidence threshold - 16374 classified
                   pre       rec       spe        f1       geo       iba       sup

          1       0.81      0.36      1.00      0.50      0.60      0.34       398
          0       0.98      1.00      0.36      0.99      0.60      0.39     15976

avg / total       0.98      0.98      0.38      0.98      0.60      0.39     16374

╒════════════╤═════════════════╤═════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │
╞════════════╪═════════════════╪═════════════════╡
│ 1 (Actual) │             145 │             253 │
├────────────┼─────────────────┼─────────────────┤
│ 0 (Actual) │              35 │           15941 │
╘════════════╧═════════════════╧═════════════════╛

2024-07-12 18:22:25,103:INFO:bugbug.model:
Confidence threshold > 0.1 - 16374 classified
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: F-score is ill-defined and being set to 0.0 in labels with no true nor predicted samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.44      0.61      0.98      0.51      0.77      0.57       398
                 0       0.99      0.98      0.61      0.99      0.77      0.62     15976
__NOT_CLASSIFIED__       0.00      0.00      1.00      0.00      0.00      0.00         0

       avg / total       0.98      0.97      0.61      0.97      0.77      0.62     16374

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             241 │             157 │                0 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │             304 │           15672 │                0 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛

2024-07-12 18:22:27,826:INFO:bugbug.model:
Confidence threshold > 0.2 - 16374 classified
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: F-score is ill-defined and being set to 0.0 in labels with no true nor predicted samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.58      0.50      0.99      0.54      0.70      0.47       398
                 0       0.99      0.99      0.50      0.99      0.70      0.52     15976
__NOT_CLASSIFIED__       0.00      0.00      1.00      0.00      0.00      0.00         0

       avg / total       0.98      0.98      0.51      0.98      0.70      0.52     16374

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             199 │             199 │                0 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │             145 │           15831 │                0 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛

2024-07-12 18:22:30,524:INFO:bugbug.model:
Confidence threshold > 0.3 - 16374 classified
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: F-score is ill-defined and being set to 0.0 in labels with no true nor predicted samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.67      0.44      0.99      0.53      0.66      0.41       398
                 0       0.99      0.99      0.44      0.99      0.66      0.46     15976
__NOT_CLASSIFIED__       0.00      0.00      1.00      0.00      0.00      0.00         0

       avg / total       0.98      0.98      0.45      0.98      0.66      0.46     16374

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             175 │             223 │                0 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │              86 │           15890 │                0 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛

2024-07-12 18:22:33,275:INFO:bugbug.model:
Confidence threshold > 0.4 - 16374 classified
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: F-score is ill-defined and being set to 0.0 in labels with no true nor predicted samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.75      0.40      1.00      0.53      0.63      0.38       398
                 0       0.99      1.00      0.40      0.99      0.63      0.43     15976
__NOT_CLASSIFIED__       0.00      0.00      1.00      0.00      0.00      0.00         0

       avg / total       0.98      0.98      0.42      0.98      0.63      0.43     16374

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             161 │             237 │                0 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │              54 │           15922 │                0 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛

2024-07-12 18:22:35,940:INFO:bugbug.model:
Confidence threshold > 0.6 - 16318 classified
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.87      0.35      1.00      0.50      0.59      0.33       398
                 0       0.99      1.00      0.40      0.99      0.63      0.43     15976
__NOT_CLASSIFIED__       0.00      0.00      1.00      0.00      0.00      0.00         0

       avg / total       0.98      0.98      0.42      0.98      0.63      0.42     16374

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             139 │             237 │               22 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │              20 │           15922 │               34 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛

2024-07-12 18:22:38,595:INFO:bugbug.model:
Confidence threshold > 0.7 - 16252 classified
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.91      0.32      1.00      0.47      0.56      0.30       398
                 0       0.99      0.99      0.44      0.99      0.66      0.46     15976
__NOT_CLASSIFIED__       0.00      0.00      0.99      0.00      0.00      0.00         0

       avg / total       0.98      0.98      0.45      0.98      0.66      0.46     16374

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             127 │             223 │               48 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │              12 │           15890 │               74 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛

2024-07-12 18:22:41,309:INFO:bugbug.model:
Confidence threshold > 0.8 - 16157 classified
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.94      0.30      1.00      0.45      0.55      0.28       398
                 0       0.99      0.99      0.50      0.99      0.70      0.52     15976
__NOT_CLASSIFIED__       0.00      0.00      0.99      0.00      0.00      0.00         0

       avg / total       0.99      0.97      0.51      0.98      0.70      0.51     16374

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             119 │             199 │               80 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │               8 │           15831 │              137 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛

2024-07-12 18:22:43,974:INFO:bugbug.model:
Confidence threshold > 0.9 - 15939 classified
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
/home/promise/anaconda3/envs/bugbug/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1531: UndefinedMetricWarning: Sensitivity is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
                          pre       rec       spe        f1       geo       iba       sup

                 1       0.99      0.27      1.00      0.43      0.52      0.25       398
                 0       0.99      0.98      0.61      0.99      0.77      0.62     15976
__NOT_CLASSIFIED__       0.00      0.00      0.97      0.00      0.00      0.00         0

       avg / total       0.99      0.96      0.62      0.97      0.76      0.61     16374

╒════════════╤═════════════════╤═════════════════╤══════════════════╕
│            │   1 (Predicted) │   0 (Predicted) │   Not classified │
╞════════════╪═════════════════╪═════════════════╪══════════════════╡
│ 1 (Actual) │             109 │             157 │              132 │
├────────────┼─────────────────┼─────────────────┼──────────────────┤
│ 0 (Actual) │               1 │           15672 │              303 │
╘════════════╧═════════════════╧═════════════════╧══════════════════╛

2024-07-12 18:22:44,477:INFO:__main__:Training done
2024-07-12 18:22:45,061:INFO:__main__:Model compressed
```
</details>