### PR TITLE
Increase size of integration test workers

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -307,7 +307,7 @@ tasks:
               - taskId: { $eval: as_slugid("integration_test") }
                 dependencies:
                   - { $eval: as_slugid("docker_push") }
-                workerType: compute-small
+                workerType: compute-large
                 scopes:
                   - secrets:get:project/bugbug/integration
                   - "docker-worker:cache:bugbug-mercurial-repository"

--- a/infra/data-pipeline.yml
+++ b/infra/data-pipeline.yml
@@ -1498,7 +1498,7 @@ tasks:
       deadline: { $fromNow: "3 days" }
       expires: { $fromNow: "1 year" }
       provisionerId: proj-bugbug
-      workerType: compute-small
+      workerType: compute-large
       dependencies:
         - docker-build
       scopes:


### PR DESCRIPTION
The integration test task is taking around 30 minutes, we should use a bigger machine so it completes faster.