### PR TITLE
Added parallelization to retrieve log

### DIFF
--- a/scripts/retrieve_ci_failures.py
+++ b/scripts/retrieve_ci_failures.py
@@ -202,8 +202,7 @@ def retrieve_logs(fixed_by_commit_pushes, upload):
             executor.submit(process_logs, failure, upload) for failure in all_failures
         ]
 
-        # We loop over the futures as they finish so tqdm can update the progress bar.
-        # The loop body is empty because we’re only using it to show progress.
+        # We iterate over the futures as they finish so tqdm can update the progress bar.
         all(tqdm(as_completed(futures), total=len(futures)))
 
 


### PR DESCRIPTION
## Description 
Added Parallelization to retrieve_logs. Used a per file lock to ensure shared resources do not cause a race condition. My assumption is that task_id and retry_id can be repeated in the failures list. If we can grantee no repetition then we can remove the lock.

## Linked Issue
Closes #5399     