### PR TITLE
Fit the extraction pipeline before applying it

### DIFF
--- a/bugbug/model.py
+++ b/bugbug/model.py
@@ -370,7 +370,7 @@ class Model:
         X_gen, y = split_tuple_generator(lambda: self.items_gen(classes))
 
         # Extract features from the items.
-        X = self.extraction_pipeline.transform(X_gen)
+        X = self.extraction_pipeline.fit_transform(X_gen)
 
         # Calculate labels.
         y = np.array(y)


### PR DESCRIPTION
This is a requirement before bumping scikit-learn to 1.8.0 (#5545).