### PR TITLE
worker: clone the hg repo into /code/bugbug-hg (bug 2025056)

### DIFF
--- a/http_service/Dockerfile.bg_worker
+++ b/http_service/Dockerfile.bg_worker
@@ -21,6 +21,8 @@ ENV CHECK_MODELS="${CHECK_MODELS}"
 ARG TAG
 ENV TAG="${TAG}"
 
+ENV BUGBUG_REPO_DIR=/code/bugbug-hg
+
 RUN bash /code/http_service/ensure_models.sh
 
 CMD bugbug-http-worker high default low


### PR DESCRIPTION
On the production deployment /code is set up to be a local ssd, while /tmp is backed by the node's own ephemeral storage.  Putting the clone on the volume should speed things up.