### PR TITLE
[code_review] Improve the filtering prompt

### DIFF
--- a/bugbug/tools/code_review.py
+++ b/bugbug/tools/code_review.py
@@ -103,30 +103,21 @@ Review comments for example {example_number}:
 {comments}"""
 
 
-PROMPT_TEMPLATE_FILTERING_ANALYSIS = """Please, double check the code review provided for the patch below.
-Just report the comments that are:
-- applicable for the patch;
-- consistent with the {target_code_consistency} source code;
-- focusing on reporting possible bugs, major readability regressions, or similar concerns;
-- filter out any descriptive comments;
-- filter out any praising comments.
+PROMPT_TEMPLATE_FILTERING_ANALYSIS = """Filter review comments to identify those that:
+- are consistent with the {target_code_consistency} source code;
+- focus on reporting possible bugs, major functional regressions, major issues, or similar concerns;
+- report major readability or design concerns.
 
-Do not change the contents of the comments and the report format.
-Adopt the template below as the report format:
-[
-    {{
-        "file": "com/br/main/Pressure.java",
-        "code_line": 458,
-        "comment" : "In the third code block, you are using `nsAutoStringN<256>` instead of `nsString`. This is a good change as `nsAutoStringN<256>` is more efficient for small strings. However, you should ensure that the size of `tempString` does not exceed 256 characters, as `nsAutoStringN<256>` has a fixed size."
-    }}
-]
+Exclude comments that:
+- only state obvious facts about the patch;
+- restate obvious facts about renamed variables or replaced code;
+- include praising, descriptive, or non-critical remarks
+- ask if changes are intentional or ask to ensure things exist.
+
 Do not report any explanation about your choice. Only return a valid JSON list.
 
-Review:
+Comments:
 {review}
-
-Patch:
-{patch}
 
 As examples of not expected comments, not related to the current patch, please, check some below:
     - {rejected_examples}
@@ -1242,8 +1233,7 @@ class CodeReviewTool(GenerativeModelTool):
 
         raw_output = self.filtering_chain.invoke(
             {
-                "review": output,
-                "patch": patch.raw_diff,
+                "comments": output,
                 "rejected_examples": rejected_examples,
             },
             return_only_outputs=True,

--- a/bugbug/tools/code_review.py
+++ b/bugbug/tools/code_review.py
@@ -109,9 +109,9 @@ PROMPT_TEMPLATE_FILTERING_ANALYSIS = """Filter review comments to keep those tha
 - report readability or design concerns.
 
 Exclude comments that:
-- only state obvious facts about the patch;
-- restate obvious facts about renamed variables or replaced code;
-- include praising, descriptive, or non-critical remarks
+- only describe the change;
+- restate obvious facts like renamed variables or replaced code;
+- include praising;
 - ask if changes are intentional or ask to ensure things exist.
 
 Do not report any explanation about your choice. Only return a valid JSON list.

--- a/bugbug/tools/code_review.py
+++ b/bugbug/tools/code_review.py
@@ -117,7 +117,7 @@ Exclude comments that:
 Do not report any explanation about your choice. Only return a valid JSON list.
 
 Comments:
-{review}
+{comments}
 
 As examples of not expected comments, not related to the current patch, please, check some below:
     - {rejected_examples}

--- a/bugbug/tools/code_review.py
+++ b/bugbug/tools/code_review.py
@@ -103,10 +103,10 @@ Review comments for example {example_number}:
 {comments}"""
 
 
-PROMPT_TEMPLATE_FILTERING_ANALYSIS = """Filter review comments to identify those that:
+PROMPT_TEMPLATE_FILTERING_ANALYSIS = """Filter review comments to keep those that:
 - are consistent with the {target_code_consistency} source code;
-- focus on reporting possible bugs, major functional regressions, major issues, or similar concerns;
-- report major readability or design concerns.
+- focus on reporting possible bugs, functional regressions, issues, or similar concerns;
+- report readability or design concerns.
 
 Exclude comments that:
 - only state obvious facts about the patch;


### PR DESCRIPTION
- Remove the patch, as the filtering step is focusing on tone and type of comment, rather than the contents. The patch could be useful in another potential future step where we double-check the validity;
- Rephrase the prompt to explicitly mention what to exclude;
- Remove the template instruction, as the LLM will just use the same formatting as the input.