### PR TITLE
Downgrade imbalanced-learn from 0.13.0 to 0.12.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 amqp==5.3.1
 beautifulsoup4==4.12.3
 boto3==1.35.76
-imbalanced-learn==0.13.0
+imbalanced-learn==0.12.4
 langchain==0.3.10
 langchain-anthropic==0.3.1
 langchain-community==0.3.9


### PR DESCRIPTION
This reverts commit a0b5392d5a65d558b917cc1b3bed81ad81a7ca2e.

This should fix (temporarily) https://github.com/mozilla/bugbug/issues/4730