### PR TITLE
[code_review_tool_evaluator] Drop duplicates when selecting the evaluation dataset

### DIFF
--- a/scripts/code_review_tool_evaluator.py
+++ b/scripts/code_review_tool_evaluator.py
@@ -433,7 +433,9 @@ def main(args):
             (revision_id, code_review.ReviewRequest(diff_id))
             for revision_id, diff_id in pd.read_csv(
                 get_latest_evaluation_results_file()
-            )[["revision_id", "diff_id"]].itertuples(name=None, index=False)
+            )[["revision_id", "diff_id"]]
+            .drop_duplicates()
+            .itertuples(name=None, index=False)
         )
     else:
         raise ValueError(

--- a/scripts/code_review_tool_evaluator.py
+++ b/scripts/code_review_tool_evaluator.py
@@ -429,9 +429,6 @@ def main(args):
             .itertuples(index=False)
         )
     elif args.evaluation_strategy == "same":
-        pd.read_csv(get_latest_evaluation_results_file())[
-            ["revision_id", "diff_id"]
-        ].itertuples()
         selected_review_requests = (
             (revision_id, code_review.ReviewRequest(diff_id))
             for revision_id, diff_id in pd.read_csv(


### PR DESCRIPTION
Follow up to fix a bug in https://github.com/mozilla/bugbug/commit/b766ea2c06cd4ac945131eda276a27395f463c95