### PR TITLE
Disable fixed comments test in integration script

### DIFF
--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -23,9 +23,10 @@ ls -lh data
 rm data/commit*
 
 # Then generate a test dataset of fixed inline comments
-bugbug-fixed-comments --limit 150
-ls -lh
-ls -lh data
+# FIXME: The test is disabled temporarily due to https://github.com/mozilla/bugbug/issues/5222
+# bugbug-fixed-comments --limit 150
+# ls -lh
+# ls -lh data
 
 # Remove DB to ensure it works as expected
 rm data/fixed_comments.json


### PR DESCRIPTION
Temporary workaround for https://github.com/mozilla/bugbug/issues/5222 to be able to release a new version.