### PR TITLE
Replace Marco's email in Taskcluster failure notification hooks

### DIFF
--- a/infra/taskcluster-hook-classify-patch.json
+++ b/infra/taskcluster-hook-classify-patch.json
@@ -62,7 +62,7 @@
     "provisionerId": "proj-bugbug",
     "retries": 5,
     "routes": [
-      "notify.email.mcastelluccio@mozilla.com.on-failed",
+      "notify.email.bugbug-team@mozilla.com.on-failed",
       "index.project.bugbug.classify_patch.latest",
       "index.project.bugbug.classify_patch.diff.${payload['DIFF_ID']}"
     ],

--- a/infra/taskcluster-hook-test-select.json
+++ b/infra/taskcluster-hook-test-select.json
@@ -60,7 +60,7 @@
     "provisionerId": "proj-bugbug",
     "retries": 5,
     "routes": [
-      "notify.email.mcastelluccio@mozilla.com.on-failed",
+      "notify.email.bugbug-team@mozilla.com.on-failed",
       "index.project.bugbug.test_select.latest",
       "index.project.bugbug.test_select.diff.${payload['DIFF_ID']}",
       "project.bugbug.test_select"


### PR DESCRIPTION
Follow up on #5429 

Changed the notification email in both classify-patch and test-select Taskcluster hook configs from mcastelluccio@mozilla.com to bugbug-team@mozilla.com to direct failure alerts to the team address.