### PR TITLE
Handle JSON parsing errors in parse_model_output

### DIFF
--- a/bugbug/tools/code_review.py
+++ b/bugbug/tools/code_review.py
@@ -1149,7 +1149,11 @@ def parse_model_output(output: str) -> list[dict]:
     if output.startswith("```json") and output.endswith("```"):
         output = output[7:-3]
 
-    comments = json.loads(output)
+    try:
+        comments = json.loads(output)
+    except json.JSONDecodeError:
+        logger.error("Failed to parse JSON from model output: %s", output)
+        return []
 
     return comments
 


### PR DESCRIPTION
Fixes #5240 

Added error handling for JSON decoding in parse_model_output. If parsing fails, an error is logged and an empty list is returned to prevent crashes.