### PR TITLE
Misc improvements to function search prompting

### DIFF
--- a/bugbug/tools/code_review.py
+++ b/bugbug/tools/code_review.py
@@ -162,7 +162,7 @@ Review:
 {review}"""
 
 
-PROMPT_TEMPLATE_FURTHER_INFO = """Based on the patch provided below and its related summarization, identify the functions you need to examine for reviewing the patch.
+PROMPT_TEMPLATE_FURTHER_INFO = """Based on the patch provided below and its related summarization, identify the functions you don't know and need to look up for reviewing the patch.
 List the names of these functions, providing only the function names, with each name on a separate line.
 Avoid using list indicators such as hyphens or numbers.
 If no function declaration is required, just return "".

--- a/bugbug/tools/code_review.py
+++ b/bugbug/tools/code_review.py
@@ -1107,7 +1107,7 @@ class CodeReviewTool(GenerativeModelTool):
             )
 
             function_list = self.further_info_chain.run(
-                patch=patch, summarization=output_summarization
+                patch=formatted_patch, summarization=output_summarization
             ).split("\n")
 
             if self.verbose:

--- a/bugbug/tools/code_review.py
+++ b/bugbug/tools/code_review.py
@@ -1160,7 +1160,7 @@ class CodeReviewTool(GenerativeModelTool):
 
                 memory.save_context(
                     {
-                        "input": "Attached, you can find some function definitions that are used in the current patch and might be useful to you, by giving more context about the code under analysis. "
+                        "input": "Attached, you can find some function definitions that are used in the current patch and might be useful to you to have more context about the code under analysis. These functions already exist in the codebase before the patch, and can't be modified. "
                         + function_declaration_text
                     },
                     {

--- a/bugbug/tools/code_review.py
+++ b/bugbug/tools/code_review.py
@@ -1155,7 +1155,7 @@ class CodeReviewTool(GenerativeModelTool):
 
             if self.function_search is not None and len(requested_functions) > 0:
                 function_declaration_text = get_structured_functions(
-                    "Required Function", requested_functions
+                    "Function Name", requested_functions
                 )
 
                 memory.save_context(


### PR DESCRIPTION
The first commit is particularly important, as it means we were effectively never being asked to look up any function.

The prompt looked like:
```
Based on the patch provided below and its related summarization, identify the functions you don't know and need to look up for reviewing the patch.
List the names of these functions, providing only the function names, with each name on a separate line.
Avoid using list indicators such as hyphens or numbers.
If no function declaration is required, just return "".
<bugbug.tools.code_review.PhabricatorPatch object at 0x7f58c2e326e0>
...
```
instead of:
```
Based on the patch provided below and its related summarization, identify the functions you don't know and need to look up for reviewing the patch.
List the names of these functions, providing only the function names, with each name on a separate line.
Avoid using list indicators such as hyphens or numbers.
If no function declaration is required, just return "".
Based on the patch provided below and its related summarization, identify the functions you don't know and need to look up for reviewing the patch.
List the names of these functions, providing only the function names, with each name on a separate line.
Avoid using list indicators such as hyphens or numbers.
If no function declaration is required, just return "".
Filename: b/toolkit/components/pdfjs/test/browser_pdfjs_properties.js
1 + /* Any copyright is dedicated to the Public Domain.
2 +  * http://creativecommons.org/publicdomain/zero/1.0/ */
3 +
4 + const RELATIVE_DIR = "toolkit/components/pdfjs/test/";
5 + const TESTROOT = "https://example.com/browser/" + RELATIVE_DIR;
6 +
7 + /**
8 +  * Test that the pdf has the correct color thanks to the SVG filters.
9 +  */
10 + add_task(async function test() {
...
```