### PR TITLE
Added regression test for issue #4643

### DIFF
--- a/tests/test_code_review.py
+++ b/tests/test_code_review.py
@@ -55,3 +55,41 @@ def test_find_comment_scope():
 
             for line_number, expected_scope in target_hunks.items():
                 assert find_comment_scope(patched_file, line_number) == expected_scope
+
+def test_generate_processed_output_attaches_comment_to_correct_line():
+    # Regression test for https://github.com/mozilla/bugbug/issues/4643
+    from bugbug.tools.code_review import generate_processed_output
+    from unidiff import PatchSet
+    from bugbug.tools.code_review import InlineComment
+    import json
+
+    # Mock output from the model
+    output = json.dumps([
+        {
+            "file": "example.py",
+            "code_line": 10,
+            "comment": "This is a test comment."
+        }
+    ])
+
+    # Create a mock patch set
+    patch_content = """\
+diff --git a/example.py b/example.py
+--- a/example.py
++++ b/example.py
+@@ -8,0 +9,2 @@
++def example_function():
++    pass
+"""
+    patch = PatchSet(patch_content)
+
+    # Generate processed output
+    comments = list(generate_processed_output(output, patch))
+
+    # Check that the comment is attached to the correct line
+    assert len(comments) == 1
+    assert isinstance(comments[0], InlineComment)
+    assert comments[0].filename == "example.py"
+    assert comments[0].start_line == 10
+    assert comments[0].end_line == 10
+    assert comments[0].content == "This is a test comment."


### PR DESCRIPTION
Added regression test for issue #4643, which was resolved in PR #4868.

The test below is automatically generated and serves as a regression test for PR #4868  because it:
- passes, and
- fails in the codebase before the PR.

This is part of our research at the [ZEST](https://www.ifi.uzh.ch/en/zest.html) group of University of Zurich in collaboration with [Mozilla](https://www.mozilla.org).
If you have any suggestions, questions, or simply want to learn more, feel free to contact us at konstantinos.kitsios@uzh.ch and mcastelluccio@mozilla.com.

<details>
<summary> Click to see which lines were covered.</summary>

```diff
diff --git a/bugbug/tools/code_review.py b/bugbug/tools/code_review.py
--- a/bugbug/tools/code_review.py
+++ b/bugbug/tools/code_review.py
@@ -1042,8 +1042,11 @@
                 if scope["has_added_lines"]
                 else patched_file.source_file[2:]
             ),
-            start_line=scope["line_start"],
-            end_line=scope["line_end"],
+            # Note(suhaib): We were previously using the hunk's scope instead of# ✅ Covered by above test
+            # the line number returned by the model. This was changed to reduce# ✅ Covered by above test
+            # confusion: https://github.com/mozilla/bugbug/issues/4643# ✅ Covered by above test
+            start_line=line_number,# ✅ Covered by above test
+            end_line=line_number,# ✅ Covered by above test
             content=comment["comment"],
             on_removed_code=not scope["has_added_lines"],
         )

```

Line coverage\* achieved: 100.0%

\* Line coverage is calculated over the lines added in this PR.

<details>
