### PR TITLE
Treat Phabricator bot accounts as trusted in comment filtering

### DIFF
--- a/bugbug/tools/core/platforms/phabricator.py
+++ b/bugbug/tools/core/platforms/phabricator.py
@@ -105,11 +105,13 @@ def _get_users_info_batch_impl(user_phids: set[str]) -> dict[str, dict]:
     for user_data in users_response.get("data", []):
         user_phid = user_data["phid"]
         fields = user_data.get("fields", {})
-        is_trusted = user_phid in moco_members or user_phid in TRUSTED_BOT_PHIDS
+        is_trusted = user_phid in moco_members
+        is_trusted_bot = user_phid in TRUSTED_BOT_PHIDS
 
         result[user_phid] = {
             "email": fields.get("username", "unknown"),  # Username is typically email
             "is_trusted": is_trusted,
+            "is_trusted_bot": is_trusted_bot,
             "real_name": fields.get("realName", ""),
         }
 
@@ -173,8 +175,9 @@ def _sanitize_comments(comments: list, users_info: dict[str, dict]) -> tuple[lis
     sanitized_comments = []
 
     for i, comment in enumerate(comments):
-        comment_is_trusted = users_info.get(comment.author_phid, {}).get(
-            "is_trusted", False
+        author = users_info.get(comment.author_phid)
+        comment_is_trusted = author and (
+            author["is_trusted"] or author["is_trusted_bot"]
         )
 
         # Create a shallow copy to avoid modifying the original

--- a/tests/test_phabricator_trusted_filtering.py
+++ b/tests/test_phabricator_trusted_filtering.py
@@ -60,16 +60,19 @@ def test_phabricator_filtering_untrusted_before_last_trusted():
     users_info = {
         "PHID-USER-untrusted1": {
             "is_trusted": False,
+            "is_trusted_bot": False,
             "email": "untrusted1@example.com",
             "real_name": "",
         },
         "PHID-USER-trusted": {
             "is_trusted": True,
+            "is_trusted_bot": False,
             "email": "trusted@mozilla.com",
             "real_name": "",
         },
         "PHID-USER-untrusted2": {
             "is_trusted": False,
+            "is_trusted_bot": False,
             "email": "untrusted2@example.com",
             "real_name": "",
         },
@@ -112,11 +115,13 @@ def test_phabricator_filtering_no_trusted_users():
     users_info = {
         "PHID-USER-untrusted1": {
             "is_trusted": False,
+            "is_trusted_bot": False,
             "email": "untrusted1@example.com",
             "real_name": "",
         },
         "PHID-USER-untrusted2": {
             "is_trusted": False,
+            "is_trusted_bot": False,
             "email": "untrusted2@example.com",
             "real_name": "",
         },
@@ -164,11 +169,13 @@ def test_phabricator_filtering_inline_comments():
     users_info = {
         "PHID-USER-untrusted": {
             "is_trusted": False,
+            "is_trusted_bot": False,
             "email": "untrusted@example.com",
             "real_name": "",
         },
         "PHID-USER-trusted": {
             "is_trusted": True,
+            "is_trusted_bot": False,
             "email": "trusted@mozilla.com",
             "real_name": "",
         },
@@ -850,6 +857,7 @@ def test_phabricator_metadata_redacted_without_trusted_comment():
         "PHID-USER-untrusted": {
             "email": "untrusted@example.com",
             "is_trusted": False,
+            "is_trusted_bot": False,
             "real_name": "Untrusted User",
         }
     }
@@ -929,11 +937,13 @@ def test_phabricator_metadata_shown_with_trusted_comment():
         "PHID-USER-author": {
             "email": "author@example.com",
             "is_trusted": False,
+            "is_trusted_bot": False,
             "real_name": "Patch Author",
         },
         "PHID-USER-trusted": {
             "email": "trusted@mozilla.com",
             "is_trusted": True,
+            "is_trusted_bot": False,
             "real_name": "Trusted Reviewer",
         },
     }
@@ -1009,6 +1019,7 @@ def test_phabricator_stack_titles_redacted():
         "PHID-USER-author": {
             "email": "author@example.com",
             "is_trusted": False,
+            "is_trusted_bot": False,
             "real_name": "Author",
         }
     }
@@ -1029,7 +1040,7 @@ def test_phabricator_stack_titles_redacted():
 
 
 def test_trusted_bot_phids_not_filtered():
-    """Test that comments from trusted bot accounts are not redacted."""
+    """Test that bot comments are shown but don't propagate trust backward."""
     bot_phid = list(TRUSTED_BOT_PHIDS)[0]
 
     comments = []
@@ -1041,9 +1052,16 @@ def test_trusted_bot_phids_not_filtered():
     trusted_comment.content_redacted = False
     comments.append(trusted_comment)
 
+    untrusted_comment = MagicMock(spec=PhabricatorGeneralComment)
+    untrusted_comment.author_phid = "PHID-USER-untrusted"
+    untrusted_comment.date_created = 2000
+    untrusted_comment.content = "Untrusted comment after trusted"
+    untrusted_comment.content_redacted = False
+    comments.append(untrusted_comment)
+
     bot_comment = MagicMock(spec=PhabricatorGeneralComment)
     bot_comment.author_phid = bot_phid
-    bot_comment.date_created = 2000
+    bot_comment.date_created = 3000
     bot_comment.content = "Bot analysis comment"
     bot_comment.content_redacted = False
     comments.append(bot_comment)
@@ -1051,11 +1069,19 @@ def test_trusted_bot_phids_not_filtered():
     users_info = {
         "PHID-USER-trusted": {
             "is_trusted": True,
+            "is_trusted_bot": False,
             "email": "trusted@mozilla.com",
             "real_name": "",
         },
+        "PHID-USER-untrusted": {
+            "is_trusted": False,
+            "is_trusted_bot": False,
+            "email": "untrusted@example.com",
+            "real_name": "",
+        },
         bot_phid: {
-            "is_trusted": True,
+            "is_trusted": False,
+            "is_trusted_bot": True,
             "email": "bot@mozilla.com",
             "real_name": "",
         },
@@ -1064,6 +1090,15 @@ def test_trusted_bot_phids_not_filtered():
     all_comments = sorted(comments, key=lambda c: c.date_created)
     sanitized_comments, filtered_count = _sanitize_comments(all_comments, users_info)
 
-    assert filtered_count == 0
-    assert sanitized_comments[1].content == "Bot analysis comment"
-    assert sanitized_comments[1].content_redacted is False
+    # Bot comment is shown (not redacted)
+    assert sanitized_comments[2].content == "Bot analysis comment"
+    assert sanitized_comments[2].content_redacted is False
+
+    # Untrusted comment after last MOCO comment is still redacted
+    # (bot doesn't propagate trust backward)
+    assert filtered_count == 1
+    assert sanitized_comments[1].content == UNTRUSTED_CONTENT_REDACTED
+    assert sanitized_comments[1].content_redacted is True
+
+    # Trusted (MOCO) comment is shown
+    assert sanitized_comments[0].content == "Trusted reviewer comment"


### PR DESCRIPTION
The trust filtering logic redacts comments from users not in the bmo-mozilla-employee-confidential group. This causes comments from Mozilla-operated bots like reviewbot (Review Helper Bot) to be redacted when they appear after the last trusted user's comment.

This adds a `TRUSTED_BOT_PHIDS` set and a separate `is_trusted_bot` field so bot content is shown without propagating trust to surrounding untrusted comments. A bot commenting does not shift `last_trusted_index`, so earlier untrusted comments remain redacted.

The reviewbot account isn't marked with the Phabricator `bot` role (only 5 accounts are: email-bot, updatebot, wptsync, lando-bot, and a disabled maintenance bot), so a role-based check isn't sufficient here.

Also extracts the reviewbot PHID into a `REVIEWBOT_PHID` constant, replacing the hardcoded string in the existing inline comment filter.

Fixes #5767