### PR TITLE
Run generate_diffs and retrieve_logs in parallel

### DIFF
--- a/scripts/retrieve_ci_failures.py
+++ b/scripts/retrieve_ci_failures.py
@@ -363,7 +363,7 @@ def main() -> None:
             try:
                 _ = task.result()
             except Exception as e:
-                logger.error(f"Task failed with exception {e}")
+                raise e
 
     write_results(fixed_by_commit_pushes)
 


### PR DESCRIPTION
## Description
This change enables the _retrieve_ci_failures_ script to run **generate_diffs** and **retrieve_logs** functions concurrently.

## Linked Issue
Closes #5401 

## Implementation Details
Since we have blocking network calls in both of the functions, I concluded it would be better to implement threading  rather than going for an async approach.