### PR TITLE
Use formatted_patch in review prompt generation

### DIFF
--- a/bugbug/tools/code_review.py
+++ b/bugbug/tools/code_review.py
@@ -1798,7 +1798,7 @@ class CodeReviewTool(GenerativeModelTool):
 
         created_before = patch.date_created if self.is_experiment_env else None
         message = PROMPT_TEMPLATE_REVIEW.format(
-            patch=patch.raw_diff,
+            patch=formatted_patch,
             patch_summarization=output_summarization,
             comment_examples=self._get_comment_examples(patch, created_before),
             approved_examples=self._get_generated_examples(patch, created_before),


### PR DESCRIPTION
Fixes #5317 

Regressed by #5268

Replaces patch.raw_diff with formatted_patch when generating the review prompt message.


## Test

Before this PR:

```
File                              Line  Comment
------------------------------  ------  --------------------------------------------------------------------------------------------------
toolkit/components/pdfjs/PdfJs      27  This creates a duplicate preference declaration for EARLY_BETA_OR_EARLIER builds. The same pref is
OverridePrefs.js                        set on line 29 within the conditional block. Remove the declaration from line 29 to avoid
                                        redundancy.
```

After this PR:

```
File                              Line  Comment
------------------------------  ------  ------------------------------------------------------------------------------------
toolkit/components/pdfjs/PdfJs      27  This preference is now duplicated: it's set here on line 27 and again on line 30 for
OverridePrefs.js                        EARLY_BETA_OR_EARLIER builds. Remove the duplicate on line 30 to avoid redundancy.
```