### PR TITLE
Fix already_analyzed inline comment paths

### DIFF
--- a/bugbug/phabricator.py
+++ b/bugbug/phabricator.py
@@ -30,7 +30,7 @@ db.register(
 )
 
 FIXED_COMMENTS_DB = "data/fixed_comments.json"
-FIXED_COMMENTS_ALREADY_ANALYZED_DB = "fixed_comments_already_analyzed.pickle"
+FIXED_COMMENTS_ALREADY_ANALYZED_DB = "fixed_comments_already_analyzed.pickle.zst"
 db.register(
     FIXED_COMMENTS_DB,
     "https://community-tc.services.mozilla.com/api/index/v1/task/project.bugbug.fixed_comments.latest/artifacts/public/fixed_comments.json.zst",

--- a/scripts/inline_comments_data_collection.py
+++ b/scripts/inline_comments_data_collection.py
@@ -81,7 +81,10 @@ def process_comments(limit, diff_length_limit):
 
     try:
         with open(
-            os.path.join("data", phabricator.FIXED_COMMENTS_ALREADY_ANALYZED_DB), "rb"
+            os.path.join(
+                "data", phabricator.FIXED_COMMENTS_ALREADY_ANALYZED_DB[: -len(".zst")]
+            ),
+            "rb",
         ) as f:
             already_done_patches = pickle.load(f)
     except FileNotFoundError:
@@ -178,11 +181,18 @@ def process_comments(limit, diff_length_limit):
             break
 
     with open(
-        os.path.join("data", phabricator.FIXED_COMMENTS_ALREADY_ANALYZED_DB), "wb"
+        os.path.join(
+            "data", phabricator.FIXED_COMMENTS_ALREADY_ANALYZED_DB[: -len(".zst")]
+        ),
+        "wb",
     ) as f:
         pickle.dump(already_done_patches, f)
 
-    zstd_compress(os.path.join("data", phabricator.FIXED_COMMENTS_ALREADY_ANALYZED_DB))
+    zstd_compress(
+        os.path.join(
+            "data", phabricator.FIXED_COMMENTS_ALREADY_ANALYZED_DB[: -len(".zst")]
+        )
+    )
 
 
 def main():


### PR DESCRIPTION
We fail to download the file otherwise, as we try to download fixed_comments_already_analyzed.pickle but it is actually uploaded as fixed_comments_already_analyzed.pickle.zst.