### PR TITLE
Use identifier search when searching functions in Searchfox

### DIFF
--- a/bugbug/code_search/searchfox_api.py
+++ b/bugbug/code_search/searchfox_api.py
@@ -93,7 +93,7 @@ def find_function_for_line(commit_hash, path, line):
 # TODO: we should use commit_hash...
 def search(commit_hash, symbol_name):
     r = utils.get_session("searchfox").get(
-        f"https://searchfox.org/mozilla-central/search?q={symbol_name}",
+        f"https://searchfox.org/mozilla-central/search?q=id:{symbol_name}",
         headers={
             "User-Agent": utils.get_user_agent(),
         },


### PR DESCRIPTION
This should be lighter on Searchfox, and will make requests faster.