### PR TITLE
Fix the branch name in the repository.pull

### DIFF
--- a/http_service/bugbug_http/models.py
+++ b/http_service/bugbug_http/models.py
@@ -311,7 +311,7 @@ def schedule_tests_from_patch(base_rev: str, patch_hash: str) -> str:
 
     # Pull the base revision to the local repository
     LOGGER.info("Pulling base revision from the remote repository...")
-    repository.pull(REPO_DIR, "autoland", hg_base_rev)
+    repository.pull(REPO_DIR, "integration/autoland", hg_base_rev)
 
     LOGGER.info("Generating commit from patch...")
     commit = repository.generate_commit_from_raw_patch(


### PR DESCRIPTION
Changed the branch name in the repository.pull call from 'autoland' to 'integration/autoland'.

Follow up on #5366