### PR TITLE
Extend deadline for the landings risk report generator task

### DIFF
--- a/infra/landings-pipeline.yml
+++ b/infra/landings-pipeline.yml
@@ -5,7 +5,7 @@ tasks:
   in:
     - ID: landings-risk-report-generator
       created: { $fromNow: "" }
-      deadline: { $fromNow: "2 hours" }
+      deadline: { $fromNow: "6 hours" }
       expires: { $fromNow: "2 weeks" }
       provisionerId: proj-bugbug
       workerType: compute-super-large


### PR DESCRIPTION
Increased the deadline for the landings-risk-report-generator task from 2 hours to 6 hours to allow more time if a run gets aborted and another one needs to be scheduled.