### PR TITLE
Downgrade llama-cpp-python to 0.2.90

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ langchain-google-genai==2.1.9
 langchain-mistralai==0.2.11
 langchain-openai==0.3.31
 libmozdata==0.2.11
-llama-cpp-python==0.3.16
+llama-cpp-python==0.2.90
 lmdb==1.7.3
 lxml-html-clean==0.4.2
 markdown2==2.5.4


### PR DESCRIPTION
Mitigates #5225 

Changed llama-cpp-python version from 0.3.16 to 0.2.90 in requirements.txt, to fix the build failure on macOS M1
