### PR TITLE
hg: update version-control-tools revision for pushlog wireproto updates (Bug 2024739)

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -99,7 +99,7 @@ tasks:
                     git -c advice.detachedHead=false checkout ${head_rev} &&
                     cp infra/hgrc /etc/mercurial/hgrc.d/bugbug.rc &&
                     uv sync --frozen --package bugbug --group test --extra nlp --group spawn-pipeline &&
-                    hg clone -r ae4bf6620a9a3821cfb9709bd03cd3f5f1849ff3 https://hg.mozilla.org/hgcustom/version-control-tools /version-control-tools/ &&
+                    hg clone -r 50a59e00c4a76fcfae660e3feb9b79e0cd549b15 https://hg.mozilla.org/hgcustom/version-control-tools /version-control-tools/ &&
                     uv run pytest --cov=./ tests/test_*.py &&
                     bash <(curl -s https://codecov.io/bash)"
               metadata:
@@ -124,7 +124,7 @@ tasks:
                     git -c advice.detachedHead=false checkout ${head_rev} &&
                     cp infra/hgrc /etc/mercurial/hgrc.d/bugbug.rc &&
                     uv sync --frozen --package bugbug --package bugbug-http-service --group test &&
-                    hg clone -r ae4bf6620a9a3821cfb9709bd03cd3f5f1849ff3 https://hg.mozilla.org/hgcustom/version-control-tools /version-control-tools/ &&
+                    hg clone -r 50a59e00c4a76fcfae660e3feb9b79e0cd549b15 https://hg.mozilla.org/hgcustom/version-control-tools /version-control-tools/ &&
                     uv run pytest --cov=http_service http_service/tests/ -vvv &&
                     bash <(curl -s https://codecov.io/bash)"
               metadata:

--- a/infra/dockerfile.commit_retrieval
+++ b/infra/dockerfile.commit_retrieval
@@ -6,7 +6,7 @@ ENV PATH="${PATH}:/git-cinnabar"
 # libcurl4 is required by git-cinnabar.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git xz-utils curl libcurl4 && \
-    hg clone -r ae4bf6620a9a3821cfb9709bd03cd3f5f1849ff3 https://hg.mozilla.org/hgcustom/version-control-tools /version-control-tools/ && \
+    hg clone -r 50a59e00c4a76fcfae660e3feb9b79e0cd549b15 https://hg.mozilla.org/hgcustom/version-control-tools /version-control-tools/ && \
     rm -r /version-control-tools/.hg /version-control-tools/ansible /version-control-tools/docs /version-control-tools/testing && \
     git clone https://github.com/glandium/git-cinnabar.git /git-cinnabar && \
     cd /git-cinnabar && git -c advice.detachedHead=false checkout fd17180c439c3eb3ab9de5cfc47923b04242394a && cd .. && \


### PR DESCRIPTION
This allows bugbug to use the streaming pushlog wire protocol command
which should fix the persistent 503s from hg.mozilla.org while cloning
against try.
