### PR TITLE
hg: set `mozext.disable_local_database = true` (Bug 2024739)

### DIFF
--- a/infra/hgrc
+++ b/infra/hgrc
@@ -7,7 +7,7 @@ pushlog = /version-control-tools/hgext/pushlog
 mozext = /version-control-tools/hgext/mozext
 
 [mozext]
-# https://bugzilla.mozilla.org/show_bug.cgi?id=2024739#c14
+# https://bugzilla.mozilla.org/show_bug.cgi?id=2024739#c15
 # Disable the mozext `changetracker.db` SQLite database as
 # we don't need any of the functionality it provides.
 disable_local_database = true

--- a/infra/hgrc
+++ b/infra/hgrc
@@ -5,3 +5,9 @@ robustcheckout = /version-control-tools/hgext/robustcheckout/__init__.py
 hgmo = /version-control-tools/hgext/hgmo
 pushlog = /version-control-tools/hgext/pushlog
 mozext = /version-control-tools/hgext/mozext
+
+[mozext]
+# https://bugzilla.mozilla.org/show_bug.cgi?id=2024739#c14
+# Disable the mozext `changetracker.db` SQLite database as
+# we don't need any of the functionality it provides.
+disable_local_database = true


### PR DESCRIPTION
This disables the local `changetracker.db` database, which still uses
the old `pushlog` wire protocol command instead of `pushlog-stream`.
