### PR TITLE
[inline_comments_data_collection] Add CL arguments for patch and diff length thresholds

### DIFF
--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -194,16 +194,14 @@ def main():
     parser.add_argument(
         "--diff-length-limit",
         type=int,
-        default=None,
+        default=1000,
         help="Limit the maximum allowed diff length. No limit if not specified.",
     )
 
     args = parser.parse_args()
 
-    limit = args.limit if args.limit is not None else float("inf")
-    diff_length_limit = (
-        args.diff_length_limit if args.diff_length_limit is not None else float("inf")
-    )
+    limit = args.limit or float("inf")
+    diff_length_limit = args.diff_length_limit or float("inf")
 
     os.makedirs("patches", exist_ok=True)
     os.makedirs("data", exist_ok=True)

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 import os
 import re
@@ -183,11 +184,38 @@ def process_comments(patch_threshold, diff_length_threshold):
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Process patch reviews.")
+    parser.add_argument(
+        "--patch-threshold",
+        type=int,
+        default=None,
+        help="Limit the number of patches to process. No limit if not specified.",
+    )
+    parser.add_argument(
+        "--diff-length-threshold",
+        type=int,
+        default=None,
+        help="Limit the maximum allowed diff length. No limit if not specified.",
+    )
+
+    args = parser.parse_args()
+
+    patch_threshold = (
+        args.patch_threshold if args.patch_threshold is not None else float("inf")
+    )
+    diff_length_threshold = (
+        args.diff_length_threshold
+        if args.diff_length_threshold is not None
+        else float("inf")
+    )
+
     os.makedirs("patches", exist_ok=True)
     os.makedirs("data", exist_ok=True)
 
     with open(phabricator.FIXED_COMMENTS_DB, "wb") as dataset_file_handle:
-        for data in process_comments(patch_threshold=1000, diff_length_threshold=5000):
+        for data in process_comments(
+            patch_threshold=patch_threshold, diff_length_threshold=diff_length_threshold
+        ):
             dataset_file_handle.write(orjson.dumps(data) + b"\n")
 
     zstd_compress(phabricator.FIXED_COMMENTS_DB)

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -202,18 +202,14 @@ def main():
 
     limit = args.limit if args.limit is not None else float("inf")
     diff_length_limit = (
-        args.diff_length_limit
-        if args.diff_length_threshold is not None
-        else float("inf")
+        args.diff_length_limit if args.diff_length_limit is not None else float("inf")
     )
 
     os.makedirs("patches", exist_ok=True)
     os.makedirs("data", exist_ok=True)
 
     with open(phabricator.FIXED_COMMENTS_DB, "wb") as dataset_file_handle:
-        for data in process_comments(
-            patch_threshold=limit, diff_length_threshold=diff_length_limit
-        ):
+        for data in process_comments(limit=limit, diff_length_limit=diff_length_limit):
             dataset_file_handle.write(orjson.dumps(data) + b"\n")
 
     zstd_compress(phabricator.FIXED_COMMENTS_DB)

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -23,7 +23,7 @@ ls -lh data
 rm data/commit*
 
 # Then generate a test dataset of fixed inline comments
-bugbug-fixed-comments --patch-threshold 150 --diff-length-threshold 1000
+bugbug-fixed-comments --limit 150 --diff-length-limit 1000
 ls -lh
 ls -lh data
 

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -22,6 +22,14 @@ ls -lh data
 # Removes it to ensure the commit retrieval work as expected
 rm data/commit*
 
+# Then generate a test dataset of fixed inline comments
+bugbug-fixed-comments --patch-threshold 150 --diff-length-threshold 1000
+ls -lh
+ls -lh data
+
+# Remove DB to ensure it works as expected
+rm data/fixed_comments.json
+
 # Then retrieve a subset of commit data
 bugbug-data-commits --limit 500 "${CACHE_DIR:-cache}"
 test -d ${CACHE_DIR:-cache}/mozilla-central

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -23,7 +23,7 @@ ls -lh data
 rm data/commit*
 
 # Then generate a test dataset of fixed inline comments
-bugbug-fixed-comments --limit 150 --diff-length-limit 1000
+bugbug-fixed-comments --limit 150
 ls -lh
 ls -lh data
 

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
             "bugbug-generate-landings-risk-report = scripts.generate_landings_risk_report:main",
             "bugbug-shadow-scheduler-stats = scripts.shadow_scheduler_stats:main",
             "bugbug-data-github = scripts.github_issue_retriever:main",
+            "bugbug-fixed-comments = scripts.inline_comments_data_collection:main",
         ]
     },
     classifiers=[


### PR DESCRIPTION
Resolves #4466.

Adds CL arguments for `patch-threshold` and `diff-length-threshold`, as well as an integration test.