### PR TITLE
Replace lambda tenacity.retry patterns with Retrying code blocks

### DIFF
--- a/scripts/regressor_finder.py
+++ b/scripts/regressor_finder.py
@@ -84,30 +84,31 @@ class RegressorFinder(object):
 
     def clone_git_repo(self, repo_url, repo_dir):
         if not os.path.exists(repo_dir):
-            tenacity.retry(
+            for attempt in tenacity.Retrying(
                 wait=tenacity.wait_exponential(multiplier=2, min=2),
                 stop=tenacity.stop_after_attempt(7),
-            )(
-                lambda: subprocess.run(
-                    ["git", "clone", "--quiet", repo_url, repo_dir], check=True
-                )
-            )()
+            ):
+                with attempt:
+                    subprocess.run(
+                        ["git", "clone", "--quiet", repo_url, repo_dir],
+                        check=True,
+                    )
 
             logger.info("%s cloned", repo_dir)
 
         logger.info("Fetching %s", repo_dir)
 
-        tenacity.retry(
+        for attempt in tenacity.Retrying(
             wait=tenacity.wait_exponential(multiplier=2, min=2),
             stop=tenacity.stop_after_attempt(7),
-        )(
-            lambda: subprocess.run(
-                ["git", "fetch", "--quiet"],
-                cwd=repo_dir,
-                capture_output=True,
-                check=True,
-            )
-        )()
+        ):
+            with attempt:
+                subprocess.run(
+                    ["git", "fetch", "--quiet"],
+                    cwd=repo_dir,
+                    capture_output=True,
+                    check=True,
+                )
 
         logger.info("%s fetched", repo_dir)
 

--- a/scripts/retrieve_ci_failures.py
+++ b/scripts/retrieve_ci_failures.py
@@ -257,15 +257,15 @@ def diff_failure_vs_fix(repo, failure_commits, fix_commits):
 
 def generate_diffs(repo_url, repo_path, fixed_by_commit_pushes, upload):
     if not os.path.exists(repo_path):
-        tenacity.retry(
+        for attempt in tenacity.Retrying(
             wait=tenacity.wait_exponential(multiplier=2, min=2),
             stop=tenacity.stop_after_attempt(7),
-        )(
-            lambda: subprocess.run(
-                ["git", "clone", repo_url, repo_path],
-                check=True,
-            )
-        )()
+        ):
+            with attempt:
+                subprocess.run(
+                    ["git", "clone", repo_url, repo_path],
+                    check=True,
+                )
 
     os.makedirs(os.path.join("data", "ci_failures_diffs"), exist_ok=True)
 


### PR DESCRIPTION
This PR implements the change requested in issue #5423 .

## Summary 
Replaced the pattern of using `tenacity.retry(...)(lambda: ...)` with the `tenacity.Retrying` class for retrying code blocks, applying the approach suggested in the issue.

## Related Issue
Closed #5423 