### PR TITLE
Phabricator API request removal for transactions

### DIFF
--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -114,8 +114,8 @@ def process_comments(limit, diff_length_limit):
                     )
                 fix_patch_id = diffs[0]["id"]
 
-            # If the most recent patch doesn't exist or is the original patch itself, skip it
-            if not fix_patch_id or fix_patch_id == patch_id:
+            # If the most recent patch is the original patch itself, skip it
+            if fix_patch_id == patch_id:
                 continue
 
             revision_phid = revision_info["phid"]

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -5,18 +5,15 @@ import re
 
 import orjson
 import requests
-from libmozdata.phabricator import PhabricatorAPI
 
 from bugbug import phabricator
 from bugbug.tools.code_review import PhabricatorReviewData
-from bugbug.utils import get_secret, zstd_compress
+from bugbug.utils import zstd_compress
 
 review_data = PhabricatorReviewData()
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-api = PhabricatorAPI(get_secret("PHABRICATOR_TOKEN"))
 
 
 class NoDiffsFoundException(Exception):

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -101,7 +101,15 @@ def process_comments(limit, diff_length_limit):
             if not most_recent_update:
                 continue
 
-            fix_patch_id = diff_phid_to_id.get(most_recent_update["fields"].get("new"))
+            try:
+                fix_patch_id = diff_phid_to_id[most_recent_update["fields"]["new"]]
+            except KeyError as ke:
+                logger.error(
+                    f"Failed to find fix patch for PHID {most_recent_update['fields']['new']}: {ke}"
+                )
+                continue
+
+            fix_patch_id = diff_phid_to_id.get(most_recent_update["fields"]["new"])
 
             # If the most recent patch doesn't exist or is the original patch itself, skip it
             if not fix_patch_id or fix_patch_id == patch_id:

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -84,8 +84,8 @@ def get_diff_info_from_phid(phid):
     return diffs[0]["id"], diffs[0]["revisionPHID"]
 
 
-def find_details_from_revision_phid(phid):
-    revision = api.load_revision(rev_phid=phid)
+def find_details_from_revision_phid(phid, revisions_map):
+    revision = revisions_map[phid]
     return revision["id"], revision["fields"]["bugzilla.bug-id"]
 
 
@@ -162,7 +162,9 @@ def process_comments(limit, diff_length_limit, revisions_map):
             if fix_patch_id == patch_id:
                 continue
 
-            revision_id, bug_id = find_details_from_revision_phid(phid=revision_phid)
+            revision_id, bug_id = find_details_from_revision_phid(
+                phid=revision_phid, revisions_map=revisions_map
+            )
 
             try:
                 previous_patch_id = find_previous_patch_id(revision_phid, fix_patch_id)


### PR DESCRIPTION
Instead of making a request to the Phabricator API for the transactions for each revision, we load it from `revisions.json`. 

An index file has also been created to store the offset of each revision in the file to avoid searching through all revisions for each patch.