### PR TITLE
Better retry policy for Redash query

### DIFF
--- a/scripts/retrieve_ci_failures.py
+++ b/scripts/retrieve_ci_failures.py
@@ -4,6 +4,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import argparse
+import enum
 import os
 import subprocess
 import tempfile
@@ -21,6 +22,15 @@ from bugbug import db, repository, utils
 
 basicConfig(level=INFO)
 logger = getLogger(__name__)
+
+
+class RedashQueryStatus(enum.IntEnum):
+    PENDING = 1
+    STARTED = 2
+    SUCCESS = 3
+    FAILURE = 4
+    CANCELLED = 5
+
 
 CI_FAILURES_DB = "data/ci_failures.json"
 db.register(
@@ -66,7 +76,10 @@ def query_redash(start_date, end_date):
 
     result = r.json()
     if "query_result" not in result:
-        logger.warning("query_result not in result: %s", result)
+        status = result.get("job", {}).get("status")
+        if status == RedashQueryStatus.FAILURE:
+            raise Exception(f"Redash query failed: {result}")
+        logger.warning("query_result not in result (status=%s): %s", status, result)
         raise tenacity.TryAgain
 
     return result["query_result"]["data"]["rows"]

--- a/scripts/retrieve_ci_failures.py
+++ b/scripts/retrieve_ci_failures.py
@@ -57,7 +57,7 @@ def download_dbs():
 
 @tenacity.retry(
     wait=tenacity.wait_exponential(multiplier=4),
-    stop=tenacity.stop_after_attempt(7),
+    stop=tenacity.stop_after_delay(900),
     reraise=True,
 )
 def query_redash(start_date, end_date):

--- a/scripts/retrieve_ci_failures.py
+++ b/scripts/retrieve_ci_failures.py
@@ -56,7 +56,7 @@ def download_dbs():
 
 
 @tenacity.retry(
-    wait=tenacity.wait_exponential(multiplier=4),
+    wait=tenacity.wait_exponential(multiplier=2, max=60),
     stop=tenacity.stop_after_delay(900),
     reraise=True,
 )


### PR DESCRIPTION
Fixes #5985

There are three changes here:
- if the Redash query fails, stop retrying. We do this to allow retrying for longer (so we don't needlessly retry if the query fails);
- retry more frequently (so we don't wait too long if the query finished in the meantime);
- retry for longer (the actual fix for #5985).