### PR TITLE
[testselect] KeyError in equivalence_sets[group] #5577 fix

### DIFF
--- a/http_service/bugbug_http/models.py
+++ b/http_service/bugbug_http/models.py
@@ -279,7 +279,8 @@ def get_config_specific_groups(config: str) -> str:
             [
                 {"name": group}
                 for group in past_failures_data.all_runnables
-                if any(
+                if group in equivalence_sets
+                and any(
                     equivalence_set == {config}
                     for equivalence_set in equivalence_sets[group]
                 )


### PR DESCRIPTION
Added a check in select_configs to handle groups missing from precomputed equivalence sets. If a group isn't found, generate its equivalence sets on-the-fly using the same logic as _get_equivalence_sets, preventing KeyError for newly discovered groups (e.g., from find_manifests_for_paths).