### PR TITLE
Adds a new MCP resource endpoint to read bugs from Bugzilla

### DIFF
--- a/bugbug/tools/code_review.py
+++ b/bugbug/tools/code_review.py
@@ -517,6 +517,204 @@ class PhabricatorPatch(Patch):
         return self._revision_metadata["fields"]["title"]
 
 
+def create_bug_timeline(comments: list[dict], history: list[dict]) -> list[str]:
+    """Create a unified timeline from bug history and comments."""
+    events = []
+
+    ignored_fields = {"cc", "flagtypes.name"}
+
+    # Add history events
+    for event in history:
+        changes = [
+            change
+            for change in event["changes"]
+            if change["field_name"] not in ignored_fields
+        ]
+        if not changes:
+            continue
+
+        events.append(
+            {
+                "time": event["when"],
+                "type": "change",
+                "who": event["who"],
+                "details": changes,
+            }
+        )
+
+    # Add comments
+    for comment in comments:
+        print(comment)
+        events.append(
+            {
+                "time": comment["time"],
+                "type": "comment",
+                "who": comment["author"],
+                "id": comment["id"],
+                "count": comment["count"],
+                "text": comment["text"],
+            }
+        )
+
+    # Sort by timestamp
+    events.sort(key=lambda x: (x["time"], x["type"] == "change"))
+
+    # Format timeline
+    timeline = []
+
+    last_event = None
+    for event in events:
+        date = event["time"][:10]
+        time = event["time"][11:19]
+
+        if last_event and last_event["time"] != event["time"]:
+            timeline.append("---\n")
+
+        last_event = event
+
+        if event["type"] == "comment":
+            timeline.append(
+                f"**{date} {time}** - Comment #{event['count']} by {event['who']}"
+            )
+            timeline.append(f"{event['text']}\n")
+        else:
+            timeline.append(f"**{date} {time}** - Changes by {event['who']}")
+            for change in event["details"]:
+                field = change.get("field_name", "unknown")
+                old = change.get("removed", "")
+                new = change.get("added", "")
+                if old or new:
+                    timeline.append(f"  - {field}: '{old}' → '{new}'")
+            timeline.append("")
+
+    return timeline
+
+
+def bug_dict_to_markdown(bug):
+    md_lines = []
+
+    # Header with bug ID and summary
+    md_lines.append(
+        f"# Bug {bug.get('id', 'Unknown')} - {bug.get('summary', 'No summary')}"
+    )
+    md_lines.append("")
+
+    # Basic Information
+    md_lines.append("## Basic Information")
+    md_lines.append(f"- **Status**: {bug.get('status', 'Unknown')}")
+    md_lines.append(f"- **Severity**: {bug.get('severity', 'Unknown')}")
+    md_lines.append(f"- **Priority**: {bug.get('priority', 'Unknown')}")
+    md_lines.append(f"- **Product**: {bug.get('product', 'Unknown')}")
+    md_lines.append(f"- **Component**: {bug.get('component', 'Unknown')}")
+    md_lines.append(f"- **Version**: {bug.get('version', 'Unknown')}")
+    md_lines.append(f"- **Platform**: {bug.get('platform', 'Unknown')}")
+    md_lines.append(f"- **OS**: {bug.get('op_sys', 'Unknown')}")
+    md_lines.append(f"- **Created**: {bug.get('creation_time', 'Unknown')}")
+    md_lines.append(f"- **Last Updated**: {bug.get('last_change_time', 'Unknown')}")
+
+    if bug.get("url"):
+        md_lines.append(f"- **Related URL**: {bug['url']}")
+
+    if bug.get("keywords"):
+        md_lines.append(f"- **Keywords**: {', '.join(bug['keywords'])}")
+
+    md_lines.append("")
+
+    # People Involved
+    md_lines.append("## People Involved")
+
+    creator_detail = bug.get("creator_detail", {})
+    if creator_detail:
+        creator_name = creator_detail.get(
+            "real_name",
+            creator_detail.get("nick", creator_detail.get("email", "Unknown")),
+        )
+        md_lines.append(
+            f"- **Reporter**: {creator_name} ({creator_detail.get('email', 'No email')})"
+        )
+
+    assignee_detail = bug.get("assigned_to_detail", {})
+    if assignee_detail:
+        assignee_name = assignee_detail.get(
+            "real_name",
+            assignee_detail.get("nick", assignee_detail.get("email", "Unknown")),
+        )
+        md_lines.append(
+            f"- **Assignee**: {assignee_name} ({assignee_detail.get('email', 'No email')})"
+        )
+
+    # CC List (summarized)
+    cc_count = len(bug.get("cc", []))
+    if cc_count > 0:
+        md_lines.append(f"- **CC Count**: {cc_count} people")
+
+    md_lines.append("")
+
+    # Dependencies and Relationships
+    relationships = []
+    if bug.get("blocks"):
+        relationships.append(f"**Blocks**: {', '.join(map(str, bug['blocks']))}")
+    if bug.get("depends_on"):
+        relationships.append(
+            f"**Depends on**: {', '.join(map(str, bug['depends_on']))}"
+        )
+    if bug.get("regressed_by"):
+        relationships.append(
+            f"**Regressed by**: {', '.join(map(str, bug['regressed_by']))}"
+        )
+    if bug.get("duplicates"):
+        relationships.append(
+            f"**Duplicates**: {', '.join(map(str, bug['duplicates']))}"
+        )
+    if bug.get("see_also"):
+        relationships.append(f"**See also**: {', '.join(bug['see_also'])}")
+
+    if relationships:
+        md_lines.append("## Bug Relationships")
+        for rel in relationships:
+            md_lines.append(f"- {rel}")
+        md_lines.append("")
+
+    timeline = create_bug_timeline(bug["comments"], bug["history"])
+    if timeline:
+        md_lines.append("## Bug Timeline")
+        md_lines.append("")
+        md_lines.extend(timeline)
+
+    return "\n".join(md_lines)
+
+
+class Bug:
+    """Represents a Bugzilla bug from bugzilla.mozilla.org."""
+
+    def __init__(self, data: dict):
+        self.metadata = data
+
+    @staticmethod
+    def get(bug_id: int) -> "Bug":
+        from libmozdata.bugzilla import Bugzilla
+
+        bugs: list[dict] = []
+        Bugzilla(
+            bug_id,
+            include_fields=["_default", "comments", "history"],
+            bughandler=lambda bug, data: data.append(bug),
+            bugdata=bugs,
+        ).get_data().wait()
+
+        if len(bugs) == 0:
+            raise ValueError(f"Bug {bug_id} not found")
+
+        bug_data = bugs[0]
+        assert bug_data["id"] == bug_id
+
+        return Bug(bug_data)
+
+    def to_md(self) -> str:
+        """Return a markdown representation of the bug."""
+        return bug_dict_to_markdown(self.metadata)
+
+
 class ReviewData(ABC):
     NIT_PATTERN = re.compile(r"[^a-zA-Z0-9]nit[\s:,]", re.IGNORECASE)
 

--- a/bugbug/tools/code_review.py
+++ b/bugbug/tools/code_review.py
@@ -544,7 +544,6 @@ def create_bug_timeline(comments: list[dict], history: list[dict]) -> list[str]:
 
     # Add comments
     for comment in comments:
-        print(comment)
         events.append(
             {
                 "time": comment["time"],

--- a/bugbug/tools/code_review.py
+++ b/bugbug/tools/code_review.py
@@ -701,7 +701,7 @@ class Bug:
             bugdata=bugs,
         ).get_data().wait()
 
-        if len(bugs) == 0:
+        if not bugs:
             raise ValueError(f"Bug {bug_id} not found")
 
         bug_data = bugs[0]

--- a/bugbug/tools/code_review.py
+++ b/bugbug/tools/code_review.py
@@ -602,7 +602,6 @@ def bug_dict_to_markdown(bug):
     md_lines.append("## Basic Information")
     md_lines.append(f"- **Status**: {bug.get('status', 'Unknown')}")
     md_lines.append(f"- **Severity**: {bug.get('severity', 'Unknown')}")
-    md_lines.append(f"- **Priority**: {bug.get('priority', 'Unknown')}")
     md_lines.append(f"- **Product**: {bug.get('product', 'Unknown')}")
     md_lines.append(f"- **Component**: {bug.get('component', 'Unknown')}")
     md_lines.append(f"- **Version**: {bug.get('version', 'Unknown')}")

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -7,3 +7,6 @@ dependencies = [
     "bugbug>=0.0.590",
     "fastmcp>=2.12.0",
 ]
+
+[tool.uv.sources]
+bugbug = { path = "..", editable = true }

--- a/mcp/src/bugbug_mcp/server.py
+++ b/mcp/src/bugbug_mcp/server.py
@@ -11,7 +11,7 @@ from fastmcp import FastMCP
 
 from bugbug import phabricator, utils
 from bugbug.code_search.searchfox_api import FunctionSearchSearchfoxAPI
-from bugbug.tools.code_review import PhabricatorPatch
+from bugbug.tools.code_review import Bug, PhabricatorPatch
 from bugbug.utils import get_secret
 
 mcp = FastMCP("BugBug Code Review MCP Server")
@@ -221,6 +221,12 @@ def find_function_definition(function_name: str) -> str:
         return "Function definition not found."
 
     return functions[0].source
+
+
+@mcp.resource("bugzilla://bug/{bug_id}")
+def handle_bug_view_resource(bug_id: int) -> str:
+    """Retrieve a bug from Bugzilla along side with its change history and comments."""
+    return Bug.get(bug_id).to_md()
 
 
 def main():

--- a/mcp/src/bugbug_mcp/server.py
+++ b/mcp/src/bugbug_mcp/server.py
@@ -225,7 +225,7 @@ def find_function_definition(function_name: str) -> str:
 
 @mcp.resource("bugzilla://bug/{bug_id}")
 def handle_bug_view_resource(bug_id: int) -> str:
-    """Retrieve a bug from Bugzilla along side with its change history and comments."""
+    """Retrieve a bug from Bugzilla alongside its change history and comments."""
     return Bug.get(bug_id).to_md()
 
 

--- a/mcp/src/bugbug_mcp/server.py
+++ b/mcp/src/bugbug_mcp/server.py
@@ -228,7 +228,11 @@ def find_function_definition(function_name: str) -> str:
     return functions[0].source
 
 
-@mcp.resource("bugzilla://bug/{bug_id}")
+@mcp.resource(
+    uri="bugzilla://bug/{bug_id}",
+    name="Bugzilla Bug Content",
+    mime_type="text/markdown",
+)
 def handle_bug_view_resource(bug_id: int) -> str:
     """Retrieve a bug from Bugzilla alongside its change history and comments."""
     return Bug.get(bug_id).to_md()

--- a/mcp/src/bugbug_mcp/server.py
+++ b/mcp/src/bugbug_mcp/server.py
@@ -103,10 +103,15 @@ def get_code_review_tool():
     from bugbug.tools.code_review import CodeReviewTool, ReviewCommentsDB
     from bugbug.vectordb import QdrantVectorDB
 
+    # FIXME: This is a workaround, we should refactor CodeReviewTool to not avoid this.
+    class MockLLM(RunnablePassthrough):
+        def bind_tools(self, *args, **kwargs):
+            return self
+
     review_comments_db = ReviewCommentsDB(QdrantVectorDB("diff_comments"))
 
     tool = CodeReviewTool(
-        [RunnablePassthrough()],
+        MockLLM(),
         review_comments_db=review_comments_db,
     )
 

--- a/mcp/src/bugbug_mcp/server.py
+++ b/mcp/src/bugbug_mcp/server.py
@@ -103,7 +103,7 @@ def get_code_review_tool():
     from bugbug.tools.code_review import CodeReviewTool, ReviewCommentsDB
     from bugbug.vectordb import QdrantVectorDB
 
-    # FIXME: This is a workaround, we should refactor CodeReviewTool to not avoid this.
+    # FIXME: This is a workaround, we should refactor CodeReviewTool to avoid this.
     class MockLLM(RunnablePassthrough):
         def bind_tools(self, *args, **kwargs):
             return self

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -268,7 +268,7 @@ wheels = [
 [[package]]
 name = "bugbug"
 version = "0.0.594"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../" }
 dependencies = [
     { name = "amqp" },
     { name = "beautifulsoup4" },
@@ -280,6 +280,7 @@ dependencies = [
     { name = "langchain-google-genai" },
     { name = "langchain-mistralai" },
     { name = "langchain-openai" },
+    { name = "langgraph" },
     { name = "libmozdata" },
     { name = "llama-cpp-python" },
     { name = "lmdb" },
@@ -314,10 +315,57 @@ dependencies = [
     { name = "xgboost" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/c6/d9848b02c3a44cfa60253c5eb2efaf33671de7e8e575413e92a1ce86a343/bugbug-0.0.594.tar.gz", hash = "sha256:fa47402d18004b666ffbe5b2adafe565416e090475ae05661bca4888754de6ad", size = 281502, upload-time = "2025-09-23T17:03:06.102Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/c0/a8e6069da0aa63eea31db13cf1fbbc134a5c3bb9f1017b2ec7c56afbf188/bugbug-0.0.594-py3-none-any.whl", hash = "sha256:70b46bf39f8a599cf0f60b71593e078e3444ff7d27fb9f82a37dff05d5c01b04", size = 338494, upload-time = "2025-09-23T17:03:04.152Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "amqp", specifier = "==5.3.1" },
+    { name = "beautifulsoup4", specifier = "==4.13.5" },
+    { name = "boto3", specifier = "==1.40.36" },
+    { name = "gensim", marker = "extra == 'nlp'", specifier = "==4.3.2" },
+    { name = "imbalanced-learn", specifier = "==0.13.0" },
+    { name = "langchain", specifier = "==0.3.27" },
+    { name = "langchain-anthropic", specifier = "==0.3.20" },
+    { name = "langchain-community", specifier = "==0.3.29" },
+    { name = "langchain-google-genai", specifier = "==2.1.12" },
+    { name = "langchain-mistralai", specifier = "==0.2.12" },
+    { name = "langchain-openai", specifier = "==0.3.33" },
+    { name = "langgraph", specifier = "==0.6.7" },
+    { name = "libmozdata", specifier = "==0.2.11" },
+    { name = "llama-cpp-python", specifier = "==0.2.90" },
+    { name = "lmdb", specifier = "==1.7.3" },
+    { name = "lxml-html-clean", specifier = "==0.4.2" },
+    { name = "markdown2", specifier = "==2.5.4" },
+    { name = "matplotlib", specifier = "==3.10.1" },
+    { name = "mercurial", specifier = "==7.1.1" },
+    { name = "microannotate", specifier = "==0.0.24" },
+    { name = "mozci", specifier = "==2.4.3" },
+    { name = "numpy", specifier = "==2.1.0" },
+    { name = "orjson", specifier = "==3.11.3" },
+    { name = "ortools", specifier = "==9.14.6206" },
+    { name = "pandas", specifier = "==2.3.2" },
+    { name = "psutil", specifier = "==7.1.0" },
+    { name = "pyopenssl", specifier = ">=0.14" },
+    { name = "python-dateutil", specifier = "==2.9.0.post0" },
+    { name = "python-hglib", specifier = "==2.6.2" },
+    { name = "qdrant-client", specifier = "==1.15.1" },
+    { name = "ratelimit", specifier = "==2.2.1" },
+    { name = "requests", specifier = "==2.32.5" },
+    { name = "requests-html", specifier = "==0.10.0" },
+    { name = "rs-parsepatch", specifier = "==0.4.4" },
+    { name = "scikit-learn", specifier = "==1.6.1" },
+    { name = "scipy", specifier = "==1.15.2" },
+    { name = "sendgrid", specifier = "==6.12.5" },
+    { name = "shap", extras = ["plots"], specifier = "==0.48.0" },
+    { name = "spacy", marker = "extra == 'nlp'", specifier = "==3.8.7" },
+    { name = "tabulate", specifier = "==0.9.0" },
+    { name = "taskcluster", specifier = "==90.0.3" },
+    { name = "tenacity", specifier = "==9.1.2" },
+    { name = "tqdm", specifier = "==4.67.1" },
+    { name = "unidiff", specifier = "==0.7.5" },
+    { name = "xgboost", specifier = "==2.1.4" },
+    { name = "zstandard", specifier = "==0.25.0" },
 ]
+provides-extras = ["nlp", "nn"]
 
 [[package]]
 name = "bugbug-mcp"
@@ -330,7 +378,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bugbug", specifier = ">=0.0.590" },
+    { name = "bugbug", editable = "../" },
     { name = "fastmcp", specifier = ">=2.12.0" },
 ]
 
@@ -1617,6 +1665,62 @@ wheels = [
 ]
 
 [[package]]
+name = "langgraph"
+version = "0.6.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+    { name = "langgraph-prebuilt" },
+    { name = "langgraph-sdk" },
+    { name = "pydantic" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/85/36feb25062da40ca395f6c44d0232a672842e5421885101f6faf4670b670/langgraph-0.6.7.tar.gz", hash = "sha256:ba7fd17b8220142d6a4269b6038f2b3dcbcef42cd5ecf4a4c8d9b60b010830a6", size = 465534, upload-time = "2025-09-07T16:49:42.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/06/f440922a58204dbfd10f7fdda0de0325529a159e9dc3d1038afe4b431a49/langgraph-0.6.7-py3-none-any.whl", hash = "sha256:c724dd8c24806b70faf4903e8e20c0234f8c0a356e0e96a88035cbecca9df2cf", size = 153329, upload-time = "2025-09-07T16:49:40.45Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "ormsgpack" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/3e/d00eb2b56c3846a0cabd2e5aa71c17a95f882d4f799a6ffe96a19b55eba9/langgraph_checkpoint-2.1.1.tar.gz", hash = "sha256:72038c0f9e22260cb9bff1f3ebe5eb06d940b7ee5c1e4765019269d4f21cf92d", size = 136256, upload-time = "2025-07-17T13:07:52.411Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/dd/64686797b0927fb18b290044be12ae9d4df01670dce6bb2498d5ab65cb24/langgraph_checkpoint-2.1.1-py3-none-any.whl", hash = "sha256:5a779134fd28134a9a83d078be4450bbf0e0c79fdf5e992549658899e6fc5ea7", size = 43925, upload-time = "2025-07-17T13:07:51.023Z" },
+]
+
+[[package]]
+name = "langgraph-prebuilt"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/21/9b198d11732101ee8cdf30af98d0b4f11254c768de15173e57f5260fd14b/langgraph_prebuilt-0.6.4.tar.gz", hash = "sha256:e9e53b906ee5df46541d1dc5303239e815d3ec551e52bb03dd6463acc79ec28f", size = 125695, upload-time = "2025-08-07T18:17:57.333Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7f/973b0d9729d9693d6e5b4bc5f3ae41138d194cb7b16b0ed230020beeb13a/langgraph_prebuilt-0.6.4-py3-none-any.whl", hash = "sha256:819f31d88b84cb2729ff1b79db2d51e9506b8fb7aaacfc0d359d4fe16e717344", size = 28025, upload-time = "2025-08-07T18:17:56.493Z" },
+]
+
+[[package]]
+name = "langgraph-sdk"
+version = "0.2.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "orjson" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/d8/40e01190a73c564a4744e29a6c902f78d34d43dad9b652a363a92a67059c/langgraph_sdk-0.2.9.tar.gz", hash = "sha256:b3bd04c6be4fa382996cd2be8fbc1e7cc94857d2bc6b6f4599a7f2a245975303", size = 99802, upload-time = "2025-09-20T18:49:14.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/05/b2d34e16638241e6f27a6946d28160d4b8b641383787646d41a3727e0896/langgraph_sdk-0.2.9-py3-none-any.whl", hash = "sha256:fbf302edadbf0fb343596f91c597794e936ef68eebc0d3e1d358b6f9f72a1429", size = 56752, upload-time = "2025-09-20T18:49:13.346Z" },
+]
+
+[[package]]
 name = "langsmith"
 version = "0.4.21"
 source = { registry = "https://pypi.org/simple" }
@@ -2359,6 +2463,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/09/17d9d2b60592890ff7382e591aa1d9afb202a266b180c3d4049b1ec70e4a/orjson-3.11.3-cp314-cp314-win32.whl", hash = "sha256:0c6d7328c200c349e3a4c6d8c83e0a5ad029bdc2d417f234152bf34842d0fc8d", size = 136266, upload-time = "2025-08-26T17:46:13.853Z" },
     { url = "https://files.pythonhosted.org/packages/15/58/358f6846410a6b4958b74734727e582ed971e13d335d6c7ce3e47730493e/orjson-3.11.3-cp314-cp314-win_amd64.whl", hash = "sha256:317bbe2c069bbc757b1a2e4105b64aacd3bc78279b66a6b9e51e846e4809f804", size = 131351, upload-time = "2025-08-26T17:46:15.27Z" },
     { url = "https://files.pythonhosted.org/packages/28/01/d6b274a0635be0468d4dbd9cafe80c47105937a0d42434e805e67cd2ed8b/orjson-3.11.3-cp314-cp314-win_arm64.whl", hash = "sha256:e8f6a7a27d7b7bec81bd5924163e9af03d49bbb63013f107b48eb5d16db711bc", size = 125985, upload-time = "2025-08-26T17:46:16.67Z" },
+]
+
+[[package]]
+name = "ormsgpack"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/36/44eed5ef8ce93cded76a576780bab16425ce7876f10d3e2e6265e46c21ea/ormsgpack-1.10.0.tar.gz", hash = "sha256:7f7a27efd67ef22d7182ec3b7fa7e9d147c3ad9be2a24656b23c989077e08b16", size = 58629, upload-time = "2025-05-24T19:07:53.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/95/f3ab1a7638f6aa9362e87916bb96087fbbc5909db57e19f12ad127560e1e/ormsgpack-1.10.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:4e159d50cd4064d7540e2bc6a0ab66eab70b0cc40c618b485324ee17037527c0", size = 376806, upload-time = "2025-05-24T19:07:17.221Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/2b/42f559f13c0b0f647b09d749682851d47c1a7e48308c43612ae6833499c8/ormsgpack-1.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eeb47c85f3a866e29279d801115b554af0fefc409e2ed8aa90aabfa77efe5cc6", size = 204433, upload-time = "2025-05-24T19:07:18.569Z" },
+    { url = "https://files.pythonhosted.org/packages/45/42/1ca0cb4d8c80340a89a4af9e6d8951fb8ba0d076a899d2084eadf536f677/ormsgpack-1.10.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c28249574934534c9bd5dce5485c52f21bcea0ee44d13ece3def6e3d2c3798b5", size = 215547, upload-time = "2025-05-24T19:07:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/38/184a570d7c44c0260bc576d1daaac35b2bfd465a50a08189518505748b9a/ormsgpack-1.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1957dcadbb16e6a981cd3f9caef9faf4c2df1125e2a1b702ee8236a55837ce07", size = 216746, upload-time = "2025-05-24T19:07:21.83Z" },
+    { url = "https://files.pythonhosted.org/packages/69/2f/1aaffd08f6b7fdc2a57336a80bdfb8df24e6a65ada5aa769afecfcbc6cc6/ormsgpack-1.10.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b29412558c740bf6bac156727aa85ac67f9952cd6f071318f29ee72e1a76044", size = 384783, upload-time = "2025-05-24T19:07:23.674Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/63/3e53d6f43bb35e00c98f2b8ab2006d5138089ad254bc405614fbf0213502/ormsgpack-1.10.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:6933f350c2041ec189fe739f0ba7d6117c8772f5bc81f45b97697a84d03020dd", size = 479076, upload-time = "2025-05-24T19:07:25.047Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/19/fa1121b03b61402bb4d04e35d164e2320ef73dfb001b57748110319dd014/ormsgpack-1.10.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a86de06d368fcc2e58b79dece527dc8ca831e0e8b9cec5d6e633d2777ec93d0", size = 390447, upload-time = "2025-05-24T19:07:26.568Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/0d/73143ecb94ac4a5dcba223402139240a75dee0cc6ba8a543788a5646407a/ormsgpack-1.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:35fa9f81e5b9a0dab42e09a73f7339ecffdb978d6dbf9deb2ecf1e9fc7808722", size = 121401, upload-time = "2025-05-24T19:07:28.308Z" },
+    { url = "https://files.pythonhosted.org/packages/61/f8/ec5f4e03268d0097545efaab2893aa63f171cf2959cb0ea678a5690e16a1/ormsgpack-1.10.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:8d816d45175a878993b7372bd5408e0f3ec5a40f48e2d5b9d8f1cc5d31b61f1f", size = 376806, upload-time = "2025-05-24T19:07:29.555Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/19/b3c53284aad1e90d4d7ed8c881a373d218e16675b8b38e3569d5b40cc9b8/ormsgpack-1.10.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a90345ccb058de0f35262893751c603b6376b05f02be2b6f6b7e05d9dd6d5643", size = 204433, upload-time = "2025-05-24T19:07:30.977Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0b/845c258f59df974a20a536c06cace593698491defdd3d026a8a5f9b6e745/ormsgpack-1.10.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:144b5e88f1999433e54db9d637bae6fe21e935888be4e3ac3daecd8260bd454e", size = 215549, upload-time = "2025-05-24T19:07:32.345Z" },
+    { url = "https://files.pythonhosted.org/packages/61/56/57fce8fb34ca6c9543c026ebebf08344c64dbb7b6643d6ddd5355d37e724/ormsgpack-1.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2190b352509d012915921cca76267db136cd026ddee42f1b0d9624613cc7058c", size = 216747, upload-time = "2025-05-24T19:07:34.075Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/3f/655b5f6a2475c8d209f5348cfbaaf73ce26237b92d79ef2ad439407dd0fa/ormsgpack-1.10.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:86fd9c1737eaba43d3bb2730add9c9e8b5fbed85282433705dd1b1e88ea7e6fb", size = 384785, upload-time = "2025-05-24T19:07:35.83Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/94/687a0ad8afd17e4bce1892145d6a1111e58987ddb176810d02a1f3f18686/ormsgpack-1.10.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:33afe143a7b61ad21bb60109a86bb4e87fec70ef35db76b89c65b17e32da7935", size = 479076, upload-time = "2025-05-24T19:07:37.533Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/34/68925232e81e0e062a2f0ac678f62aa3b6f7009d6a759e19324dbbaebae7/ormsgpack-1.10.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f23d45080846a7b90feabec0d330a9cc1863dc956728412e4f7986c80ab3a668", size = 390446, upload-time = "2025-05-24T19:07:39.469Z" },
+    { url = "https://files.pythonhosted.org/packages/12/ad/f4e1a36a6d1714afb7ffb74b3ababdcb96529cf4e7a216f9f7c8eda837b6/ormsgpack-1.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:534d18acb805c75e5fba09598bf40abe1851c853247e61dda0c01f772234da69", size = 121399, upload-time = "2025-05-24T19:07:40.854Z" },
 ]
 
 [[package]]
@@ -3931,6 +4059,44 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/53/37032dca20dae7a88ad1907f817a81f232ca6e935f0c28c98db3c0a0bd22/xgboost-2.1.4-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:d366097d0db047315736f46af852feaa907f6d7371716af741cdce488ae36d20", size = 4206715, upload-time = "2025-02-06T18:17:08.448Z" },
     { url = "https://files.pythonhosted.org/packages/e4/3c/e3a93bfa7e8693c825df5ec02a40f7ff5f0950e02198b1e85da9315a8d47/xgboost-2.1.4-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:8df6da72963969ab2bf49a520c3e147b1e15cbeddd3aa0e3e039b3532c739339", size = 223642416, upload-time = "2025-02-06T18:17:25.08Z" },
     { url = "https://files.pythonhosted.org/packages/43/80/0b5a2dfcf5b4da27b0b68d2833f05d77e1a374d43db951fca200a1f12a52/xgboost-2.1.4-py3-none-win_amd64.whl", hash = "sha256:8bbfe4fedc151b83a52edbf0de945fd94358b09a81998f2945ad330fd5f20cd6", size = 124910381, upload-time = "2025-02-06T18:17:43.202Z" },
+]
+
+[[package]]
+name = "xxhash"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/5e/d6e5258d69df8b4ed8c83b6664f2b47d30d2dec551a29ad72a6c69eafd31/xxhash-3.5.0.tar.gz", hash = "sha256:84f2caddf951c9cbf8dc2e22a89d4ccf5d86391ac6418fe81e3c67d0cf60b45f", size = 84241, upload-time = "2024-08-17T09:20:38.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/0e/1bfce2502c57d7e2e787600b31c83535af83746885aa1a5f153d8c8059d6/xxhash-3.5.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:14470ace8bd3b5d51318782cd94e6f94431974f16cb3b8dc15d52f3b69df8e00", size = 31969, upload-time = "2024-08-17T09:18:24.025Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/d6/8ca450d6fe5b71ce521b4e5db69622383d039e2b253e9b2f24f93265b52c/xxhash-3.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:59aa1203de1cb96dbeab595ded0ad0c0056bb2245ae11fac11c0ceea861382b9", size = 30787, upload-time = "2024-08-17T09:18:25.318Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/84/de7c89bc6ef63d750159086a6ada6416cc4349eab23f76ab870407178b93/xxhash-3.5.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08424f6648526076e28fae6ea2806c0a7d504b9ef05ae61d196d571e5c879c84", size = 220959, upload-time = "2024-08-17T09:18:26.518Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/86/51258d3e8a8545ff26468c977101964c14d56a8a37f5835bc0082426c672/xxhash-3.5.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:61a1ff00674879725b194695e17f23d3248998b843eb5e933007ca743310f793", size = 200006, upload-time = "2024-08-17T09:18:27.905Z" },
+    { url = "https://files.pythonhosted.org/packages/02/0a/96973bd325412feccf23cf3680fd2246aebf4b789122f938d5557c54a6b2/xxhash-3.5.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f2f2c61bee5844d41c3eb015ac652a0229e901074951ae48581d58bfb2ba01be", size = 428326, upload-time = "2024-08-17T09:18:29.335Z" },
+    { url = "https://files.pythonhosted.org/packages/11/a7/81dba5010f7e733de88af9555725146fc133be97ce36533867f4c7e75066/xxhash-3.5.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d32a592cac88d18cc09a89172e1c32d7f2a6e516c3dfde1b9adb90ab5df54a6", size = 194380, upload-time = "2024-08-17T09:18:30.706Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7d/f29006ab398a173f4501c0e4977ba288f1c621d878ec217b4ff516810c04/xxhash-3.5.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70dabf941dede727cca579e8c205e61121afc9b28516752fd65724be1355cc90", size = 207934, upload-time = "2024-08-17T09:18:32.133Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6e/6e88b8f24612510e73d4d70d9b0c7dff62a2e78451b9f0d042a5462c8d03/xxhash-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e5d0ddaca65ecca9c10dcf01730165fd858533d0be84c75c327487c37a906a27", size = 216301, upload-time = "2024-08-17T09:18:33.474Z" },
+    { url = "https://files.pythonhosted.org/packages/af/51/7862f4fa4b75a25c3b4163c8a873f070532fe5f2d3f9b3fc869c8337a398/xxhash-3.5.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3e5b5e16c5a480fe5f59f56c30abdeba09ffd75da8d13f6b9b6fd224d0b4d0a2", size = 203351, upload-time = "2024-08-17T09:18:34.889Z" },
+    { url = "https://files.pythonhosted.org/packages/22/61/8d6a40f288f791cf79ed5bb113159abf0c81d6efb86e734334f698eb4c59/xxhash-3.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:149b7914451eb154b3dfaa721315117ea1dac2cc55a01bfbd4df7c68c5dd683d", size = 210294, upload-time = "2024-08-17T09:18:36.355Z" },
+    { url = "https://files.pythonhosted.org/packages/17/02/215c4698955762d45a8158117190261b2dbefe9ae7e5b906768c09d8bc74/xxhash-3.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:eade977f5c96c677035ff39c56ac74d851b1cca7d607ab3d8f23c6b859379cab", size = 414674, upload-time = "2024-08-17T09:18:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/31/5c/b7a8db8a3237cff3d535261325d95de509f6a8ae439a5a7a4ffcff478189/xxhash-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fa9f547bd98f5553d03160967866a71056a60960be00356a15ecc44efb40ba8e", size = 192022, upload-time = "2024-08-17T09:18:40.138Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e3/dd76659b2811b3fd06892a8beb850e1996b63e9235af5a86ea348f053e9e/xxhash-3.5.0-cp312-cp312-win32.whl", hash = "sha256:f7b58d1fd3551b8c80a971199543379be1cee3d0d409e1f6d8b01c1a2eebf1f8", size = 30170, upload-time = "2024-08-17T09:18:42.163Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/6b/1c443fe6cfeb4ad1dcf231cdec96eb94fb43d6498b4469ed8b51f8b59a37/xxhash-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:fa0cafd3a2af231b4e113fba24a65d7922af91aeb23774a8b78228e6cd785e3e", size = 30040, upload-time = "2024-08-17T09:18:43.699Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/eb/04405305f290173acc0350eba6d2f1a794b57925df0398861a20fbafa415/xxhash-3.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:586886c7e89cb9828bcd8a5686b12e161368e0064d040e225e72607b43858ba2", size = 26796, upload-time = "2024-08-17T09:18:45.29Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/e4b3ad92d249be5c83fa72916c9091b0965cb0faeff05d9a0a3870ae6bff/xxhash-3.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:37889a0d13b0b7d739cfc128b1c902f04e32de17b33d74b637ad42f1c55101f6", size = 31795, upload-time = "2024-08-17T09:18:46.813Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d8/b3627a0aebfbfa4c12a41e22af3742cf08c8ea84f5cc3367b5de2d039cce/xxhash-3.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:97a662338797c660178e682f3bc180277b9569a59abfb5925e8620fba00b9fc5", size = 30792, upload-time = "2024-08-17T09:18:47.862Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cc/762312960691da989c7cd0545cb120ba2a4148741c6ba458aa723c00a3f8/xxhash-3.5.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f85e0108d51092bdda90672476c7d909c04ada6923c14ff9d913c4f7dc8a3bc", size = 220950, upload-time = "2024-08-17T09:18:49.06Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e9/cc266f1042c3c13750e86a535496b58beb12bf8c50a915c336136f6168dc/xxhash-3.5.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd2fd827b0ba763ac919440042302315c564fdb797294d86e8cdd4578e3bc7f3", size = 199980, upload-time = "2024-08-17T09:18:50.445Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/85/a836cd0dc5cc20376de26b346858d0ac9656f8f730998ca4324921a010b9/xxhash-3.5.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:82085c2abec437abebf457c1d12fccb30cc8b3774a0814872511f0f0562c768c", size = 428324, upload-time = "2024-08-17T09:18:51.988Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0e/15c243775342ce840b9ba34aceace06a1148fa1630cd8ca269e3223987f5/xxhash-3.5.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07fda5de378626e502b42b311b049848c2ef38784d0d67b6f30bb5008642f8eb", size = 194370, upload-time = "2024-08-17T09:18:54.164Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a1/b028bb02636dfdc190da01951d0703b3d904301ed0ef6094d948983bef0e/xxhash-3.5.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c279f0d2b34ef15f922b77966640ade58b4ccdfef1c4d94b20f2a364617a493f", size = 207911, upload-time = "2024-08-17T09:18:55.509Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d5/73c73b03fc0ac73dacf069fdf6036c9abad82de0a47549e9912c955ab449/xxhash-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:89e66ceed67b213dec5a773e2f7a9e8c58f64daeb38c7859d8815d2c89f39ad7", size = 216352, upload-time = "2024-08-17T09:18:57.073Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2a/5043dba5ddbe35b4fe6ea0a111280ad9c3d4ba477dd0f2d1fe1129bda9d0/xxhash-3.5.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bcd51708a633410737111e998ceb3b45d3dbc98c0931f743d9bb0a209033a326", size = 203410, upload-time = "2024-08-17T09:18:58.54Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b2/9a8ded888b7b190aed75b484eb5c853ddd48aa2896e7b59bbfbce442f0a1/xxhash-3.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3ff2c0a34eae7df88c868be53a8dd56fbdf592109e21d4bfa092a27b0bf4a7bf", size = 210322, upload-time = "2024-08-17T09:18:59.943Z" },
+    { url = "https://files.pythonhosted.org/packages/98/62/440083fafbc917bf3e4b67c2ade621920dd905517e85631c10aac955c1d2/xxhash-3.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:4e28503dccc7d32e0b9817aa0cbfc1f45f563b2c995b7a66c4c8a0d232e840c7", size = 414725, upload-time = "2024-08-17T09:19:01.332Z" },
+    { url = "https://files.pythonhosted.org/packages/75/db/009206f7076ad60a517e016bb0058381d96a007ce3f79fa91d3010f49cc2/xxhash-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a6c50017518329ed65a9e4829154626f008916d36295b6a3ba336e2458824c8c", size = 192070, upload-time = "2024-08-17T09:19:03.007Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/6d/c61e0668943a034abc3a569cdc5aeae37d686d9da7e39cf2ed621d533e36/xxhash-3.5.0-cp313-cp313-win32.whl", hash = "sha256:53a068fe70301ec30d868ece566ac90d873e3bb059cf83c32e76012c889b8637", size = 30172, upload-time = "2024-08-17T09:19:04.355Z" },
+    { url = "https://files.pythonhosted.org/packages/96/14/8416dce965f35e3d24722cdf79361ae154fa23e2ab730e5323aa98d7919e/xxhash-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:80babcc30e7a1a484eab952d76a4f4673ff601f54d5142c26826502740e70b43", size = 30041, upload-time = "2024-08-17T09:19:05.435Z" },
+    { url = "https://files.pythonhosted.org/packages/27/ee/518b72faa2073f5aa8e3262408d284892cb79cf2754ba0c3a5870645ef73/xxhash-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:4811336f1ce11cac89dcbd18f3a25c527c16311709a89313c3acaf771def2d4b", size = 26801, upload-time = "2024-08-17T09:19:06.547Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Resolves #5292

Introduces a Bug class and markdown export utilities to bugbug.tools.code_review.py for representing Bugzilla bugs, including their history and comments. Adds a new MCP resource endpoint in server.py to retrieve and render bug details in markdown format for a given bug ID.