### PR TITLE
Fix manifest key check in find_manifests_for_paths

### DIFF
--- a/bugbug/test_scheduling.py
+++ b/bugbug/test_scheduling.py
@@ -927,7 +927,7 @@ def find_manifests_for_paths(repo_dir_str: str, paths: list[str]) -> set[str]:
 
             # HACK: If there is no "DEFAULT" key and there is no key that starts with "test", this is unlikely a test manifest.
             if "DEFAULT" not in data and not any(
-                key.startswith("test") for key in data.values()
+                key.startswith("test") for key in data.keys()
             ):
                 continue
 


### PR DESCRIPTION
Fixes #5482 

Corrects the logic to check if any key in the manifest data starts with 'test' by iterating over data.keys() instead of data.values().