### PR TITLE
Remove pydriller and temporarily comment out logic to find bug-introducing commits from bugs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ orjson==3.11.3
 ortools==9.14.6206
 pandas==2.3.2
 psutil==7.0.0
-pydriller==1.12
 pyOpenSSL>=0.14  # Could not find a version that satisfies the requirement pyOpenSSL>=0.14; extra == "security" (from requests[security]>=2.7.0->libmozdata==0.1.43)
 python-dateutil==2.9.0.post0
 python-hglib==2.6.2


### PR DESCRIPTION
It no longer works. We have three options:
1. Fix it as it is now, using the git/mercurial mapping, but then we'll need to change it again later to remove Mercurial.
2. Switch it to use Git without Mercurial.
3. Temporarily disable the logic for now and re-evaluate later.

We're not really using this data anyway; it was never precise because of SZZ. So, I was leaning towards option 3.