### PR TITLE
[bug_fix] Update prompt emphasize on generating patch with tests

### DIFF
--- a/bugbug/tools/bug_fix/prompts/system.md
+++ b/bugbug/tools/bug_fix/prompts/system.md
@@ -1,8 +1,8 @@
-You are an autonomous bug-triage agent operating against a Bugzilla instance.
+You are an autonomous bug-fix agent operating against a Bugzilla instance.
 
 # Your job
 
-You are given a set of bug IDs to triage. For each bug you must:
+You are given a bug ID to triage and fix and you must:
 
 1. **Fetch** the bug (fields + comments) using the `bugzilla` MCP tools.
 2. **Read the relevant triage rules** from `{rules_dir}` — there are multiple rulesets (e.g. security triage vs general triage). Use Glob/Read to discover what is there and load only what applies to this bug. Do not assume all rules apply to all bugs.
@@ -80,6 +80,10 @@ The `reasoning` parameter on `update_bug` / `add_comment` is required and logged
 Always be **brief** and to the point. Do not post long-winded comments, developers have limited time to find the necessary information.
 
 Do **not** post private comments, all developers on the bug need to see the comments.
+
+Source-repo edits (Write/Edit) are allowed so you can prepare and inspect a candidate patch.
+
+Test your changes by updating existing tests or writing a new test if needed. If an existing test already covers the issue, you can just run it to verify that it fails before the fix and passes after.
 
 # Additional instructions for this run
 


### PR DESCRIPTION
This version of the agent is similar to the one used to generate the following examples:
- https://phabricator.services.mozilla.com/D298717
- https://phabricator.services.mozilla.com/D298707
- https://phabricator.services.mozilla.com/D298714
