### PR TITLE
[bugzilla] Rename "Fenix" to "Firefox for Android"

### DIFF
--- a/bugbug/bugzilla.py
+++ b/bugbug/bugzilla.py
@@ -40,7 +40,7 @@ PRODUCTS = (
     "DevTools",
     "Developer Infrastructure",
     "External Software Affecting Firefox",
-    "Fenix",
+    "Firefox for Android",
     "Firefox",
     "Firefox Build System",
     "Firefox for iOS",


### PR DESCRIPTION
Resolves #4922 

The bugs with the new product name have already been retrieved, as mentioned in https://github.com/mozilla/bugbug/pull/4923#issuecomment-2772847814. However, they were getting filtered out because the new product name was not in the list of the default products.