### PR TITLE
Fixed artifact name for `fixed_comments.json`

### DIFF
--- a/infra/data-pipeline.yml
+++ b/infra/data-pipeline.yml
@@ -251,10 +251,10 @@ tasks:
           - "bugbug-fixed-comments"
 
         artifacts:
-          public/bugs.json.zst:
+          public/fixed_comments.json.zst:
             path: /data/fixed_comments.json.zst
             type: file
-          public/bugs.json.version:
+          public/fixed_comments.json.version:
             path: /data/fixed_comments.json.version
             type: file
 


### PR DESCRIPTION
Originally was `public/bugs.json.zst` and 'public/bugs.json.version`.

Fixed to be public/fixed_comments.json.zst` and 'public/fixed_comments.json.version`.