### PR TITLE
[searchfox_api] Replace invalid escape from searchfox results

### DIFF
--- a/bugbug/code_search/searchfox_api.py
+++ b/bugbug/code_search/searchfox_api.py
@@ -105,6 +105,7 @@ def search(commit_hash, symbol_name):
 
     # A workaround to fix: https://github.com/mozilla/bugbug/issues/4448
     results = results.replace(r"<\s", r"<\\s")
+    results = results.replace(r"<\!", r"<\\!")
 
     results = json.loads(results)
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/bugbug/issues/4448