### PR TITLE
Fix incorrect database reference in docs

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -39,7 +39,7 @@ for revision in phabricator.get_revisions():
 ```py
 from bugbug import repository, db
 
-db.download(bugzilla.COMMITS_DB)
+db.download(repository.COMMITS_DB)
 
 for commit in repository.get_commits():
     print(commit["node"])


### PR DESCRIPTION
Replaces the incorrect use of bugzilla.COMMITS_DB with repository.COMMITS_DB in the documentation example to ensure the correct database is downloaded.