### PR TITLE
[searchfox_api] Handle elements without line number id

### DIFF
--- a/bugbug/code_search/searchfox_api.py
+++ b/bugbug/code_search/searchfox_api.py
@@ -25,6 +25,9 @@ def get_line_number(elements: Iterable[HtmlElement], position: Literal["start", 
     else:
         *_, element = iter(elements)
 
+    if "syn_comment" in element.get("class", ""):
+        return -1
+
     if "data-nesting-sym" in element.attrib:
         return get_line_number(element.iterdescendants(), position)
 
@@ -57,12 +60,18 @@ def get_functions(commit_hash, path, symbol_name=None):
     functions = []
 
     for sym_wrap in sym_wraps:
+        start_line = get_line_number(sym_wrap, "start")
+        end_line = get_line_number(sym_wrap, "end")
+
+        if start_line == -1 or end_line == -1:
+            continue
+
         functions.append(
             {
                 "name": sym_wrap.attrib["data-nesting-sym"][1:],
                 "path": path,
-                "start": get_line_number(sym_wrap, "start"),
-                "end": get_line_number(sym_wrap, "end"),
+                "start": start_line,
+                "end": end_line,
             }
         )
 


### PR DESCRIPTION
Resolves #4796.

We were encountering this error when running `code_review_tool_evaluator`, and it was due to elements that didn't have an ID, for example: `<span class="syn_comment"># Can't use argparse default or this choice will be always present</span>` which was from recursively getting the descendants.

I've added a conditional to only get the descendants for elements with the attribute `data-nesting-sym` if it contains an `id` starting with `line-`.