### PR TITLE
Revert "Bump xgboost from 3.1.0 to 3.1.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,5 +41,5 @@ taskcluster==91.1.2
 tenacity==9.1.2
 tqdm==4.67.1
 unidiff==0.7.5
-xgboost==3.1.1
+xgboost==3.1.0
 zstandard==0.25.0


### PR DESCRIPTION
Reverts mozilla/bugbug#5376

Train on Taskcluster: stepstoreproduce