### PR TITLE
Relax langgraph version pin in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ langchain-community==0.4.1
 langchain-google-genai==4.2.1
 langchain-mistralai==1.1.1
 langchain-openai==1.1.11
-langgraph==1.0.8
+langgraph>=1.0.8
 libmozdata==0.2.12
 llama-cpp-python==0.3.16
 lmdb==1.8.1


### PR DESCRIPTION
Update requirements.txt to change langgraph==1.0.8 to langgraph>=1.0.8. This relaxes the strict version pin to allow newer langgraph releases and improve dependency resolution flexibility.

This should resolve the dependency conflict in https://github.com/mozilla/bugbug/pull/5856.

Once we have https://github.com/mozilla/bugbug/issues/5022 resolved, we do not need to pin dependencies anymore, the lock file would be a better solution.  