### PR TITLE
Revert "Bump scikit-learn from 1.6.1 to 1.7.2 (#5332)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ ratelimit==2.2.1
 requests==2.32.5
 requests-html==0.10.0
 rs_parsepatch==0.4.4
-scikit-learn==1.7.2
+scikit-learn==1.6.1
 scipy==1.16.3
 sendgrid==6.12.5
 shap[plots]==0.49.1


### PR DESCRIPTION
This reverts commit e592f7c033c203cfb5661b60ee7a70fb542a2745.

Train on Taskcluster: stepstoreproduce