### PR TITLE
Remove run-mode note from bug-fix prompt

### DIFF
--- a/bugbug/tools/bug_fix/agent.py
+++ b/bugbug/tools/bug_fix/agent.py
@@ -319,7 +319,7 @@ class BugFixTool(GenerativeModelTool):
         print(f"[bug_fix] triaging {len(selected)} bug(s): {selected}", file=sys.stderr)
 
         # --- Build agent options ------------------------------------------ #
-        system_prompt = load_system_prompt(rules_dir, instructions, dry_run)
+        system_prompt = load_system_prompt(rules_dir, instructions)
 
         options = ClaudeAgentOptions(
             system_prompt=system_prompt,

--- a/bugbug/tools/bug_fix/agent.py
+++ b/bugbug/tools/bug_fix/agent.py
@@ -112,20 +112,10 @@ def load_system_prompt(
     dry_run: bool,
 ) -> str:
     tmpl = (HERE / "prompts" / "system.md").read_text()
-    if dry_run:
-        mode = (
-            "**DRY-RUN ACTIVE.** Bugzilla write tools (`update_bug`, "
-            "`add_comment`, `add_attachment`, `create_bug`) are disabled — "
-            "do not attempt them. Source-repo edits (Write/Edit) are still "
-            "allowed so you can prepare and inspect a candidate patch; the "
-            "caller will review diffs manually."
-        )
-    else:
-        mode = "Writes are live. Be careful."
+
     return tmpl.format(
         rules_dir=str(rules_dir.resolve()),
         extra_instructions=extra or "(none)",
-        run_mode_note=mode,
     )
 
 

--- a/bugbug/tools/bug_fix/agent.py
+++ b/bugbug/tools/bug_fix/agent.py
@@ -106,11 +106,7 @@ def fetch_initial_bugs(
 # --------------------------------------------------------------------------- #
 
 
-def load_system_prompt(
-    rules_dir: Path,
-    extra: str,
-    dry_run: bool,
-) -> str:
+def load_system_prompt(rules_dir: Path, extra: str) -> str:
     tmpl = (HERE / "prompts" / "system.md").read_text()
 
     return tmpl.format(

--- a/bugbug/tools/bug_fix/prompts/system.md
+++ b/bugbug/tools/bug_fix/prompts/system.md
@@ -81,7 +81,6 @@ Always be **brief** and to the point. Do not post long-winded comments, develope
 
 Do **not** post private comments, all developers on the bug need to see the comments.
 
-
 # Additional instructions for this run
 
 {extra_instructions}

--- a/bugbug/tools/bug_fix/prompts/system.md
+++ b/bugbug/tools/bug_fix/prompts/system.md
@@ -81,9 +81,6 @@ Always be **brief** and to the point. Do not post long-winded comments, develope
 
 Do **not** post private comments, all developers on the bug need to see the comments.
 
-# Run mode
-
-{run_mode_note}
 
 # Additional instructions for this run
 


### PR DESCRIPTION
This will enable the agent to change the files locally when running in dry-run mode.