### PR TITLE
Fixed TC issue with `inline_comments_data_collection.py`

### DIFF
--- a/bugbug/phabricator.py
+++ b/bugbug/phabricator.py
@@ -29,7 +29,7 @@ db.register(
 
 FIXED_COMMENTS_DB = "data/fixed_comments.json"
 db.register(
-    REVISIONS_DB,
+    FIXED_COMMENTS_DB,
     "https://community-tc.services.mozilla.com/api/index/v1/task/project.bugbug.fixed_comments.latest/artifacts/public/fixed_comments.json.zst",
     1,
 )

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -7,7 +7,7 @@ import orjson
 import requests
 from libmozdata.phabricator import PhabricatorAPI
 
-from bugbug import db, phabricator
+from bugbug import phabricator
 from bugbug.tools.code_review import PhabricatorReviewData
 from bugbug.utils import get_secret, zstd_compress
 
@@ -17,12 +17,6 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 api = PhabricatorAPI(get_secret("PHABRICATOR_TOKEN"))
-
-db.register(
-    phabricator.REVISIONS_DB,
-    "https://community-tc.services.mozilla.com/api/index/v1/task/project.bugbug.data_revisions.latest/artifacts/public/revisions.json.zst",
-    4,
-)
 
 
 class NoDiffsFoundException(Exception):

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -7,7 +7,7 @@ import orjson
 import requests
 from libmozdata.phabricator import PhabricatorAPI
 
-from bugbug import phabricator
+from bugbug import db, phabricator
 from bugbug.tools.code_review import PhabricatorReviewData
 from bugbug.utils import get_secret, zstd_compress
 
@@ -17,6 +17,12 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 api = PhabricatorAPI(get_secret("PHABRICATOR_TOKEN"))
+
+db.register(
+    phabricator.REVISIONS_DB,
+    "https://community-tc.services.mozilla.com/api/index/v1/task/project.bugbug.data_revisions.latest/artifacts/public/revisions.json.zst",
+    4,
+)
 
 
 class NoDiffsFoundException(Exception):


### PR DESCRIPTION
The original script was missing `db.register()`, so it was unable to download the `revisions.json` dataset. 

It has been added to ensure that the dataset can be downloaded and used to populate the `fixed_comments.json` dataset.