### PR TITLE
[component] Combine all Fenix and GeckoView bugs in training set for component model

### DIFF
--- a/bugbug/models/component.py
+++ b/bugbug/models/component.py
@@ -131,11 +131,8 @@ class ComponentModel(BugModel):
         }
 
     def filter_component(self, product, component):
-        if product == "Fenix":
+        if product == "Fenix" or product == "GeckoView":
             return "Fenix"
-
-        if product == "GeckoView":
-            return "GeckoView::General"
 
         full_comp = f"{product}::{component}"
 

--- a/bugbug/models/component.py
+++ b/bugbug/models/component.py
@@ -133,6 +133,10 @@ class ComponentModel(BugModel):
     def filter_component(self, product, component):
         if product == "Fenix":
             return "Fenix"
+
+        if product == "GeckoView":
+            return "GeckoView::General"
+
         full_comp = f"{product}::{component}"
 
         if full_comp in self.CONFLATED_COMPONENTS_INVERSE_MAPPING:


### PR DESCRIPTION
Resolves #4374.

Intended to combine all Fenix and GeckoView bugs into a single class for the training set.

Linked to #4355, as these bugs will be classified generally by the component model prior to being passed into the Fenix/GeckoView-specific component model.