### PR TITLE
[fenixcomponent] Include GeckoView in training set

### DIFF
--- a/bugbug/models/fenixcomponent.py
+++ b/bugbug/models/fenixcomponent.py
@@ -89,7 +89,10 @@ class FenixComponentModel(BugModel):
                 continue
 
             # Exclude 'General' because it contains bugs that may belong to other components, thus introducing noise.
-            if bug_data["component"] == "General":
+            if (
+                bug_data["component"] == "General"
+                and bug_data["product"] != "GeckoView"
+            ):
                 continue
 
             if dateutil.parser.parse(bug_data["creation_time"]) < date_limit:

--- a/bugbug/models/fenixcomponent.py
+++ b/bugbug/models/fenixcomponent.py
@@ -85,7 +85,7 @@ class FenixComponentModel(BugModel):
         date_limit = datetime.now(timezone.utc) - relativedelta(years=2)
 
         for bug_data in bugzilla.get_bugs():
-            if bug_data["product"] != "Fenix":
+            if bug_data["product"] != "Fenix" and bug_data["product"] != "GeckoView":
                 continue
 
             # Exclude 'General' because it contains bugs that may belong to other components, thus introducing noise.

--- a/bugbug/models/fenixcomponent.py
+++ b/bugbug/models/fenixcomponent.py
@@ -85,10 +85,12 @@ class FenixComponentModel(BugModel):
         date_limit = datetime.now(timezone.utc) - relativedelta(years=2)
 
         for bug_data in bugzilla.get_bugs():
+            # Include GeckoView bugs as they are closely related to Fenix.
             if bug_data["product"] != "Fenix" and bug_data["product"] != "GeckoView":
                 continue
 
-            # Exclude 'General' because it contains bugs that may belong to other components, thus introducing noise.
+            # Exclude 'Fenix::General' because it contains bugs that may belong to other components, thus introducing unwanted noise.
+            # Include 'GeckoView::General' because the model is intended to either predict Fenix components or reclassify Fenix bugs to GeckoView.
             if (
                 bug_data["component"] == "General"
                 and bug_data["product"] != "GeckoView"

--- a/bugbug/models/fenixcomponent.py
+++ b/bugbug/models/fenixcomponent.py
@@ -85,7 +85,8 @@ class FenixComponentModel(BugModel):
         date_limit = datetime.now(timezone.utc) - relativedelta(years=2)
 
         for bug_data in bugzilla.get_bugs():
-            # Include GeckoView bugs as they are closely related to Fenix.
+            # We want the model to be aware of GeckoView bugs, as it is common
+            # for bugs filed under Fenix to end up in GeckoView.
             if bug_data["product"] != "Fenix" and bug_data["product"] != "GeckoView":
                 continue
 

--- a/bugbug/models/fenixcomponent.py
+++ b/bugbug/models/fenixcomponent.py
@@ -85,7 +85,7 @@ class FenixComponentModel(BugModel):
         date_limit = datetime.now(timezone.utc) - relativedelta(years=2)
 
         for bug_data in bugzilla.get_bugs():
-            if bug_data["product"] != "Fenix" and bug_data["product"] != "GeckoView":
+            if bug_data["product"] != "Fenix":
                 continue
 
             # Exclude 'General' because it contains bugs that may belong to other components, thus introducing noise.

--- a/bugbug/models/fenixcomponent.py
+++ b/bugbug/models/fenixcomponent.py
@@ -90,8 +90,10 @@ class FenixComponentModel(BugModel):
             if bug_data["product"] != "Fenix" and bug_data["product"] != "GeckoView":
                 continue
 
-            # Exclude 'Fenix::General' because it contains bugs that may belong to other components, thus introducing unwanted noise.
-            # Include 'GeckoView::General' because the model is intended to either predict Fenix components or reclassify Fenix bugs to GeckoView.
+            # Exclude 'General' because it contains bugs that may belong to
+            # other components, thus introducing noise. However, include
+            # 'GeckoView::General' because the model should be able to move
+            # bugs to GeckoView.
             if (
                 bug_data["component"] == "General"
                 and bug_data["product"] != "GeckoView"


### PR DESCRIPTION
Resolves #4355.

Includes GeckoView when generating labels for the training dataset for the Fenix component model.