### PR TITLE
Trigger the data pipeline hook on new versions

### DIFF
--- a/infra/taskcluster-hook-data-pipeline.json
+++ b/infra/taskcluster-hook-data-pipeline.json
@@ -1,4 +1,10 @@
 {
+  "bindings": [
+    {
+      "exchange": "exchange/taskcluster-queue/v1/task-completed",
+      "routingKeyPattern": "route.project.bugbug.deploy_ending"
+    }
+  ],
   "schedule": ["0 0 1,16 * *"],
   "metadata": {
     "description": "",


### PR DESCRIPTION
I already added the route binding to the hook via the web UI. Let us merge this PR once it is confirmed to work as expected.