### PR TITLE
Ensure HTTP errors are raised when fetching crash signatures

### DIFF
--- a/scripts/generate_landings_risk_report.py
+++ b/scripts/generate_landings_risk_report.py
@@ -119,6 +119,7 @@ def get_component_team_mapping() -> dict[str, dict[str, str]]:
 
 def get_crash_signatures(channel: str) -> dict:
     r = requests.get(f"https://mozilla.github.io/stab-crashes/{channel}.json")
+    r.raise_for_status()
     response = r.json()
     return response["signatures"]
 


### PR DESCRIPTION
This will make errors like https://github.com/mozilla/bugbug/issues/5575 a bit clearer.