### PR TITLE
Enable editable install and live code reload in Docker for http_service

### DIFF
--- a/http_service/Dockerfile
+++ b/http_service/Dockerfile
@@ -10,7 +10,7 @@ RUN pip install --disable-pip-version-check --quiet --no-cache-dir -r /requireme
 COPY . /code/http_service
 # Use same version as bugbug
 RUN python -c "import importlib.metadata; print(importlib.metadata.version('bugbug'))" > /code/http_service/VERSION
-RUN pip install --disable-pip-version-check --no-cache-dir /code/http_service
+RUN pip install --disable-pip-version-check --no-cache-dir -e /code/http_service
 
 # Run the Pulse listener in the background
 CMD (bugbug-http-pulse-listener &) && gunicorn -b 0.0.0.0:$PORT bugbug_http.app --preload --timeout 30 -w 3

--- a/http_service/docker-compose.yml
+++ b/http_service/docker-compose.yml
@@ -3,6 +3,13 @@ services:
   bugbug-http-service:
     build:
       context: .
+    develop:
+      watch:
+        - action: sync+restart
+          path: .
+          target: /code/http_service
+          initial_sync: true
+
     image: mozilla/bugbug-http-service
     environment:
       - BUGBUG_BUGZILLA_TOKEN


### PR DESCRIPTION
Resolves #5370

Switches to an editable install of http_service in the Dockerfile and adds a develop/watch section to docker-compose.yml for live code syncing and automatic container restart during development.