### PR TITLE
Use "default" instead of "tip" for Mercurial

### DIFF
--- a/bugbug/code_search/mozilla.py
+++ b/bugbug/code_search/mozilla.py
@@ -20,9 +20,9 @@ class FunctionSearchMozilla(FunctionSearch):
         self, commit_hash, path, function_name=None, line=None, fast=False
     ):
         # FIXME: we should use commit_hash. However, since not all stages support
-        # retrieving data based on commit_hash, we are using "tip" as a
+        # retrieving data based on commit_hash, we are using "default" as a
         # workaround to guarantee the integrity of the data.
-        commit_hash = "tip"
+        commit_hash = "default"
 
         # In fast mode, only use Searchfox website.
         # In slow mode (for historical data), try Searchfox first and fallback on parsing with rust-code-analysis.

--- a/bugbug/code_search/searchfox_api.py
+++ b/bugbug/code_search/searchfox_api.py
@@ -230,7 +230,7 @@ class FunctionSearchSearchfoxAPI(FunctionSearch):
                 else definition["end"],
                 read_mc_path=lambda path: io.StringIO(
                     self.get_file(
-                        commit_hash or "tip",
+                        commit_hash or "default",
                         path,
                     )
                 ),
@@ -250,7 +250,7 @@ class FunctionSearchSearchfoxAPI(FunctionSearch):
         self, commit_hash: str, path: str, line: int
     ) -> list[Function]:
         definition = find_function_for_line(
-            commit_hash or "tip",
+            commit_hash or "default",
             path,
             line,
         )
@@ -264,7 +264,7 @@ class FunctionSearchSearchfoxAPI(FunctionSearch):
         self, commit_hash: str, path: str, function_name: str
     ) -> list[Function]:
         definitions = search(
-            commit_hash or "tip",
+            commit_hash or "default",
             function_name,
         )
 
@@ -298,7 +298,7 @@ if __name__ == "__main__":
             definition["end"] + 1
             if definition["end"] != definition["start"]
             else definition["end"],
-            read_mc_path=lambda path: io.StringIO(get_file("tip", path)),
+            read_mc_path=lambda path: io.StringIO(get_file("default", path)),
         )
         result.append(
             {
@@ -322,14 +322,15 @@ if __name__ == "__main__":
             func["end"] + 1 if func["end"] != func["start"] else func["end"],
             read_mc_path=lambda path: io.StringIO(
                 get_file(
-                    "tip", "browser/components/asrouter/modules/CFRPageActions.sys.mjs"
+                    "default",
+                    "browser/components/asrouter/modules/CFRPageActions.sys.mjs",
                 )
             ),
         )
     )
 
     print("RESULT5")
-    print(search("tip", "ShouldNotProcessUpdatesReasonAsString"))
+    print(search("default", "ShouldNotProcessUpdatesReasonAsString"))
 
     print("RESULT6")
-    print(search("tip", "range"))
+    print(search("default", "range"))

--- a/bugbug/code_search/searchfox_data.py
+++ b/bugbug/code_search/searchfox_data.py
@@ -398,7 +398,7 @@ class FunctionSearchSearchfoxData(FunctionSearch):
                 definition["target_end_line"],
                 read_mc_path=lambda path: io.StringIO(
                     get_file(
-                        commit_hash or "tip",
+                        commit_hash or "default",
                         path,
                     )
                 ),
@@ -445,7 +445,7 @@ class FunctionSearchSearchfoxData(FunctionSearch):
         # If it wasn't found, try with entire file next
         if not result:
             if commit_hash is None:
-                mc_file = get_file("tip", path)
+                mc_file = get_file("default", path)
             else:
                 mc_file = get_file(commit_hash, path)
 
@@ -462,7 +462,7 @@ class FunctionSearchSearchfoxData(FunctionSearch):
                 searchfox_path,
                 read_mc_path=lambda path: io.StringIO(
                     get_file(
-                        commit_hash or "tip",
+                        commit_hash or "default",
                         path,
                     )
                 ),
@@ -488,7 +488,7 @@ class FunctionSearchSearchfoxData(FunctionSearch):
                     definition["target_end_line"],
                     read_mc_path=lambda path: io.StringIO(
                         get_file(
-                            commit_hash or "tip",
+                            commit_hash or "default",
                             path,
                         )
                     ),
@@ -586,7 +586,7 @@ if __name__ == "__main__":
             caller_function_obj,
             "",
             searchfox_path,
-            read_mc_path=lambda path: io.StringIO(get_file("tip", path)),
+            read_mc_path=lambda path: io.StringIO(get_file("default", path)),
         )
     )
     print("\n\nfind_symbol_definition1")
@@ -617,7 +617,7 @@ if __name__ == "__main__":
             definition_path,
             definition["target_line"],
             definition["target_end_line"],
-            read_mc_path=lambda path: io.StringIO(get_file("tip", path)),
+            read_mc_path=lambda path: io.StringIO(get_file("default", path)),
         )
         result.append(
             {

--- a/bugbug/repository.py
+++ b/bugbug/repository.py
@@ -360,7 +360,7 @@ def hg_modified_files(hg, commit):
         template=template,
         no_merges=True,
         rev=commit.node.encode("ascii"),
-        branch="tip",
+        branch="default",
     )
     x = hg.rawcommand(args)
     files_str, file_copies_str = x.split(b"\x00")[:-1]
@@ -872,7 +872,7 @@ def _transform(commit):
 
 
 def hg_log(
-    hg: hglib.client, revs: list[bytes], branch: str | None = "tip"
+    hg: hglib.client, revs: list[bytes], branch: str | None = "default"
 ) -> tuple[Commit, ...]:
     if len(revs) == 0:
         return tuple()
@@ -959,18 +959,18 @@ def hg_log(
     return tuple(commits)
 
 
-def _hg_log(revs: list[bytes], branch: str = "tip") -> tuple[Commit, ...]:
+def _hg_log(revs: list[bytes], branch: str = "default") -> tuple[Commit, ...]:
     return hg_log(thread_local.hg, revs, branch)
 
 
-def get_revs(hg, rev_start=0, rev_end="tip"):
+def get_revs(hg, rev_start=0, rev_end="default"):
     logger.info("Getting revs from %s to %s...", rev_start, rev_end)
 
     args = hglib.util.cmdbuilder(
         b"log",
         template="{node}\n",
         no_merges=True,
-        branch="tip",
+        branch="default",
         rev=f"{rev_start}:{rev_end}",
     )
     x = hg.rawcommand(args)
@@ -1307,7 +1307,7 @@ def close_component_mapping():
 
 
 def hg_log_multi(
-    repo_dir: str, revs: list[bytes], branch: str | None = "tip"
+    repo_dir: str, revs: list[bytes], branch: str | None = "default"
 ) -> tuple[Commit, ...]:
     if len(revs) == 0:
         return tuple()
@@ -1342,7 +1342,7 @@ def download_commits(
     repo_dir: str,
     rev_start: str | None = None,
     revs: list[bytes] | None = None,
-    branch: str | None = "tip",
+    branch: str | None = "default",
     save: bool = True,
     use_single_process: bool = False,
     include_no_bug: bool = False,
@@ -1505,7 +1505,7 @@ def clone(
         purge=True,
         sharebase=repo_dir + "-shared",
         networkattempts=7,
-        branch=b"tip",
+        branch=b"default",
         noupdate=not update,
     )
     subprocess.run(cmd, check=True)

--- a/bugbug/repository.py
+++ b/bugbug/repository.py
@@ -1335,7 +1335,11 @@ def hg_log_multi(
 @lru_cache(maxsize=None)
 def get_first_pushdate(repo_dir):
     with hglib.open(repo_dir) as hg:
-        return hg_log(hg, [b"0"])[0].pushdate
+        commits = hg_log(hg, [b"0"])
+        assert len(commits) == 1, (
+            f"There should be exactly one commit corresponding to revision 0: {commits}"
+        )
+        return commits[0].pushdate
 
 
 def download_commits(

--- a/http_service/bugbug_http/models.py
+++ b/http_service/bugbug_http/models.py
@@ -254,11 +254,11 @@ def schedule_tests(branch: str, rev: str) -> str:
     )
 
     # On "try", consider commits from other branches too (see https://bugzilla.mozilla.org/show_bug.cgi?id=1790493).
-    # On other repos, only consider "tip" commits (to exclude commits such as https://hg.mozilla.org/integration/autoland/rev/961f253985a4388008700a6a6fde80f4e17c0b4b).
+    # On other repos, only consider "default" commits (to exclude commits such as https://hg.mozilla.org/integration/autoland/rev/961f253985a4388008700a6a6fde80f4e17c0b4b).
     if branch == "try":
         repo_branch = None
     else:
-        repo_branch = "tip"
+        repo_branch = "default"
 
     # Analyze patches.
     commits = repository.download_commits(

--- a/scripts/commit_classifier.py
+++ b/scripts/commit_classifier.py
@@ -315,13 +315,13 @@ class CommitClassifier(object):
         hg_base = needed_stack[0].base_revision
         if not self.has_revision(hg, hg_base):
             logger.warning("Missing base revision {} from Phabricator".format(hg_base))
-            hg_base = "tip"
+            hg_base = "default"
 
         if hg_base:
             hg.update(rev=hg_base, clean=True)
             logger.info("Updated repo to %s", hg_base)
 
-            if self.git_repo_dir and hg_base != "tip":
+            if self.git_repo_dir and hg_base != "default":
                 try:
                     self.git_base = tuple(
                         vcs_map.mercurial_to_git(self.git_repo_dir, [hg_base])

--- a/scripts/testing_policy_stats.py
+++ b/scripts/testing_policy_stats.py
@@ -24,7 +24,7 @@ class TestingPolicyStatsGenerator(object):
         if not os.path.exists(repo_dir):
             repository.clone(repo_dir)
         else:
-            repository.pull(repo_dir, "mozilla-central", "tip")
+            repository.pull(repo_dir, "mozilla-central", "default")
 
         logger.info("Downloading commits database...")
         assert db.download(repository.COMMITS_DB, support_files_too=True)


### PR DESCRIPTION
"tip" is an ambiguous reference, it can be the current tip of any branch in the repository. In many cases on hg.mozilla.org, this ends up being a tags branch.

"default" is safer as it will always be the tip of the default branch.

This will maybe help with #5239