### PR TITLE
[searchfox_api] Consider nested blocks when determining line numbers

### DIFF
--- a/bugbug/code_search/searchfox_api.py
+++ b/bugbug/code_search/searchfox_api.py
@@ -5,7 +5,7 @@
 
 import io
 import json
-from typing import Iterable
+from typing import Iterable, Literal
 
 import requests
 from lxml.html import HtmlElement
@@ -20,10 +20,8 @@ from bugbug.code_search.function_search import (
 
 
 # TODO: we should use commit_hash...
-def get_line_number(elements: Iterable[HtmlElement], position):
-    assert position in ("first", "end")
-
-    if position == "first":
+def get_line_number(elements: Iterable[HtmlElement], position: Literal["start", "end"]):
+    if position == "start":
         element = next(iter(elements))
     else:
         *_, element = iter(elements)

--- a/bugbug/code_search/searchfox_api.py
+++ b/bugbug/code_search/searchfox_api.py
@@ -19,7 +19,6 @@ from bugbug.code_search.function_search import (
 )
 
 
-# TODO: we should use commit_hash...
 def get_line_number(elements: Iterable[HtmlElement], position: Literal["start", "end"]):
     if position == "start":
         element = next(iter(elements))
@@ -32,6 +31,7 @@ def get_line_number(elements: Iterable[HtmlElement], position: Literal["start", 
     return int(element.get("id")[len("line-") :])
 
 
+# TODO: we should use commit_hash...
 def get_functions(commit_hash, path, symbol_name=None):
     html_session = HTMLSession()
 


### PR DESCRIPTION
This should fix the problem when the last element is a nested code block.