### PR TITLE
Add action recording mechanism to hackbot and make Bugzilla read-only

### DIFF
--- a/agents/bug-fix/agent_runner/__main__.py
+++ b/agents/bug-fix/agent_runner/__main__.py
@@ -96,10 +96,12 @@ async def main(ctx: Context) -> AgentResult:
         effort=inputs.effort,
         log=log_path,
         verbose=True,
+        actions_recorder=ctx.actions,
     )
 
-    if log_path.exists() and ctx.uploader is not None:
-        ctx.uploader.upload_file("logs/agent.log", log_path, "text/plain")
+    if log_path.exists():
+        # Uploaded when a signed policy is set, else copied into ./artifacts.
+        ctx.publish_file("logs/agent.log", log_path, "text/plain")
 
     return AgentResult(
         status="ok" if result.exit_code == 0 else "error",

--- a/agents/bug-fix/broker/__main__.py
+++ b/agents/bug-fix/broker/__main__.py
@@ -25,7 +25,6 @@ log = logging.getLogger("bugzilla-broker")
 class BrokerInputs(BaseSettings):
     bugzilla_api_url: str
     bugzilla_api_key: str
-    dry_run: bool = False
     host: str = "0.0.0.0"
     port: int = 8765
 
@@ -36,7 +35,7 @@ def build_app(inputs: BrokerInputs) -> Starlette:
     client = bugsy.Bugsy(
         api_key=inputs.bugzilla_api_key, bugzilla_url=inputs.bugzilla_api_url
     )
-    ctx = BugzillaContext(client=client, dry_run=inputs.dry_run)
+    ctx = BugzillaContext(client=client)
     sdk_config = build_bugzilla_server(ctx)
     mcp_server = sdk_config["instance"]
 
@@ -46,10 +45,9 @@ def build_app(inputs: BrokerInputs) -> Starlette:
     async def lifespan(app):
         async with manager.run():
             log.info(
-                "bugzilla broker ready on %s:%d (dry_run=%s)",
+                "bugzilla broker ready on %s:%d (read-only)",
                 inputs.host,
                 inputs.port,
-                inputs.dry_run,
             )
             yield
 

--- a/agents/bug-fix/compose.yml
+++ b/agents/bug-fix/compose.yml
@@ -7,7 +7,6 @@ services:
     environment:
       BUGZILLA_API_URL: ${BUGZILLA_API_URL}
       BUGZILLA_API_KEY: ${BUGZILLA_API_KEY}
-      DRY_RUN: ${BROKER_DRY_RUN:-true}
     expose:
       - "8765"
 
@@ -17,13 +16,18 @@ services:
       dockerfile: agents/bug-fix/Dockerfile
       target: agent
     environment:
-      RUN_ID: ${RUN_ID:-local-dev}
-      BUG_ID: ${BUG_ID:?error}
-      BUGZILLA_MCP_URL: http://bug-fix-broker:8765/mcp
-      SOURCE_REPO: /workspace/firefox
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:?error}
+      - RUN_ID
+      - BUG_ID=${BUG_ID:?error}
+      - BUGZILLA_MCP_URL=http://bug-fix-broker:8765/mcp
+      - SOURCE_REPO=/workspace/firefox
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:?error}
+      # No uploader locally: summary/logs/attachments are written under
+      # /artifacts/<run_id>, bind-mounted to the host's ~/hackbot/artifacts so
+      # compose and direct runs land in the same user-scoped location.
+      - ARTIFACTS_DIR=/artifacts
     volumes:
       - workspace:/workspace
+      - ${HOME}/hackbot/artifacts:/artifacts
     depends_on:
       bug-fix-broker:
         condition: service_started

--- a/agents/bug-fix/pyproject.toml
+++ b/agents/bug-fix/pyproject.toml
@@ -5,7 +5,7 @@ description = "Cloud Run Job image that runs the bug-fix agent for hackbot-api"
 requires-python = ">=3.12"
 dependencies = [
     "bugbug",
-    "hackbot-runtime",
+    "hackbot-runtime[claude-sdk]",
     "bugsy",
     "grizzly-framework",
     "prefpicker",

--- a/bugbug/tools/bug_fix/agent.py
+++ b/bugbug/tools/bug_fix/agent.py
@@ -27,11 +27,15 @@ from claude_agent_sdk import (
     ToolUseBlock,
     UserMessage,
 )
+from hackbot_runtime import ActionsRecorder
+from hackbot_runtime.actions.claude_sdk import build_actions_sdk_server
+from hackbot_runtime.actions.naming import ACTIONS_SERVER_NAME
 
 from bugbug.tools.base import GenerativeModelTool
 from bugbug.tools.bug_fix.config import (
     BUGZILLA_READ_TOOLS,
-    BUGZILLA_WRITE_TOOLS,
+    ENABLED_ACTION_TOOLS,
+    ENABLED_ACTION_TYPES,
     FIREFOX_TOOLS,
     SOURCE_WRITE_TOOLS,
 )
@@ -224,6 +228,7 @@ class BugFixTool(GenerativeModelTool):
         effort: str | None = None,
         verbose: bool = False,
         log: Path | None = None,
+        actions_recorder: ActionsRecorder | None = None,
     ) -> BugFixResult:
         if rules_dir is None:
             rules_dir = HERE / "rules"
@@ -239,12 +244,24 @@ class BugFixTool(GenerativeModelTool):
         fx_ctx = FirefoxContext.from_source_repo(source_repo)
         firefox_server = build_firefox_server(fx_ctx)
 
+        # --- Action-recording MCP server (in-process) --------------------- #
+        if actions_recorder is None:
+            # Standalone/script runs have no uploader; copy attachments locally.
+            actions_recorder = ActionsRecorder(artifacts_dir=Path("artifacts"))
+        actions_server = build_actions_sdk_server(
+            actions_recorder, types=ENABLED_ACTION_TYPES
+        )
+
         # --- Build agent options ------------------------------------------ #
         system_prompt = load_system_prompt(rules_dir, instructions)
 
         options = ClaudeAgentOptions(
             system_prompt=system_prompt,
-            mcp_servers={"bugzilla": bugzilla_mcp_server, "firefox": firefox_server},
+            mcp_servers={
+                "bugzilla": bugzilla_mcp_server,
+                "firefox": firefox_server,
+                ACTIONS_SERVER_NAME: actions_server,
+            },
             agents={"investigator": make_investigator()},
             cwd=str(source_repo.resolve()),
             add_dirs=[str(rules_dir.resolve())],
@@ -257,7 +274,7 @@ class BugFixTool(GenerativeModelTool):
                 "Task",
                 *SOURCE_WRITE_TOOLS,
                 *BUGZILLA_READ_TOOLS,
-                *BUGZILLA_WRITE_TOOLS,
+                *ENABLED_ACTION_TOOLS,
                 *FIREFOX_TOOLS,
             ],
             model=model,

--- a/bugbug/tools/bug_fix/bugzilla_mcp.py
+++ b/bugbug/tools/bug_fix/bugzilla_mcp.py
@@ -1,18 +1,18 @@
 """In-process MCP server wrapping bugsy for Bugzilla REST access.
 
-Exposes read and write tools to a Claude agent. Write tools honour
-dry-run and confirm modes. All tools gracefully handle proxy-level
-restrictions (code 101: endpoint not exposed, code 102: access denied).
+Exposes read-only tools to a Claude agent. Write actions are recorded
+via the in-process ``actions`` MCP server built from the framework-agnostic
+registry in ``hackbot_runtime.actions`` (see
+``hackbot_runtime/actions/claude_sdk.py``), so the broker holds the Bugzilla
+API key but has no write capability at all.
+All tools gracefully handle proxy-level restrictions (code 101:
+endpoint not exposed, code 102: access denied).
 """
 
 from __future__ import annotations
 
-import asyncio
 import base64
 import json
-import mimetypes
-import os
-import sys
 from dataclasses import dataclass
 
 import bugsy
@@ -25,16 +25,13 @@ from claude_agent_sdk import create_sdk_mcp_server, tool
 
 @dataclass
 class BugzillaContext:
-    """Holds the live bugsy client and runtime flags.
+    """Holds the live bugsy client.
 
     The MCP tool functions close over a single instance of this class so
-    they can share auth and honour dry-run / confirm without re-parsing
-    CLI args.
+    they share auth and one TCP connection pool.
     """
 
     client: bugsy.Bugsy
-    dry_run: bool = False
-    confirm: bool = False
 
 
 def _text(content: str) -> dict:
@@ -75,24 +72,6 @@ def _handle_bugsy_error(e: bugsy.BugsyException) -> dict:
     }
 
 
-async def _confirm_prompt(action: str, details: dict) -> bool:
-    """Interactively ask the user whether to proceed with a write.
-
-    Runs ``input()`` in a thread so the event loop keeps turning —
-    the Agent SDK's subprocess reader stays alive while we wait on
-    the human. Prompt text goes to stderr so it doesn't tangle with
-    the streamed agent transcript on stdout.
-    """
-    print(f"\n[CONFIRM] About to {action}:", file=sys.stderr)
-    print(json.dumps(details, indent=2, default=str), file=sys.stderr)
-    sys.stderr.flush()
-    try:
-        answer = await asyncio.to_thread(input, "Proceed? [y/N] ")
-    except EOFError:
-        answer = ""
-    return answer.strip().lower() in ("y", "yes")
-
-
 # --------------------------------------------------------------------------- #
 # Server factory
 # --------------------------------------------------------------------------- #
@@ -102,8 +81,7 @@ def build_server(ctx: BugzillaContext):
     """Create and return the in-process MCP server bound to ``ctx``.
 
     All tool functions are closures over ``ctx`` so they share the same
-    bugsy session (one TCP connection pool, one auth header) and the same
-    dry-run / confirm state.
+    bugsy session (one TCP connection pool, one auth header).
     """
     # ----- READ TOOLS -------------------------------------------------- #
 
@@ -331,397 +309,6 @@ def build_server(ctx: BugzillaContext):
             }
         )
 
-    # ----- WRITE TOOLS ------------------------------------------------- #
-
-    @tool(
-        "update_bug",
-        "Change fields on a bug. Accepts any field the Bugzilla REST PUT "
-        "endpoint accepts: status, resolution, priority, severity, "
-        "whiteboard, assigned_to, component, product, version, and the "
-        "keywords / cc / see_also / depends_on / blocks set-operations "
-        "({'add': [...], 'remove': [...]}). Returns Bugzilla's change "
-        "report. Honours --dry-run and --confirm.",
-        {
-            "type": "object",
-            "properties": {
-                "bug_id": {"type": "integer"},
-                "changes": {
-                    "type": "object",
-                    "description": (
-                        "Field → new value. For list fields (keywords, cc, "
-                        "blocks, depends_on, see_also) you may pass "
-                        '{"add": [...], "remove": [...], "set": [...]}.'
-                    ),
-                    "additionalProperties": True,
-                },
-                "reasoning": {
-                    "type": "string",
-                    "description": (
-                        "Why you are making this change. Logged alongside "
-                        "dry-run / confirm output so the human can audit."
-                    ),
-                },
-            },
-            "required": ["bug_id", "changes", "reasoning"],
-        },
-    )
-    async def update_bug(args):
-        bug_id = args["bug_id"]
-        changes = args["changes"]
-        reasoning = args["reasoning"]
-
-        action_desc = {
-            "bug_id": bug_id,
-            "changes": changes,
-            "reasoning": reasoning,
-        }
-
-        if ctx.dry_run:
-            print(f"\n[DRY-RUN] update_bug {bug_id}", file=sys.stderr)
-            print(json.dumps(action_desc, indent=2, default=str), file=sys.stderr)
-            return _jtext(
-                {
-                    "dry_run": True,
-                    "would_update": bug_id,
-                    "changes": changes,
-                    "note": "No request sent. Re-run without --dry-run to apply.",
-                }
-            )
-
-        if ctx.confirm and not await _confirm_prompt(
-            f"update bug {bug_id}", action_desc
-        ):
-            return _jtext(
-                {
-                    "skipped": True,
-                    "bug_id": bug_id,
-                    "reason": "User declined at --confirm prompt.",
-                }
-            )
-
-        try:
-            result = ctx.client.request(f"bug/{bug_id}", method="PUT", json=changes)
-        except bugsy.BugsyException as e:
-            return _handle_bugsy_error(e)
-        return _jtext({"updated": bug_id, "result": result})
-
-    @tool(
-        "add_comment",
-        "Post a comment on a bug. Honours --dry-run and --confirm. "
-        "Use is_private=true for security-sensitive notes.",
-        {
-            "type": "object",
-            "properties": {
-                "bug_id": {"type": "integer"},
-                "text": {"type": "string"},
-                "is_private": {
-                    "type": "boolean",
-                    "description": "Mark the comment private (security group only).",
-                },
-                "reasoning": {
-                    "type": "string",
-                    "description": "Why you are posting this comment (for audit log).",
-                },
-            },
-            "required": ["bug_id", "text", "reasoning"],
-        },
-    )
-    async def add_comment(args):
-        bug_id = args["bug_id"]
-        text = args["text"]
-        is_private = bool(args.get("is_private", False))
-        reasoning = args["reasoning"]
-
-        footer = (
-            "*This is an automated analysis result. If this result is incorrect "
-            "please add a needinfo and feel free to correct the error.* "
-        )
-        text = text.rstrip() + "\n\n" + footer
-
-        action_desc = {
-            "bug_id": bug_id,
-            "is_private": is_private,
-            "reasoning": reasoning,
-            "text": text,
-        }
-
-        if ctx.dry_run:
-            print(f"\n[DRY-RUN] add_comment on bug {bug_id}", file=sys.stderr)
-            print(json.dumps(action_desc, indent=2, default=str), file=sys.stderr)
-            return _jtext(
-                {
-                    "dry_run": True,
-                    "would_comment_on": bug_id,
-                    "text_preview": text[:200],
-                    "note": "No request sent. Re-run without --dry-run to apply.",
-                }
-            )
-
-        if ctx.confirm and not await _confirm_prompt(
-            f"comment on bug {bug_id}", action_desc
-        ):
-            return _jtext(
-                {
-                    "skipped": True,
-                    "bug_id": bug_id,
-                    "reason": "User declined at --confirm prompt.",
-                }
-            )
-
-        body = {"comment": text, "is_markdown": True}
-        if is_private:
-            body["is_private"] = True
-        try:
-            result = ctx.client.request(
-                f"bug/{bug_id}/comment", method="POST", json=body
-            )
-        except bugsy.BugsyException as e:
-            return _handle_bugsy_error(e)
-        return _jtext({"commented_on": bug_id, "comment_id": result.get("id")})
-
-    @tool(
-        "add_attachment",
-        "Upload a file as an attachment to a bug. Pass a local filesystem "
-        "path — the tool reads and base64-encodes the file itself (do NOT "
-        "inline file contents in the tool call). For patches, set "
-        "is_patch=true and omit content_type. Honours --dry-run and "
-        "--confirm.",
-        {
-            "type": "object",
-            "properties": {
-                "bug_id": {"type": "integer"},
-                "file_path": {
-                    "type": "string",
-                    "description": "Local path to the file to upload.",
-                },
-                "summary": {
-                    "type": "string",
-                    "description": "Short description of the attachment. "
-                    "Defaults to the filename.",
-                },
-                "content_type": {
-                    "type": "string",
-                    "description": "MIME type. Guessed from extension if "
-                    "omitted. Ignored when is_patch=true.",
-                },
-                "is_patch": {
-                    "type": "boolean",
-                    "description": "Mark as a patch (Bugzilla forces "
-                    "text/plain and enables diff view).",
-                },
-                "comment": {
-                    "type": "string",
-                    "description": "Optional comment to post alongside the "
-                    "attachment. Posted as a separate "
-                    "markdown-enabled comment after upload "
-                    "(the attachment endpoint itself does "
-                    "not support is_markdown).",
-                },
-                "reasoning": {
-                    "type": "string",
-                    "description": "Why you are attaching this (for audit log).",
-                },
-            },
-            "required": ["bug_id", "file_path", "reasoning"],
-        },
-    )
-    async def add_attachment(args):
-        bug_id = args["bug_id"]
-        file_path = args["file_path"]
-        reasoning = args["reasoning"]
-        is_patch = bool(args.get("is_patch", False))
-
-        if not os.path.isfile(file_path):
-            return {
-                "content": [
-                    {
-                        "type": "text",
-                        "text": json.dumps(
-                            {"error": "file_not_found", "path": file_path}
-                        ),
-                    }
-                ],
-                "is_error": True,
-            }
-
-        file_name = os.path.basename(file_path)
-        summary = args.get("summary") or file_name
-        size = os.path.getsize(file_path)
-
-        if is_patch:
-            content_type = "text/plain"
-        else:
-            content_type = args.get("content_type") or (
-                mimetypes.guess_type(file_path)[0] or "application/octet-stream"
-            )
-
-        action_desc = {
-            "bug_id": bug_id,
-            "file_path": file_path,
-            "file_name": file_name,
-            "size_bytes": size,
-            "content_type": content_type,
-            "is_patch": is_patch,
-            "summary": summary,
-            "reasoning": reasoning,
-        }
-
-        if ctx.dry_run:
-            print(f"\n[DRY-RUN] add_attachment on bug {bug_id}", file=sys.stderr)
-            print(json.dumps(action_desc, indent=2, default=str), file=sys.stderr)
-            return _jtext(
-                {
-                    "dry_run": True,
-                    "would_attach_to": bug_id,
-                    "file_name": file_name,
-                    "size_bytes": size,
-                    "note": "No request sent. Re-run without --dry-run to apply.",
-                }
-            )
-
-        if ctx.confirm and not await _confirm_prompt(
-            f"attach {file_name} ({size} bytes) to bug {bug_id}", action_desc
-        ):
-            return _jtext(
-                {
-                    "skipped": True,
-                    "bug_id": bug_id,
-                    "reason": "User declined at --confirm prompt.",
-                }
-            )
-
-        # Read + encode here, server-side — keeps the agent's tool call tiny
-        # (just a path string) instead of forcing it to stream base64 tokens.
-        with open(file_path, "rb") as fp:
-            data = base64.b64encode(fp.read()).decode("ascii")
-
-        body = {
-            "ids": [bug_id],
-            "data": data,
-            "file_name": file_name,
-            "summary": summary,
-            "content_type": content_type,
-            "is_patch": is_patch,
-        }
-
-        try:
-            result = ctx.client.request(
-                f"bug/{bug_id}/attachment", method="POST", json=body
-            )
-        except bugsy.BugsyException as e:
-            return _handle_bugsy_error(e)
-
-        response = {"attached_to": bug_id, "result": result}
-
-        # The attachment endpoint's inline comment field doesn't honour
-        # is_markdown — post the comment separately so markdown renders.
-        comment = args.get("comment")
-        if comment:
-            footer = (
-                "*This is the analysis tool's suggested fix. Feel welcome "
-                "to adopt it as a starting point and evolve it as needed to "
-                "meet our coding standards.*"
-            )
-            comment = comment.rstrip() + "\n\n" + footer
-            try:
-                cres = ctx.client.request(
-                    f"bug/{bug_id}/comment",
-                    method="POST",
-                    json={"comment": comment, "is_markdown": True},
-                )
-                response["comment_id"] = cres.get("id")
-            except bugsy.BugsyException as e:
-                # Attachment already succeeded; surface the comment failure
-                # without clobbering that fact.
-                response["comment_error"] = str(e)
-
-        return _jtext(response)
-
-    @tool(
-        "create_bug",
-        "File a new bug. Requires the proxy key to have allow_create=true. "
-        "The description becomes comment 0 and is rendered as Markdown. "
-        "Pass any additional Bugzilla POST /bug fields (severity, priority, "
-        "keywords, whiteboard, blocks, depends_on, cc, groups, op_sys, "
-        "platform, assigned_to, see_also, ...) via 'extra'. "
-        "Honours --dry-run and --confirm.",
-        {
-            "type": "object",
-            "properties": {
-                "product": {"type": "string"},
-                "component": {"type": "string"},
-                "summary": {"type": "string"},
-                "version": {"type": "string"},
-                "description": {
-                    "type": "string",
-                    "description": "Comment 0. Markdown is enabled.",
-                },
-                "extra": {
-                    "type": "object",
-                    "description": (
-                        "Optional additional fields accepted by Bugzilla's "
-                        "POST /bug endpoint. Merged into the request body."
-                    ),
-                    "additionalProperties": True,
-                },
-                "reasoning": {
-                    "type": "string",
-                    "description": "Why you are filing this bug (for audit log).",
-                },
-            },
-            "required": [
-                "product",
-                "component",
-                "summary",
-                "version",
-                "description",
-                "reasoning",
-            ],
-        },
-    )
-    async def create_bug(args):
-        reasoning = args["reasoning"]
-        body = {
-            "product": args["product"],
-            "component": args["component"],
-            "summary": args["summary"],
-            "version": args["version"],
-            "description": args["description"],
-            "is_markdown": True,
-        }
-        extra = args.get("extra") or {}
-        # Explicit top-level args win over anything smuggled in via extra.
-        for k, v in extra.items():
-            body.setdefault(k, v)
-
-        action_desc = {"reasoning": reasoning, "body": body}
-
-        if ctx.dry_run:
-            print("\n[DRY-RUN] create_bug", file=sys.stderr)
-            print(json.dumps(action_desc, indent=2, default=str), file=sys.stderr)
-            return _jtext(
-                {
-                    "dry_run": True,
-                    "would_create": body["summary"],
-                    "body": body,
-                    "note": "No request sent. Re-run without --dry-run to apply.",
-                }
-            )
-
-        if ctx.confirm and not await _confirm_prompt("create bug", action_desc):
-            return _jtext(
-                {
-                    "skipped": True,
-                    "reason": "User declined at --confirm prompt.",
-                }
-            )
-
-        try:
-            result = ctx.client.request("bug", method="POST", json=body)
-        except bugsy.BugsyException as e:
-            return _handle_bugsy_error(e)
-        return _jtext({"created": result.get("id"), "result": result})
-
     return create_sdk_mcp_server(
         name="bugzilla",
         version="0.1.0",
@@ -731,9 +318,5 @@ def build_server(ctx: BugzillaContext):
             get_bug_comments,
             get_bug_attachments,
             download_attachment,
-            update_bug,
-            add_comment,
-            add_attachment,
-            create_bug,
         ],
     )

--- a/bugbug/tools/bug_fix/config.py
+++ b/bugbug/tools/bug_fix/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import yaml
+from hackbot_runtime.actions.naming import ACTIONS_SERVER_NAME, tool_name_for
 
 # Tools that can modify the source repo — blocked under dry-run.
 SOURCE_WRITE_TOOLS = {"Write", "Edit", "MultiEdit", "NotebookEdit"}
@@ -15,11 +16,20 @@ BUGZILLA_READ_TOOLS = [
     "mcp__bugzilla__get_bug_attachments",
     "mcp__bugzilla__download_attachment",
 ]
-BUGZILLA_WRITE_TOOLS = [
-    "mcp__bugzilla__update_bug",
-    "mcp__bugzilla__add_comment",
-    "mcp__bugzilla__add_attachment",
-    "mcp__bugzilla__create_bug",
+# Recording action types this agent enables. Served by the in-process
+# `actions` MCP server (hackbot_runtime.actions.claude_sdk). Tool calls land
+# in summary.json's `actions` array instead of mutating any external system.
+# New domains (phabricator, treeherder, ...) just append to this list.
+ENABLED_ACTION_TYPES = [
+    "bugzilla.update_bug",
+    "bugzilla.add_comment",
+    "bugzilla.add_attachment",
+    "bugzilla.create_bug",
+]
+# claude-agent-sdk tool identifiers derived from the above, using the shared
+# server name and tool-name helper so they stay in sync with the adapter.
+ENABLED_ACTION_TOOLS = [
+    f"mcp__{ACTIONS_SERVER_NAME}__{tool_name_for(t)}" for t in ENABLED_ACTION_TYPES
 ]
 
 # Firefox build/test tools.

--- a/bugbug/tools/bug_fix/prompts/system.md
+++ b/bugbug/tools/bug_fix/prompts/system.md
@@ -64,22 +64,24 @@ Use it when:
 
 When you spawn an investigator via the Task tool, write a complete, self-contained prompt: what to look at, what question to answer, what format to return. The investigator has no memory of previous spawns.
 
-# Confidence and acting
+# Recording actions
 
-Before calling `update_bug` or `add_comment`, state in your response:
+The `actions` MCP tools (`bugzilla_update_bug`, `bugzilla_add_comment`, `bugzilla_add_attachment`, `bugzilla_create_bug`) do **not** mutate Bugzilla directly. They record an intended action into the run's `summary.json` for a human reviewer (or a downstream apply step) to enact. Treat each recorded action as a final, irrevocable proposal — once recorded it appears in the run output verbatim.
 
-- **What** you are about to change and **why** (cite the specific rule)
+Before calling any action tool, state in your response:
+
+- **What** action you are recording and **why** (cite the specific rule)
 - **Your confidence**: high / medium / low
 
-Only call `update_bug` to change fields when confidence is **high** and a specific triage rule directs it. If confidence is medium or low, `add_comment` instead to ask for clarification or note your findings — do not silently skip.
+Only record a `bugzilla_update_bug` action when confidence is **high** and a specific triage rule directs it. If confidence is medium or low, record a `bugzilla_add_comment` instead to ask for clarification or note your findings — do not silently skip.
 
-Never set `status: RESOLVED` unless a rule explicitly covers that case and you have verified the resolution condition.
+Never record `status: RESOLVED` unless a rule explicitly covers that case and you have verified the resolution condition.
 
-The `reasoning` parameter on `update_bug` / `add_comment` is required and logged. Fill it properly.
+The `reasoning` parameter on every action tool is required and stored alongside the recorded action. Fill it properly.
 
-Always be **brief** and to the point. Do not post long-winded comments, developers have limited time to find the necessary information.
+Always be **brief** and to the point. Do not record long-winded comments — developers have limited time to find the necessary information.
 
-Do **not** post private comments, all developers on the bug need to see the comments.
+Do **not** record private comments, all developers on the bug need to see the comments.
 
 Source-repo edits (Write/Edit) are allowed so you can prepare and inspect a candidate patch.
 

--- a/bugbug/tools/duplicate_bugs/agent.py
+++ b/bugbug/tools/duplicate_bugs/agent.py
@@ -498,7 +498,7 @@ class DuplicateBugsTool(GenerativeModelTool):
             raise ValueError("meta_bug is required for local/bugs modes")
 
         bz = bugsy.Bugsy(api_key=api_key, bugzilla_url=base_url)
-        bz_ctx = BugzillaContext(client=bz, dry_run=True)
+        bz_ctx = BugzillaContext(client=bz)
         bugzilla_server = build_bugzilla_server(bz_ctx)
 
         if mode == "local":

--- a/libs/hackbot-runtime/hackbot_runtime/__init__.py
+++ b/libs/hackbot-runtime/hackbot_runtime/__init__.py
@@ -1,12 +1,24 @@
+from hackbot_runtime.actions import (
+    ALL_ACTIONS,
+    ActionDefinition,
+    ActionInputError,
+    ActionsRecorder,
+    get_actions,
+)
 from hackbot_runtime.context import Context
 from hackbot_runtime.result import AgentResult
 from hackbot_runtime.runtime import run, run_async
 from hackbot_runtime.uploader import SignedPolicyUploader
 
 __all__ = [
+    "ALL_ACTIONS",
+    "ActionDefinition",
+    "ActionInputError",
+    "ActionsRecorder",
     "AgentResult",
     "Context",
     "SignedPolicyUploader",
+    "get_actions",
     "run",
     "run_async",
 ]

--- a/libs/hackbot-runtime/hackbot_runtime/actions/__init__.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/__init__.py
@@ -1,0 +1,26 @@
+"""Recordable actions for hackbot agents.
+
+The runtime exposes a generic ``ActionsRecorder`` plus a registry of
+domain-grouped declarative actions (``bugzilla.update_bug``,
+``bugzilla.add_comment``, ...). Per-framework wrappers (MCP today,
+LangChain later) wrap the registry without touching the action
+declarations themselves.
+"""
+
+from hackbot_runtime.actions import bugzilla as _bugzilla
+from hackbot_runtime.actions.recorder import ActionsRecorder
+from hackbot_runtime.actions.registry import (
+    ActionDefinition,
+    ActionInputError,
+    get_actions,
+)
+
+ALL_ACTIONS: list[ActionDefinition] = [*_bugzilla.DEFINITIONS]
+
+__all__ = [
+    "ALL_ACTIONS",
+    "ActionDefinition",
+    "ActionInputError",
+    "ActionsRecorder",
+    "get_actions",
+]

--- a/libs/hackbot-runtime/hackbot_runtime/actions/bugzilla.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/bugzilla.py
@@ -1,0 +1,259 @@
+"""Bugzilla-domain recordable actions.
+
+Each handler takes the ``ActionsRecorder`` as its first positional
+parameter (excluded from the agent-facing schema) plus the agent-facing
+args annotated with ``Annotated[T, Field(...)]`` so any adapter can derive
+the JSON Schema from the signature. Handlers return a short confirmation
+string and raise ``ActionInputError`` on invalid input.
+"""
+
+from __future__ import annotations
+
+import mimetypes
+import os
+from pathlib import Path
+from typing import Annotated, Any
+
+from pydantic import Field
+
+from hackbot_runtime.actions.recorder import ActionsRecorder
+from hackbot_runtime.actions.registry import ActionDefinition, ActionInputError
+
+_COMMENT_FOOTER = (
+    "*This is an automated analysis result. If this result is incorrect "
+    "please add a needinfo and feel free to correct the error.* "
+)
+_ATTACHMENT_COMMENT_FOOTER = (
+    "*This is the analysis tool's suggested fix. Feel welcome to adopt "
+    "it as a starting point and evolve it as needed to meet our coding "
+    "standards.*"
+)
+
+
+def _confirm(recorder: ActionsRecorder, action_type: str) -> str:
+    return f"Recorded {action_type} (#{len(recorder.actions) - 1})."
+
+
+async def update_bug(
+    recorder: ActionsRecorder,
+    bug_id: Annotated[int, Field(description="Bug ID to change.")],
+    changes: Annotated[
+        dict[str, Any],
+        Field(
+            description=(
+                "Field → new value. Accepts any field the Bugzilla REST "
+                "PUT endpoint accepts (status, resolution, priority, "
+                "severity, whiteboard, assigned_to, component, product, "
+                "version, ...). For list fields (keywords, cc, blocks, "
+                "depends_on, see_also) you may pass "
+                '{"add": [...], "remove": [...], "set": [...]}.'
+            )
+        ),
+    ],
+    reasoning: Annotated[
+        str,
+        Field(
+            description=(
+                "Why you are recording this change. Stored alongside the "
+                "action so the human reviewer can audit."
+            )
+        ),
+    ],
+) -> str:
+    recorder.record(
+        "bugzilla.update_bug",
+        {"bug_id": bug_id, "changes": changes},
+        reasoning=reasoning,
+    )
+    return _confirm(recorder, "bugzilla.update_bug")
+
+
+async def add_comment(
+    recorder: ActionsRecorder,
+    bug_id: Annotated[int, Field(description="Bug ID to comment on.")],
+    text: Annotated[str, Field(description="Comment body (Markdown supported).")],
+    reasoning: Annotated[
+        str, Field(description="Why you are recording this comment (for audit log).")
+    ],
+    is_private: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="Mark the comment private (security group only).",
+        ),
+    ] = False,
+) -> str:
+    text_with_footer = text.rstrip() + "\n\n" + _COMMENT_FOOTER
+    recorder.record(
+        "bugzilla.add_comment",
+        {"bug_id": bug_id, "text": text_with_footer, "is_private": is_private},
+        reasoning=reasoning,
+    )
+    return _confirm(recorder, "bugzilla.add_comment")
+
+
+async def add_attachment(
+    recorder: ActionsRecorder,
+    bug_id: Annotated[int, Field(description="Bug ID to attach to.")],
+    file_path: Annotated[
+        str,
+        Field(
+            description=(
+                "Local path to the file. The runtime uploads a copy as an "
+                "artifact so the apply step can fetch it; the local path "
+                "is not persisted."
+            )
+        ),
+    ],
+    reasoning: Annotated[
+        str, Field(description="Why you are attaching this (for audit log).")
+    ],
+    summary: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Short description of the attachment. Defaults to the filename.",
+        ),
+    ] = None,
+    content_type: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "MIME type. Guessed from extension if omitted. Ignored "
+                "when is_patch=true."
+            ),
+        ),
+    ] = None,
+    is_patch: Annotated[
+        bool,
+        Field(
+            default=False,
+            description=(
+                "Mark as a patch (Bugzilla forces text/plain and enables "
+                "diff view)."
+            ),
+        ),
+    ] = False,
+    comment: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Optional comment to record alongside the attachment.",
+        ),
+    ] = None,
+) -> str:
+    if not os.path.isfile(file_path):
+        raise ActionInputError(f"file not found: {file_path}")
+
+    file_name = os.path.basename(file_path)
+    resolved_summary = summary or file_name
+    size = os.path.getsize(file_path)
+    if is_patch:
+        resolved_content_type = "text/plain"
+    else:
+        resolved_content_type = content_type or (
+            mimetypes.guess_type(file_path)[0] or "application/octet-stream"
+        )
+
+    params: dict[str, Any] = {
+        "bug_id": bug_id,
+        "file_name": file_name,
+        "summary": resolved_summary,
+        "content_type": resolved_content_type,
+        "is_patch": is_patch,
+        "size_bytes": size,
+    }
+    if comment:
+        params["comment"] = comment.rstrip() + "\n\n" + _ATTACHMENT_COMMENT_FOOTER
+
+    recorder.record(
+        "bugzilla.add_attachment",
+        params,
+        reasoning=reasoning,
+        attachments={"file": Path(file_path)},
+    )
+    return _confirm(recorder, "bugzilla.add_attachment")
+
+
+async def create_bug(
+    recorder: ActionsRecorder,
+    product: Annotated[str, Field(description="Bugzilla product.")],
+    component: Annotated[str, Field(description="Bugzilla component.")],
+    summary: Annotated[str, Field(description="Bug summary (title).")],
+    version: Annotated[str, Field(description="Product version affected.")],
+    description: Annotated[
+        str, Field(description="Comment 0. Markdown is enabled.")
+    ],
+    reasoning: Annotated[
+        str, Field(description="Why you are filing this bug (for audit log).")
+    ],
+    extra: Annotated[
+        dict[str, Any] | None,
+        Field(
+            default=None,
+            description=(
+                "Optional additional fields accepted by Bugzilla's POST /bug "
+                "endpoint (severity, priority, keywords, whiteboard, blocks, "
+                "depends_on, cc, groups, op_sys, platform, assigned_to, "
+                "see_also, ...). Merged into the recorded body — explicit "
+                "top-level args win on conflict."
+            ),
+        ),
+    ] = None,
+) -> str:
+    body: dict[str, Any] = {
+        "product": product,
+        "component": component,
+        "summary": summary,
+        "version": version,
+        "description": description,
+        "is_markdown": True,
+    }
+    for k, v in (extra or {}).items():
+        body.setdefault(k, v)
+
+    recorder.record("bugzilla.create_bug", body, reasoning=reasoning)
+    return _confirm(recorder, "bugzilla.create_bug")
+
+
+DEFINITIONS: list[ActionDefinition] = [
+    ActionDefinition(
+        type="bugzilla.update_bug",
+        description=(
+            "Record an intended change to a Bugzilla bug. Recorded into the "
+            "run summary for human review — does not modify Bugzilla."
+        ),
+        handler=update_bug,
+    ),
+    ActionDefinition(
+        type="bugzilla.add_comment",
+        description=(
+            "Record an intended comment on a bug. Use is_private=true for "
+            "security-sensitive notes. Recorded into the run summary for "
+            "human review — does not post to Bugzilla."
+        ),
+        handler=add_comment,
+    ),
+    ActionDefinition(
+        type="bugzilla.add_attachment",
+        description=(
+            "Record an intended file attachment on a bug. Pass a local "
+            "filesystem path — the runtime uploads a copy of the file "
+            "alongside summary.json so the apply step can fetch it. For "
+            "patches, set is_patch=true and omit content_type. Recorded "
+            "into the run summary for human review — does not upload to "
+            "Bugzilla."
+        ),
+        handler=add_attachment,
+    ),
+    ActionDefinition(
+        type="bugzilla.create_bug",
+        description=(
+            "Record an intended new-bug filing. The description becomes "
+            "comment 0 and is rendered as Markdown. Recorded into the run "
+            "summary for human review — does not file in Bugzilla."
+        ),
+        handler=create_bug,
+    ),
+]

--- a/libs/hackbot-runtime/hackbot_runtime/actions/bugzilla.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/bugzilla.py
@@ -130,8 +130,7 @@ async def add_attachment(
         Field(
             default=False,
             description=(
-                "Mark as a patch (Bugzilla forces text/plain and enables "
-                "diff view)."
+                "Mark as a patch (Bugzilla forces text/plain and enables diff view)."
             ),
         ),
     ] = False,
@@ -182,9 +181,7 @@ async def create_bug(
     component: Annotated[str, Field(description="Bugzilla component.")],
     summary: Annotated[str, Field(description="Bug summary (title).")],
     version: Annotated[str, Field(description="Product version affected.")],
-    description: Annotated[
-        str, Field(description="Comment 0. Markdown is enabled.")
-    ],
+    description: Annotated[str, Field(description="Comment 0. Markdown is enabled.")],
     reasoning: Annotated[
         str, Field(description="Why you are filing this bug (for audit log).")
     ],

--- a/libs/hackbot-runtime/hackbot_runtime/actions/claude_sdk.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/claude_sdk.py
@@ -1,0 +1,49 @@
+"""claude-agent-sdk adapter for runtime-registered actions.
+
+Exposes the enabled actions as an in-process MCP server built with the
+SDK's own ``tool`` + ``create_sdk_mcp_server`` — guaranteed compatible with
+claude-agent-sdk. Other frameworks (LangChain, ...) get their own sibling
+adapter as needed; the action registry is shared and framework-neutral.
+
+Requires the ``claude-sdk`` optional extra of hackbot-runtime.
+"""
+
+from __future__ import annotations
+
+from claude_agent_sdk import create_sdk_mcp_server, tool
+
+from hackbot_runtime.actions.naming import ACTIONS_SERVER_NAME, tool_name_for
+from hackbot_runtime.actions.recorder import ActionsRecorder
+from hackbot_runtime.actions.registry import ActionDefinition, get_actions
+
+
+def _text(message: str) -> dict:
+    """Wrap a message in the MCP tool-result content shape the SDK expects."""
+    return {"content": [{"type": "text", "text": message}]}
+
+
+def _make_tool(defn: ActionDefinition, recorder: ActionsRecorder):
+    @tool(tool_name_for(defn.type), defn.description, defn.input_schema)
+    async def run(args):
+        # The handler returns a short confirmation string. An ActionInputError
+        # raised inside it propagates and is rendered by the SDK as an
+        # is_error result with the message preserved.
+        return _text(await defn.handler(recorder, **args))
+
+    return run
+
+
+def build_actions_sdk_server(
+    recorder: ActionsRecorder,
+    types: list[str] | None = None,
+    name: str = ACTIONS_SERVER_NAME,
+):
+    """Return a claude-agent-sdk ``McpSdkServerConfig`` for the enabled actions.
+
+    ``types`` selects a subset of action types; ``None`` exposes all.
+    """
+    return create_sdk_mcp_server(
+        name=name,
+        version="0.1.0",
+        tools=[_make_tool(defn, recorder) for defn in get_actions(types)],
+    )

--- a/libs/hackbot-runtime/hackbot_runtime/actions/naming.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/naming.py
@@ -1,0 +1,15 @@
+"""Shared naming for the actions MCP server.
+
+Kept dependency-light (no framework imports) so both the runtime adapter
+and agent-side config can derive identical tool names from one place.
+"""
+
+ACTIONS_SERVER_NAME = "actions"
+
+
+def tool_name_for(action_type: str) -> str:
+    """Map an action type to its MCP tool name.
+
+    ``"bugzilla.update_bug"`` -> ``"bugzilla_update_bug"``.
+    """
+    return action_type.replace(".", "_")

--- a/libs/hackbot-runtime/hackbot_runtime/actions/recorder.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/recorder.py
@@ -56,7 +56,10 @@ class ActionsRecorder:
             recorded_attachments: list[dict] = []
             for name, path in attachments.items():
                 key = publish_file(
-                    self._uploader, self._artifacts_dir, f"attachments/{idx}/{name}", path
+                    self._uploader,
+                    self._artifacts_dir,
+                    f"attachments/{idx}/{name}",
+                    path,
                 )
                 recorded_attachments.append({"name": name, "uploaded_key": key})
             action["attachments"] = recorded_attachments

--- a/libs/hackbot-runtime/hackbot_runtime/actions/recorder.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/recorder.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+from hackbot_runtime.artifacts import publish_file
+from hackbot_runtime.uploader import SignedPolicyUploader
+
+
+class ActionsRecorder:
+    """Collects structured actions an agent decided to take.
+
+    The runtime serialises the collected list into the
+    ``actions`` array of ``summary.json``; a downstream apply step picks
+    them up from there.
+
+    Framework-agnostic: knows nothing about MCP, LangChain, or any specific
+    action domain. Per-framework adapters wrap this and translate their
+    native tool calls into ``record(...)`` calls.
+    """
+
+    def __init__(
+        self,
+        uploader: SignedPolicyUploader | None = None,
+        artifacts_dir: Path | None = None,
+    ) -> None:
+        self._actions: list[dict] = []
+        self._uploader = uploader
+        self._artifacts_dir = artifacts_dir
+
+    def record(
+        self,
+        action_type: str,
+        params: dict,
+        *,
+        reasoning: str | None = None,
+        attachments: dict[str, Path] | None = None,
+    ) -> dict:
+        """Record an intended action.
+
+        ``action_type`` uses ``<domain>.<verb>`` (e.g. ``bugzilla.update_bug``,
+        ``phabricator.create_revision``). ``params`` is action-specific data
+        the apply step will need. ``attachments`` maps a logical name to a
+        local file path; each file is preserved under the stable key
+        ``attachments/<action_index>/<name>``: uploaded via the runtime
+        uploader when one is configured, otherwise copied into the local
+        artifacts directory (so it is retrievable from compose/direct runs).
+        The recorded action references it by that key; the original local
+        path is not persisted (it disappears with the container).
+        """
+        idx = len(self._actions)
+        action: dict = {
+            "type": action_type,
+            "params": params,
+            "reasoning": reasoning,
+        }
+
+        if attachments:
+            recorded_attachments: list[dict] = []
+            for name, path in attachments.items():
+                key = publish_file(
+                    self._uploader, self._artifacts_dir, f"attachments/{idx}/{name}", path
+                )
+                recorded_attachments.append({"name": name, "uploaded_key": key})
+            action["attachments"] = recorded_attachments
+
+        self._actions.append(action)
+        return action
+
+    @property
+    def actions(self) -> list[dict]:
+        return list(self._actions)

--- a/libs/hackbot-runtime/hackbot_runtime/actions/registry.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/registry.py
@@ -1,0 +1,63 @@
+import functools
+import inspect
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from pydantic import create_model
+
+
+class ActionInputError(Exception):
+    """Invalid action input (bad path, etc.).
+
+    Raised by handlers; a per-framework adapter turns it into the
+    framework's tool-error signal. The action layer imports no framework
+    error type.
+    """
+
+
+@dataclass
+class ActionDefinition:
+    """Declarative description of one recordable action.
+
+    ``handler`` is an async function whose **first positional parameter** is
+    the ``ActionsRecorder``. The remaining parameters carry typed
+    annotations (``Annotated[T, Field(...)]``) that double as the
+    agent-facing schema, exposed framework-neutrally via ``input_schema``.
+    Handlers return a short confirmation string.
+    """
+
+    type: str
+    description: str
+    handler: Callable[..., Awaitable[str]]
+
+    @functools.cached_property
+    def input_schema(self) -> dict:
+        """JSON schema of the agent-facing arguments (excludes ``recorder``).
+
+        Derived once from the handler signature so every adapter (MCP today,
+        LangChain later) shares one schema.
+        """
+        sig = inspect.signature(self.handler, eval_str=True)
+        fields = {
+            name: (
+                param.annotation,
+                ... if param.default is inspect.Parameter.empty else param.default,
+            )
+            for name, param in list(sig.parameters.items())[1:]  # skip `recorder`
+        }
+        model = create_model(self.type.replace(".", "_") + "_args", **fields)
+        return model.model_json_schema()
+
+
+def get_actions(types: list[str] | None = None) -> list[ActionDefinition]:
+    """Return registered actions, optionally filtered by ``type`` list.
+
+    Import is deferred to avoid an import cycle between the registry and
+    the per-domain modules that register actions.
+    """
+    from hackbot_runtime.actions import ALL_ACTIONS
+
+    if types is None:
+        return list(ALL_ACTIONS)
+    wanted = set(types)
+    return [a for a in ALL_ACTIONS if a.type in wanted]

--- a/libs/hackbot-runtime/hackbot_runtime/artifacts.py
+++ b/libs/hackbot-runtime/hackbot_runtime/artifacts.py
@@ -1,0 +1,63 @@
+"""Publish run artifacts: upload via the signed policy, else write locally.
+
+A single rule across the runtime — summary, logs, attachments: if an uploader
+is configured the artifact is uploaded under ``key``; otherwise it is written
+to ``artifacts_dir / key`` so local/compose/direct runs leave everything
+retrievable on the host. Both branches use the same ``key``, so a downstream
+apply step resolves it identically against GCS or the local dir.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from hackbot_runtime.uploader import SignedPolicyUploader
+
+
+def publish_file(
+    uploader: SignedPolicyUploader | None,
+    artifacts_dir: Path | None,
+    key: str,
+    path: Path,
+    content_type: str | None = None,
+) -> str:
+    if uploader is not None:
+        uploader.upload_file(key, path, content_type)
+    elif artifacts_dir is not None:
+        dest = artifacts_dir / key
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(path, dest)
+    return key
+
+
+def publish_bytes(
+    uploader: SignedPolicyUploader | None,
+    artifacts_dir: Path | None,
+    key: str,
+    data: bytes,
+    content_type: str = "application/octet-stream",
+) -> str:
+    if uploader is not None:
+        uploader.upload_bytes(key, data, content_type)
+    elif artifacts_dir is not None:
+        dest = artifacts_dir / key
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(data)
+    return key
+
+
+def publish_json(
+    uploader: SignedPolicyUploader | None,
+    artifacts_dir: Path | None,
+    key: str,
+    payload: dict,
+) -> str:
+    return publish_bytes(
+        uploader,
+        artifacts_dir,
+        key,
+        json.dumps(payload, indent=2, default=str).encode("utf-8"),
+        "application/json",
+    )

--- a/libs/hackbot-runtime/hackbot_runtime/context.py
+++ b/libs/hackbot-runtime/hackbot_runtime/context.py
@@ -1,23 +1,47 @@
+import datetime
+import uuid
 from functools import cached_property
+from pathlib import Path
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from hackbot_runtime import artifacts
+from hackbot_runtime.actions import ActionsRecorder
 from hackbot_runtime.uploader import SignedPolicyUploader
+
+
+def _default_run_id() -> str:
+    """A unique, sortable id for runs that don't get one from the platform.
+
+    The orchestrator sets ``RUN_ID`` explicitly in production; this fallback
+    keeps local/compose/direct runs unique (so per-run artifact dirs don't
+    collide). The ``local-`` prefix marks it as not platform-assigned.
+    """
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d-%H%M%S")
+    return f"local-{stamp}-{uuid.uuid4().hex[:6]}"
 
 
 class Context(BaseSettings):
     """Platform context handed to every agent's main() by the runtime.
 
-    `run_id` is required. The results-upload fields are optional so
+    `run_id` defaults to a generated unique id (the orchestrator overrides it
+    via ``RUN_ID`` in production). The results-upload fields are optional so
     local-dev runs (compose, scripts) can start the agent without a
-    signed POST policy — in that case the runtime skips the summary
-    upload and logs a warning rather than failing.
+    signed POST policy — in that case the runtime writes results into the
+    local artifacts dir rather than uploading.
     """
 
-    run_id: str
+    run_id: str = Field(default_factory=_default_run_id)
     results_prefix: str = ""
     results_policy_url: str | None = None
     results_policy_fields: dict[str, str] = {}
+    # Base for locally-persisted artifacts when no uploader is configured
+    # (compose/direct runs). Each run is namespaced under it by run_id (see
+    # `run_artifacts_dir`). Overridable via ARTIFACTS_DIR — compose points this
+    # at a host-mounted dir; the default stays relative so it does not bake a
+    # host path into the container.
+    artifacts_dir: Path = Path("artifacts")
 
     model_config = SettingsConfigDict(extra="ignore")
 
@@ -29,4 +53,27 @@ class Context(BaseSettings):
             url=self.results_policy_url,
             fields=self.results_policy_fields,
             prefix=self.results_prefix,
+        )
+
+    @cached_property
+    def run_artifacts_dir(self) -> Path:
+        """Per-run local artifacts directory: ``artifacts_dir / run_id``."""
+        return self.artifacts_dir / self.run_id
+
+    @cached_property
+    def actions(self) -> ActionsRecorder:
+        return ActionsRecorder(self.uploader, artifacts_dir=self.run_artifacts_dir)
+
+    def publish_file(
+        self, key: str, path: Path, content_type: str | None = None
+    ) -> str:
+        """Upload ``path`` under ``key``, else copy it into the artifacts dir."""
+        return artifacts.publish_file(
+            self.uploader, self.run_artifacts_dir, key, path, content_type
+        )
+
+    def publish_json(self, key: str, payload: dict) -> str:
+        """Upload ``payload`` JSON under ``key``, else write it to artifacts."""
+        return artifacts.publish_json(
+            self.uploader, self.run_artifacts_dir, key, payload
         )

--- a/libs/hackbot-runtime/hackbot_runtime/result.py
+++ b/libs/hackbot-runtime/hackbot_runtime/result.py
@@ -8,7 +8,8 @@ class AgentResult:
 
     The runtime serialises this into the summary.json artifact the orchestrator
     reads. `status` drives the run's terminal state in hackbot-api; `findings`
-    is opaque to the platform and surfaced verbatim.
+    is opaque to the platform and surfaced verbatim. Recorded actions are not
+    carried here — the runtime reads them from `Context.actions`.
     """
 
     status: Literal["ok", "error"] = "ok"

--- a/libs/hackbot-runtime/hackbot_runtime/runtime.py
+++ b/libs/hackbot-runtime/hackbot_runtime/runtime.py
@@ -26,19 +26,22 @@ def _configure_logging() -> None:
         )
 
 
-def _summary_payload_from_result(result: AgentResult) -> dict:
+def _summary_payload_from_result(result: AgentResult, ctx: Context) -> dict:
+    # Actions are recorded via Context.actions; the result never carries them.
     return {
         "status": result.status,
         "error": result.error,
         "findings": result.findings,
+        "actions": ctx.actions.actions,
     }
 
 
-def _summary_payload_from_exception(exc: BaseException) -> dict:
+def _summary_payload_from_exception(exc: BaseException, ctx: Context) -> dict:
     return {
         "status": "error",
         "error": f"{type(exc).__name__}: {exc}",
         "findings": {"traceback": traceback.format_exc()},
+        "actions": ctx.actions.actions,
     }
 
 
@@ -55,25 +58,25 @@ def _load_context() -> Context | None:
 
 def _finish(ctx: Context, result_or_exc: AgentResult | BaseException) -> int:
     if isinstance(result_or_exc, AgentResult):
-        payload = _summary_payload_from_result(result_or_exc)
+        payload = _summary_payload_from_result(result_or_exc, ctx)
         exit_code = result_or_exc.exit_code
     else:
-        payload = _summary_payload_from_exception(result_or_exc)
+        payload = _summary_payload_from_exception(result_or_exc, ctx)
         exit_code = 1
 
-    if ctx.uploader is None:
-        log.warning(
-            "RESULTS_POLICY_URL not configured; skipping summary.json upload. "
-            "Summary that would have been uploaded: %s",
-            payload,
-        )
-        return exit_code
-
+    # Upload when a signed policy is configured, else write into the local
+    # artifacts dir (so local/compose/direct runs leave it on the host).
     try:
-        ctx.uploader.upload_json(_SUMMARY_NAME, payload)
+        ctx.publish_json(_SUMMARY_NAME, payload)
     except Exception:
-        log.exception("Failed to upload summary.json")
+        log.exception("Failed to publish summary.json")
         return 1 if exit_code == 0 else exit_code
+
+    if ctx.uploader is None:
+        log.info(
+            "RESULTS_POLICY_URL not configured; wrote summary to %s.",
+            ctx.run_artifacts_dir / _SUMMARY_NAME,
+        )
 
     return exit_code
 

--- a/libs/hackbot-runtime/pyproject.toml
+++ b/libs/hackbot-runtime/pyproject.toml
@@ -7,3 +7,13 @@ dependencies = [
     "requests>=2.32.0",
     "pydantic-settings>=2.1.0",
 ]
+
+[project.optional-dependencies]
+# claude-agent-sdk adapter (hackbot_runtime.actions.claude_sdk) that exposes
+# the action registry as an in-process MCP server. Not needed by consumers
+# that only read the summary contract.
+claude-sdk = ["claude-agent-sdk>=0.1.30"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/libs/hackbot-runtime/tests/test_bugzilla_actions.py
+++ b/libs/hackbot-runtime/tests/test_bugzilla_actions.py
@@ -1,0 +1,71 @@
+"""Tests for the bugzilla action handlers (footers, mime, merge, errors)."""
+
+import pytest
+from hackbot_runtime.actions import ActionInputError, ActionsRecorder, bugzilla
+
+
+async def test_add_comment_appends_footer():
+    rec = ActionsRecorder()
+    await bugzilla.add_comment(rec, bug_id=1, text="Looks invalid.", reasoning="r")
+    text = rec.actions[0]["params"]["text"]
+    assert text.startswith("Looks invalid.")
+    assert "automated analysis result" in text
+    assert rec.actions[0]["params"]["is_private"] is False
+
+
+async def test_add_attachment_patch_forces_text_plain(tmp_path):
+    src = tmp_path / "fix.patch"
+    src.write_text("diff")
+    rec = ActionsRecorder(artifacts_dir=tmp_path / "a")
+    await bugzilla.add_attachment(
+        rec, bug_id=1, file_path=str(src), reasoning="r", is_patch=True, comment="fix"
+    )
+    params = rec.actions[0]["params"]
+    assert params["content_type"] == "text/plain"
+    assert params["is_patch"] is True
+    assert "suggested fix" in params["comment"]
+    assert params["file_name"] == "fix.patch"
+
+
+async def test_add_attachment_guesses_mime(tmp_path):
+    src = tmp_path / "note.txt"
+    src.write_text("hi")
+    rec = ActionsRecorder(artifacts_dir=tmp_path / "a")
+    await bugzilla.add_attachment(rec, bug_id=1, file_path=str(src), reasoning="r")
+    assert rec.actions[0]["params"]["content_type"] == "text/plain"
+
+
+async def test_add_attachment_missing_file_raises():
+    rec = ActionsRecorder()
+    with pytest.raises(ActionInputError):
+        await bugzilla.add_attachment(
+            rec, bug_id=1, file_path="/no/such.patch", reasoning="r"
+        )
+    assert rec.actions == []
+
+
+async def test_create_bug_merges_extra_top_level_wins():
+    rec = ActionsRecorder()
+    await bugzilla.create_bug(
+        rec,
+        product="Core",
+        component="JS",
+        summary="x",
+        version="unspecified",
+        description="desc",
+        reasoning="r",
+        extra={"severity": "S3", "product": "IGNORED"},
+    )
+    body = rec.actions[0]["params"]
+    assert body["severity"] == "S3"
+    assert body["product"] == "Core"  # explicit arg wins over extra
+    assert body["is_markdown"] is True
+
+
+async def test_handlers_return_confirmation_string():
+    rec = ActionsRecorder()
+    msg = await bugzilla.update_bug(
+        rec, bug_id=1, changes={"severity": "S2"}, reasoning="r"
+    )
+    assert isinstance(msg, str)
+    assert "bugzilla.update_bug" in msg

--- a/libs/hackbot-runtime/tests/test_claude_sdk.py
+++ b/libs/hackbot-runtime/tests/test_claude_sdk.py
@@ -1,0 +1,84 @@
+"""Tests for the claude-agent-sdk actions adapter (guards issue #1)."""
+
+import mcp.server.lowlevel.server as low
+from hackbot_runtime.actions import ActionsRecorder
+from hackbot_runtime.actions.claude_sdk import build_actions_sdk_server
+from mcp.types import CallToolRequest, CallToolRequestParams, ListToolsRequest
+
+_ALL = [
+    "bugzilla.update_bug",
+    "bugzilla.add_comment",
+    "bugzilla.add_attachment",
+    "bugzilla.create_bug",
+]
+
+
+def _server(recorder):
+    config = build_actions_sdk_server(recorder, types=_ALL)
+    assert config["type"] == "sdk"
+    return config["instance"]
+
+
+async def _list(srv):
+    return (
+        await srv.request_handlers[ListToolsRequest](ListToolsRequest(method="tools/list"))
+    ).root.tools
+
+
+async def _call(srv, name, arguments):
+    return (
+        await srv.request_handlers[CallToolRequest](
+            CallToolRequest(
+                method="tools/call",
+                params=CallToolRequestParams(name=name, arguments=arguments),
+            )
+        )
+    ).root
+
+
+def test_returns_lowlevel_server():
+    srv = _server(ActionsRecorder())
+    assert isinstance(srv, low.Server)
+    assert ListToolsRequest in srv.request_handlers
+    assert CallToolRequest in srv.request_handlers
+
+
+async def test_lists_expected_tools_without_recorder():
+    srv = _server(ActionsRecorder())
+    tools = await _list(srv)
+    assert {t.name for t in tools} == {
+        "bugzilla_update_bug",
+        "bugzilla_add_comment",
+        "bugzilla_add_attachment",
+        "bugzilla_create_bug",
+    }
+    for t in tools:
+        assert "recorder" not in t.inputSchema.get("properties", {})
+
+
+async def test_call_records_action():
+    recorder = ActionsRecorder()
+    srv = _server(recorder)
+    result = await _call(
+        srv,
+        "bugzilla_update_bug",
+        {"bug_id": 7, "changes": {"severity": "S2"}, "reasoning": "rule X"},
+    )
+    assert result.isError is False
+    assert recorder.actions[0]["type"] == "bugzilla.update_bug"
+    assert recorder.actions[0]["params"] == {
+        "bug_id": 7,
+        "changes": {"severity": "S2"},
+    }
+
+
+async def test_missing_file_surfaces_is_error():
+    srv = _server(ActionsRecorder())
+    result = await _call(
+        srv,
+        "bugzilla_add_attachment",
+        {"bug_id": 7, "file_path": "/no/such/file.patch", "reasoning": "r"},
+    )
+    assert result.isError is True
+    text = " ".join(getattr(c, "text", "") for c in result.content)
+    assert "file not found" in text

--- a/libs/hackbot-runtime/tests/test_claude_sdk.py
+++ b/libs/hackbot-runtime/tests/test_claude_sdk.py
@@ -21,7 +21,9 @@ def _server(recorder):
 
 async def _list(srv):
     return (
-        await srv.request_handlers[ListToolsRequest](ListToolsRequest(method="tools/list"))
+        await srv.request_handlers[ListToolsRequest](
+            ListToolsRequest(method="tools/list")
+        )
     ).root.tools
 
 

--- a/libs/hackbot-runtime/tests/test_recorder.py
+++ b/libs/hackbot-runtime/tests/test_recorder.py
@@ -1,0 +1,78 @@
+"""Tests for ActionsRecorder: attachment upload vs local-copy behavior."""
+
+from pathlib import Path
+
+from hackbot_runtime.actions import ActionsRecorder
+
+
+class _StubUploader:
+    def __init__(self):
+        self.uploaded: list[tuple[str, Path]] = []
+
+    def upload_file(self, name, path, content_type=None):
+        self.uploaded.append((name, Path(path)))
+
+
+def test_record_basic_shape():
+    rec = ActionsRecorder()
+    returned = rec.record(
+        "bugzilla.update_bug",
+        {"bug_id": 1, "changes": {"severity": "S2"}},
+        reasoning="rule X",
+    )
+    assert returned == rec.actions[0]
+    assert rec.actions == [
+        {
+            "type": "bugzilla.update_bug",
+            "params": {"bug_id": 1, "changes": {"severity": "S2"}},
+            "reasoning": "rule X",
+        }
+    ]
+
+
+def test_action_type_is_positional():
+    # The first parameter is `action_type`; passing it positionally must work.
+    rec = ActionsRecorder()
+    rec.record("bugzilla.add_comment", {"bug_id": 1})
+    assert rec.actions[0]["type"] == "bugzilla.add_comment"
+
+
+def test_attachment_uploaded_when_uploader_set(tmp_path):
+    src = tmp_path / "fix.patch"
+    src.write_text("diff")
+    uploader = _StubUploader()
+    artifacts = tmp_path / "artifacts"
+    rec = ActionsRecorder(uploader=uploader, artifacts_dir=artifacts)
+
+    rec.record("bugzilla.add_attachment", {"bug_id": 1}, attachments={"file": src})
+
+    # Uploaded under the stable key; NOT copied locally.
+    assert uploader.uploaded == [("attachments/0/file", src)]
+    assert not artifacts.exists()
+    assert rec.actions[0]["attachments"] == [
+        {"name": "file", "uploaded_key": "attachments/0/file"}
+    ]
+
+
+def test_attachment_copied_when_no_uploader(tmp_path):
+    src = tmp_path / "fix.patch"
+    src.write_text("diff-content")
+    artifacts = tmp_path / "artifacts"
+    rec = ActionsRecorder(artifacts_dir=artifacts)
+
+    rec.record("bugzilla.add_attachment", {"bug_id": 1}, attachments={"file": src})
+
+    copied = artifacts / "attachments/0/file"
+    assert copied.read_text() == "diff-content"
+    assert rec.actions[0]["attachments"] == [
+        {"name": "file", "uploaded_key": "attachments/0/file"}
+    ]
+
+
+def test_attachment_key_uses_action_index(tmp_path):
+    src = tmp_path / "f.txt"
+    src.write_text("x")
+    rec = ActionsRecorder(artifacts_dir=tmp_path / "a")
+    rec.record("bugzilla.update_bug", {"bug_id": 1})
+    rec.record("bugzilla.add_attachment", {"bug_id": 1}, attachments={"file": src})
+    assert rec.actions[1]["attachments"][0]["uploaded_key"] == "attachments/1/file"

--- a/libs/hackbot-runtime/tests/test_registry.py
+++ b/libs/hackbot-runtime/tests/test_registry.py
@@ -1,0 +1,47 @@
+"""Tests for the action registry and schema derivation."""
+
+from hackbot_runtime.actions import ActionInputError, get_actions
+from hackbot_runtime.actions.registry import ActionDefinition
+
+_BUGZILLA_TYPES = {
+    "bugzilla.update_bug",
+    "bugzilla.add_comment",
+    "bugzilla.add_attachment",
+    "bugzilla.create_bug",
+}
+
+
+def test_get_actions_returns_all():
+    assert {a.type for a in get_actions()} == _BUGZILLA_TYPES
+
+
+def test_get_actions_filtered():
+    got = get_actions(["bugzilla.update_bug", "bugzilla.add_comment"])
+    assert {a.type for a in got} == {"bugzilla.update_bug", "bugzilla.add_comment"}
+
+
+def test_action_input_error_is_exception():
+    assert issubclass(ActionInputError, Exception)
+
+
+def test_input_schema_excludes_recorder_and_keeps_descriptions():
+    update = next(a for a in get_actions() if a.type == "bugzilla.update_bug")
+    schema = update.input_schema
+    props = schema["properties"]
+    assert "recorder" not in props
+    assert set(props) == {"bug_id", "changes", "reasoning"}
+    assert set(schema["required"]) == {"bug_id", "changes", "reasoning"}
+    assert props["bug_id"]["description"]
+
+
+def test_input_schema_marks_optional_params():
+    comment = next(a for a in get_actions() if a.type == "bugzilla.add_comment")
+    # is_private has a default -> not required.
+    assert "is_private" not in comment.input_schema.get("required", [])
+
+
+def test_input_schema_is_cached():
+    defn = ActionDefinition(
+        type="x.y", description="d", handler=get_actions()[0].handler
+    )
+    assert defn.input_schema is defn.input_schema

--- a/libs/hackbot-runtime/tests/test_runtime.py
+++ b/libs/hackbot-runtime/tests/test_runtime.py
@@ -63,7 +63,9 @@ def test_runs_are_namespaced_by_run_id(tmp_path):
 
     base = tmp_path / "artifacts"
     assert json.loads((base / "run-a" / "summary.json").read_text())["status"] == "ok"
-    assert json.loads((base / "run-b" / "summary.json").read_text())["status"] == "error"
+    assert (
+        json.loads((base / "run-b" / "summary.json").read_text())["status"] == "error"
+    )
 
 
 def test_publish_file_copies_locally_without_uploader(tmp_path):

--- a/libs/hackbot-runtime/tests/test_runtime.py
+++ b/libs/hackbot-runtime/tests/test_runtime.py
@@ -1,0 +1,78 @@
+"""Tests for summary persistence when no uploader is configured."""
+
+import json
+
+from hackbot_runtime import AgentResult, Context
+from hackbot_runtime.runtime import _finish
+
+
+def test_run_id_defaults_to_unique_generated_id(monkeypatch):
+    monkeypatch.delenv("RUN_ID", raising=False)
+    a, b = Context(), Context()
+    assert a.run_id != b.run_id
+    assert a.run_id.startswith("local-")
+
+
+def test_run_id_env_overrides_default(monkeypatch):
+    monkeypatch.setenv("RUN_ID", "orchestrator-42")
+    assert Context().run_id == "orchestrator-42"
+
+
+def _ctx(tmp_path, run_id="local-test"):
+    # No results_policy_url -> uploader is None -> local artifacts path.
+    return Context(run_id=run_id, artifacts_dir=tmp_path / "artifacts")
+
+
+def test_summary_written_locally_without_uploader(tmp_path):
+    ctx = _ctx(tmp_path)
+    ctx.actions.record(
+        "bugzilla.update_bug",
+        {"bug_id": 1, "changes": {"severity": "S2"}},
+        reasoning="rule X",
+    )
+
+    code = _finish(ctx, AgentResult(status="ok", findings={"bugs_processed": 1}))
+
+    assert code == 0
+    # Written under the per-run subdir: artifacts_dir / run_id.
+    summary = json.loads(
+        (tmp_path / "artifacts" / "local-test" / "summary.json").read_text()
+    )
+    assert summary["status"] == "ok"
+    assert summary["findings"] == {"bugs_processed": 1}
+    assert summary["actions"][0]["type"] == "bugzilla.update_bug"
+
+
+def test_summary_written_for_exception(tmp_path):
+    ctx = _ctx(tmp_path)
+    code = _finish(ctx, RuntimeError("boom"))
+
+    assert code == 1
+    summary = json.loads(
+        (tmp_path / "artifacts" / "local-test" / "summary.json").read_text()
+    )
+    assert summary["status"] == "error"
+    assert "boom" in summary["error"]
+
+
+def test_runs_are_namespaced_by_run_id(tmp_path):
+    ctx_a = _ctx(tmp_path, run_id="run-a")
+    ctx_b = _ctx(tmp_path, run_id="run-b")
+    _finish(ctx_a, AgentResult(status="ok"))
+    _finish(ctx_b, AgentResult(status="error", error="x"))
+
+    base = tmp_path / "artifacts"
+    assert json.loads((base / "run-a" / "summary.json").read_text())["status"] == "ok"
+    assert json.loads((base / "run-b" / "summary.json").read_text())["status"] == "error"
+
+
+def test_publish_file_copies_locally_without_uploader(tmp_path):
+    ctx = _ctx(tmp_path)
+    log = tmp_path / "agent.log"
+    log.write_text("hello log")
+
+    key = ctx.publish_file("logs/agent.log", log)
+
+    assert key == "logs/agent.log"
+    written = tmp_path / "artifacts" / "local-test" / "logs" / "agent.log"
+    assert written.read_text() == "hello log"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "beautifulsoup4~=4.14.3",
     "boto3>=1.42.78,<1.44.0",
     "claude-agent-sdk>=0.1.30",
-    "hackbot-runtime[claude-sdk]",
     "httpx~=0.28.1",
     "imbalanced-learn~=0.14.1",
     "langchain~=1.2.13",
@@ -72,6 +71,12 @@ nlp = [
     "spacy==3.8.14",
 ]
 nn = []
+# Tooling for the hackbot bug-fix agent (bugbug/tools/bug_fix). Not a base
+# dependency: hackbot-runtime is a workspace-only package, so a standalone
+# `pip install bugbug` must not require it.
+bug-fix = [
+    "hackbot-runtime[claude-sdk]",
+]
 
 [dependency-groups]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "beautifulsoup4~=4.14.3",
     "boto3>=1.42.78,<1.44.0",
     "claude-agent-sdk>=0.1.30",
+    "hackbot-runtime[claude-sdk]",
     "httpx~=0.28.1",
     "imbalanced-learn~=0.14.1",
     "langchain~=1.2.13",
@@ -134,6 +135,9 @@ artifacts = [
 
 [tool.uv.workspace]
 members = ["http_service", "services/hackbot-api", "agents/bug-fix", "libs/hackbot-runtime"]
+
+[tool.uv.sources]
+hackbot-runtime = { workspace = true }
 
 [tool.ruff]
 extend-exclude = ["data"]

--- a/scripts/run_bug_fix.py
+++ b/scripts/run_bug_fix.py
@@ -35,7 +35,6 @@ async def main():
                 api_key=settings.bugzilla_api_key,
                 bugzilla_url=settings.bugzilla_api_url,
             ),
-            dry_run=True,
         )
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -514,7 +514,6 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "claude-agent-sdk" },
-    { name = "hackbot-runtime", extra = ["claude-sdk"] },
     { name = "httpx" },
     { name = "imbalanced-learn" },
     { name = "langchain" },
@@ -562,6 +561,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+bug-fix = [
+    { name = "hackbot-runtime", extra = ["claude-sdk"] },
+]
 nlp = [
     { name = "spacy" },
 ]
@@ -593,7 +595,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = "~=4.14.3" },
     { name = "boto3", specifier = ">=1.42.78,<1.44.0" },
     { name = "claude-agent-sdk", specifier = ">=0.1.30" },
-    { name = "hackbot-runtime", extras = ["claude-sdk"], editable = "libs/hackbot-runtime" },
+    { name = "hackbot-runtime", extras = ["claude-sdk"], marker = "extra == 'bug-fix'", editable = "libs/hackbot-runtime" },
     { name = "httpx", specifier = "~=0.28.1" },
     { name = "imbalanced-learn", specifier = "~=0.14.1" },
     { name = "langchain", specifier = "~=1.2.13" },
@@ -640,7 +642,7 @@ requires-dist = [
     { name = "xgboost", specifier = "~=3.2.0" },
     { name = "zstandard", specifier = "~=0.25.0" },
 ]
-provides-extras = ["nlp", "nn"]
+provides-extras = ["bug-fix", "nlp", "nn"]
 
 [package.metadata.requires-dev]
 spawn-pipeline = [
@@ -2111,7 +2113,7 @@ dependencies = [
     { name = "bugsy" },
     { name = "claude-agent-sdk" },
     { name = "grizzly-framework" },
-    { name = "hackbot-runtime" },
+    { name = "hackbot-runtime", extra = ["claude-sdk"] },
     { name = "mcp" },
     { name = "prefpicker" },
     { name = "starlette" },
@@ -2124,7 +2126,7 @@ requires-dist = [
     { name = "bugsy" },
     { name = "claude-agent-sdk", specifier = ">=0.1.30" },
     { name = "grizzly-framework" },
-    { name = "hackbot-runtime", editable = "libs/hackbot-runtime" },
+    { name = "hackbot-runtime", extras = ["claude-sdk"], editable = "libs/hackbot-runtime" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "prefpicker" },
     { name = "starlette", specifier = ">=0.36.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -245,7 +245,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.105.2"
+version = "0.107.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -257,9 +257,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/46/47581b8c689c743ceabf6a0f9ff48472160900ce802d26c0fb50423997b3/anthropic-0.105.2.tar.gz", hash = "sha256:0e26b90841c2dced7cc6e98d21d5517d0be33f1876b8e779f478202e28bcaa07", size = 853789, upload-time = "2026-05-29T00:21:14.104Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/f1/c6076a92e0bf6b0dfa126e213b3f9e8a510acd73567953210713aae6c256/anthropic-0.107.1.tar.gz", hash = "sha256:8e7169a6ab57fb806b778d9af018c867bad688144efec8969cdb4c5ccecd6670", size = 856312, upload-time = "2026-06-07T17:18:57.358Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/75/be0c357e33a5a56c8f9db5b4212f886138d2bf59c0952d858f6b75d710ef/anthropic-0.105.2-py3-none-any.whl", hash = "sha256:e53ed5f6bf36fb1ecb9b25d8634cfd30e02fab9fb3374a0c2d5c585874757230", size = 837507, upload-time = "2026-05-29T00:21:15.528Z" },
+    { url = "https://files.pythonhosted.org/packages/86/0e/71432f0777a263701955a23ebcc6650485c2753be9afbce2a6a8d72526e3/anthropic-0.107.1-py3-none-any.whl", hash = "sha256:b74338d08000ba105dfc8adae29af3713ece845a4bffec9986a20697e087c7b3", size = 838729, upload-time = "2026-06-07T17:18:58.729Z" },
 ]
 
 [[package]]
@@ -467,30 +467,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.19"
+version = "1.43.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/da/229987ebb70daf5928f959aa8f4dd77dfcf425e6b0e7ff03aaef61ccc333/boto3-1.43.19.tar.gz", hash = "sha256:8b84704719dd3960ac12a8f37d9ff5adb853715baa9742f84fdbe2de0305c4cb", size = 113225, upload-time = "2026-06-01T19:33:06.514Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/8f/94dfa39ec618ecb2fe5b5b79428c95100e3ae3c1aa5083c283dd3cfb5ecd/boto3-1.43.24.tar.gz", hash = "sha256:ba5afa266bf7265e0c1a454fcfd48bffe5939cb16ed223bebc669c3dc8ee0bc8", size = 113154, upload-time = "2026-06-05T19:30:01.635Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/cc/77097be39d83068f864767b710cee0d8f9cd61331de816dd2675a596c328/boto3-1.43.19-py3-none-any.whl", hash = "sha256:ec6825193b75fbb6bfbf12181e4960d00ad2f404343586765394ce620e63783c", size = 140535, upload-time = "2026-06-01T19:33:03.758Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e66c9b37b96153aa371fe48d24194151293f6577dd3eaa1fc146c281456d/boto3-1.43.24-py3-none-any.whl", hash = "sha256:b18ef745274ef548a9660d733d985d4a971b16bd8a6af88165ea9d0e40913b86", size = 140536, upload-time = "2026-06-05T19:29:58.968Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.19"
+version = "1.43.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/a7/298986789785b74a954e2347114993be7e6b070417159125a6865f2687b6/botocore-1.43.19.tar.gz", hash = "sha256:18ac2fdd76c89b940707eb10493ff58678adad337d03215caec2d408ccd43cc0", size = 15435441, upload-time = "2026-06-01T19:32:53.126Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/55d0611b341482bc9649d16df765f849a1862184ac3709356decf632279f/botocore-1.43.24.tar.gz", hash = "sha256:0c02f2b40e99419d496ece0ea2dcdedb5c45998c16fd1674276c7dbb30767a16", size = 15471690, upload-time = "2026-06-05T19:29:33.731Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/75/fe4d45bdd08afd66f3d5273db58f3d8a29365e52ce3a0851f7f5e5900943/botocore-1.43.19-py3-none-any.whl", hash = "sha256:99dbdccbf748974750601e805cecc9362a85d11fee89d6d58cd3f4ff302e6ff9", size = 15117709, upload-time = "2026-06-01T19:32:47.871Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b7/360b5afe74c4d7cff871ea6e8f335e2e11de2945c9deb1eea6438f49faa2/botocore-1.43.24-py3-none-any.whl", hash = "sha256:42903b4bfafd8f15a735ed940473f28e4ba21b2ea67a9b9aaa11dfa7fcb19fd5", size = 15155182, upload-time = "2026-06-05T19:29:29.457Z" },
 ]
 
 [[package]]
@@ -514,6 +514,7 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "claude-agent-sdk" },
+    { name = "hackbot-runtime", extra = ["claude-sdk"] },
     { name = "httpx" },
     { name = "imbalanced-learn" },
     { name = "langchain" },
@@ -592,6 +593,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = "~=4.14.3" },
     { name = "boto3", specifier = ">=1.42.78,<1.44.0" },
     { name = "claude-agent-sdk", specifier = ">=0.1.30" },
+    { name = "hackbot-runtime", extras = ["claude-sdk"], editable = "libs/hackbot-runtime" },
     { name = "httpx", specifier = "~=0.28.1" },
     { name = "imbalanced-learn", specifier = "~=0.14.1" },
     { name = "langchain", specifier = "~=1.2.13" },
@@ -934,20 +936,20 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.2.87"
+version = "0.2.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/dc/e2afd59a1dd6484b6500245fa2331a0d8c0b68e6c180bc29d8ce9540f38a/claude_agent_sdk-0.2.87.tar.gz", hash = "sha256:56f02a49a97f7be37e0cd7323494d1c09e52fb0db7ab94f53bba8a230bb4bd0e", size = 252063, upload-time = "2026-05-23T04:19:25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/9b/66f0f671095a80f78f80aace954f4475705de17933120ff61bc8acc31d68/claude_agent_sdk-0.2.93.tar.gz", hash = "sha256:4fa2f534028c9054eb34960497147df345cb0042331694dfacd54560dd6378bd", size = 253644, upload-time = "2026-06-06T01:44:57.726Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/4e/b83c4c6ec1e0b63e9d4d58ba9a5abfd9936c55b8ee4c06b88f5e93bdfd70/claude_agent_sdk-0.2.87-py3-none-macosx_11_0_arm64.whl", hash = "sha256:52204a9609dec3aa96032afd48c07d72e05d13311faf614978f17b61326e6e31", size = 63037960, upload-time = "2026-05-23T04:19:29.056Z" },
-    { url = "https://files.pythonhosted.org/packages/13/d7/5fb02260c5b95c66e108c35e046d4d66011921251f7896274b6b21594f14/claude_agent_sdk-0.2.87-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:1713e34e50b830ecac54386d39af14e3a2775f833f1ef715eb53566eaa1b6325", size = 65095745, upload-time = "2026-05-23T04:19:32.533Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/84/1061f6580bbbc78de629467abf051cdbbabe71b982297b401e3fde65c7e0/claude_agent_sdk-0.2.87-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:e9e23119d2a02ad1ea1a2707214db98f5baf2c8809577186629843ddfcb8ec18", size = 72725120, upload-time = "2026-05-23T04:19:36.539Z" },
-    { url = "https://files.pythonhosted.org/packages/04/50/449f5044d76d9de18cf6a9f4b1c9386a74f41b4e2da5312df245d9dd23ef/claude_agent_sdk-0.2.87-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:5ac525d9ae3481296df5639d005e12ce2b6b0427426991f35da64db30be25c6e", size = 72875504, upload-time = "2026-05-23T04:19:40.839Z" },
-    { url = "https://files.pythonhosted.org/packages/80/dd/3f9d7c491d5a98138d293192b31cc9ed792d3552b3a7e276163d7fe2d43a/claude_agent_sdk-0.2.87-py3-none-win_amd64.whl", hash = "sha256:f34973669a1efaeb1543e7b22d7b22feefd8af2fae3adfd39181635077dae432", size = 73514880, upload-time = "2026-05-23T04:19:44.65Z" },
+    { url = "https://files.pythonhosted.org/packages/73/b6/62fbdf6862b8f06b71e35cb76753cd4fcf3cbbfc74cf369d129e43045d96/claude_agent_sdk-0.2.93-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4fbf4f2c6e6b1085adaac304fa00ac29169a239fc3a15d114d964d2e77ce3e85", size = 64824363, upload-time = "2026-06-06T01:45:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1d/eb11c804242bf39ba305fdff6dd18bbcb0732dce6baeb8c9df637d700b6d/claude_agent_sdk-0.2.93-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:04779660231c399ffb37a467f3ce070349e34232163a5d92d94dbae7ae168ec3", size = 66888963, upload-time = "2026-06-06T01:45:04.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e2/196e32d83bf95dc9227958d0f70f5c7bd53495dc7af7c8448c7027311fce/claude_agent_sdk-0.2.93-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:6263db6cc6778bb041931190e0316db9ceec1f570ea116554e23683339520ae0", size = 74450006, upload-time = "2026-06-06T01:45:09.438Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/84/479d0f52c0459780ed469ac874377838fcb19089d7ec5ac0630507dd35e6/claude_agent_sdk-0.2.93-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:10064d8e2c36e31248a517d74913c5c26bc0677ddbd63ffe614891ab638df0ac", size = 74621071, upload-time = "2026-06-06T01:45:13.938Z" },
+    { url = "https://files.pythonhosted.org/packages/db/80/5286c4a5ad126d8ee24329de9693c5700c8f6e2b0113799b2787573bebd1/claude_agent_sdk-0.2.93-py3-none-win_amd64.whl", hash = "sha256:51fb629151aff62b6db370bc595104fb609142e08385391f49162fc9ceb6696a", size = 75251517, upload-time = "2026-06-06T01:45:18.03Z" },
 ]
 
 [[package]]
@@ -1357,11 +1359,11 @@ wheels = [
 
 [[package]]
 name = "distlib"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/b2/d6fc3f2347f43dada79e5ff118493e8109c98400a0e29a1d5264a3aa479b/distlib-0.4.1.tar.gz", hash = "sha256:c3804d0d2d4b5fcd44036eb860cb6660485fcdf5c2aba53dc324d805837ea65b", size = 610526, upload-time = "2026-06-02T11:17:40.691Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+    { url = "https://files.pythonhosted.org/packages/25/18/3497c4fa83a76dcb154923fd2075522e8dd6995ecee4093c00ae18160046/distlib-0.4.1-py2.py3-none-any.whl", hash = "sha256:9c2c552c68cbadc619f2d0ed3a69e27c351a3f4c9baa9ffb7df9e9cdc3d19a97", size = 469216, upload-time = "2026-06-02T11:17:38.779Z" },
 ]
 
 [[package]]
@@ -1467,11 +1469,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.0"
+version = "3.29.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/f9/f38573ed5844586db374d085911740a501ccfa373b455fc9413f09f85237/filelock-3.29.1.tar.gz", hash = "sha256:d97e6b1b9757569626c58caa07dc4beb1613f4a2938b1e8cc81afca398906c9e", size = 59335, upload-time = "2026-06-03T15:19:04.053Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/a0/614c5fe402fd88951df45f4dda2fa3b4e17a99ecd92340771929169b3b95/filelock-3.29.1-py3-none-any.whl", hash = "sha256:85199dfd706869641b72b2e8955d5416a4b2b7dc4b0e8e6d97b4cc1299a6983b", size = 40750, upload-time = "2026-06-03T15:19:02.959Z" },
 ]
 
 [[package]]
@@ -1517,15 +1519,15 @@ wheels = [
 
 [[package]]
 name = "flask-cors"
-version = "6.0.2"
+version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/74/0fc0fa68d62f21daef41017dafab19ef4b36551521260987eb3a5394c7ba/flask_cors-6.0.2.tar.gz", hash = "sha256:6e118f3698249ae33e429760db98ce032a8bf9913638d085ca0f4c5534ad2423", size = 13472, upload-time = "2025-12-12T20:31:42.861Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/0a/ccc5176e3f041fd731b5e6a644e18f74dcdbc3c5b8d42415bc2884309975/flask_cors-6.0.3.tar.gz", hash = "sha256:d8b13989a630eef065a7b8ff10a183761be5abbb7f001294bd2963e10946cadd", size = 92022, upload-time = "2026-06-06T23:29:31.621Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/af/72ad54402e599152de6d067324c46fe6a4f531c7c65baf7e96c63db55eaf/flask_cors-6.0.2-py3-none-any.whl", hash = "sha256:e57544d415dfd7da89a9564e1e3a9e515042df76e12130641ca6f3f2f03b699a", size = 13257, upload-time = "2025-12-12T20:31:41.3Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c2/42a274bd1fc35c9fce442eb5c8614cb0f86e993f0cfd7b4b00eabb95b757/flask_cors-6.0.3-py3-none-any.whl", hash = "sha256:f49be9b367355a1ad3a871be5cfd1c4ef97100c81b2078b2cea1db8cd4e42389", size = 13158, upload-time = "2026-06-06T23:29:30.271Z" },
 ]
 
 [[package]]
@@ -1710,7 +1712,7 @@ wheels = [
 
 [[package]]
 name = "google-api-core"
-version = "2.30.3"
+version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
@@ -1719,9 +1721,9 @@ dependencies = [
     { name = "protobuf" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/22/155cadf1d49272a9cf48f3168c0f3874fa13397297e611a5ea00cd093880/google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2", size = 176492, upload-time = "2026-06-03T14:52:17.257Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
+    { url = "https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl", hash = "sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab", size = 173102, upload-time = "2026-06-03T14:51:26.729Z" },
 ]
 
 [package.optional-dependencies]
@@ -1780,7 +1782,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-storage"
-version = "3.10.1"
+version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
@@ -1790,9 +1792,9 @@ dependencies = [
     { name = "google-resumable-media" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/47/205eb8e9a1739b5345843e5a425775cbdc472cc38e7eda082ba5b8d02450/google_cloud_storage-3.10.1.tar.gz", hash = "sha256:97db9aa4460727982040edd2bd13ff3d5e2260b5331ad22895802da1fc2a5286", size = 17309950, upload-time = "2026-03-23T09:35:23.409Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/09/8953e2993e604c8882fd441b5b2de624a2dfe7e6144c6166d7b477509596/google_cloud_storage-3.11.0.tar.gz", hash = "sha256:498bf37c999028f69a245f586b5e50d89f59df1fafc0e3a93783ac56be2a456b", size = 17335639, upload-time = "2026-06-03T16:14:04.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/ff/ca9ab2417fa913d75aae38bf40bf856bb2749a604b2e0f701b37cfcd23cc/google_cloud_storage-3.10.1-py3-none-any.whl", hash = "sha256:a72f656759b7b99bda700f901adcb3425a828d4a29f911bc26b3ea79c5b1217f", size = 324453, upload-time = "2026-03-23T09:35:21.368Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7e/ee0dd1a67ac75d29d0c438969d85d4fadbc4bcab47b0a8ccfa7eb22f643c/google_cloud_storage-3.11.0-py3-none-any.whl", hash = "sha256:cfcc33aa6b899ec9dd1771286f8e79fbed5c35c1c174718071b079aa827f37c2", size = 339654, upload-time = "2026-06-03T16:12:46.052Z" },
 ]
 
 [[package]]
@@ -1820,7 +1822,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "2.7.0"
+version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1834,21 +1836,21 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/7b/6eb3b3d545b6bb4c374acba1ccf91b0f33b605e551536a6243cfcef2f07f/google_genai-2.7.0.tar.gz", hash = "sha256:3c6f32f5ced9877ededd1b384b5e5b7f09c20046ec3390b662b16d8cd1882ac5", size = 555853, upload-time = "2026-05-28T15:39:24.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/52/0244e310812f3063d09d60b30ae29ab7df9343bd005744cd5eeaa6ba39b4/google_genai-2.8.0.tar.gz", hash = "sha256:37a9b3cb127d763e7f4ca47452ae3562c87728773bd1b149f7b559c239da2bc1", size = 564955, upload-time = "2026-06-03T22:55:38.397Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/dd/7a8be39e9d698e80e9db796514efbc6083dbd787bdb9a101e8ba47248e5e/google_genai-2.7.0-py3-none-any.whl", hash = "sha256:21cac381e09a869151706aba797b6a4f96cfe92c484e13204d092caee7ff11cb", size = 822545, upload-time = "2026-05-28T15:39:22.907Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/de/747ad1aa49e902da9a4699081c282a1ed8ceed3b4d295fd99a6d286e09e4/google_genai-2.8.0-py3-none-any.whl", hash = "sha256:4da0a223a100f4b37f609a68b835e3326ab0fa313314dc0fd9d34e76ee293844", size = 832497, upload-time = "2026-06-03T22:55:36.598Z" },
 ]
 
 [[package]]
 name = "google-resumable-media"
-version = "2.9.0"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-crc32c" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/4b/0b235beccc310d0a48adbc7246b719d173cca6c88c572dfa4b090e39143c/google_resumable_media-2.9.0.tar.gz", hash = "sha256:f7cfb224846a9dd444d125115dfbe8ef02a2b893e78f087762fe716a255a734b", size = 2164534, upload-time = "2026-05-07T08:04:44.236Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/f8/1ca5781d6be9cb9f73f7d40f4958c4bd1226a60598e3e39e1d6aaf838c4b/google_resumable_media-2.10.0.tar.gz", hash = "sha256:e324bc9d0fdae4c52a08ae90456edc4e71ece858399e1217ac0eb3a51d6bc6ee", size = 2164570, upload-time = "2026-06-03T16:14:26.103Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/73/3518e63deb1667c5409a4579e28daf5e84479a87a72c547e0487f7883dcd/google_resumable_media-2.9.0-py3-none-any.whl", hash = "sha256:c8901e88e389af8bed64d9696c74d8bad961865eb2236e13e0bfca9bb0a65ca3", size = 81507, upload-time = "2026-05-07T08:03:23.809Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d8/00c6854ac1512bb9eaf13bd3f8f28222f7674947fc510a4ff7616f2efc80/google_resumable_media-2.10.0-py3-none-any.whl", hash = "sha256:88152884bee37b2bf36a0ab81ad8c7fd12212c9803dd981d77c1b35b02d34e7c", size = 81533, upload-time = "2026-06-03T16:13:12.51Z" },
 ]
 
 [[package]]
@@ -1890,11 +1892,11 @@ httpx = [
 
 [[package]]
 name = "graphql-core"
-version = "3.2.8"
+version = "3.2.11"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/68/c5/36aa96205c3ecbb3d34c7c24189e4553c7ca2ebc7e1dd07432339b980272/graphql_core-3.2.8.tar.gz", hash = "sha256:015457da5d996c924ddf57a43f4e959b0b94fb695b85ed4c29446e508ed65cf3", size = 513181, upload-time = "2026-03-05T19:55:37.332Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/90/f2aff026ab4aebd80eb71905106a0885f4cfde85dcf965543f45bed0d9ee/graphql_core-3.2.11.tar.gz", hash = "sha256:e7e156d10beb127cab5c89ff0da71416fc73d27c484a4757d3b2d35633774802", size = 528407, upload-time = "2026-06-05T13:45:22.915Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/41/cb887d9afc5dabd78feefe6ccbaf83ff423c206a7a1b7aeeac05120b2125/graphql_core-3.2.8-py3-none-any.whl", hash = "sha256:cbee07bee1b3ed5e531723685369039f32ff815ef60166686e0162f540f1520c", size = 207349, upload-time = "2026-03-05T19:55:35.911Z" },
+    { url = "https://files.pythonhosted.org/packages/00/15/b92b4e1d88d02c6eff9733c9eea21846ab435cc4d813d84ccc5d335955df/graphql_core-3.2.11-py3-none-any.whl", hash = "sha256:0b3e35ff41e9adba53021ab0cef475eb18f57c7f53f0f2ca55567fbf3c537ea0", size = 214879, upload-time = "2026-06-05T13:45:21.245Z" },
 ]
 
 [[package]]
@@ -2182,11 +2184,18 @@ dependencies = [
     { name = "requests" },
 ]
 
+[package.optional-dependencies]
+claude-sdk = [
+    { name = "claude-agent-sdk" },
+]
+
 [package.metadata]
 requires-dist = [
+    { name = "claude-agent-sdk", marker = "extra == 'claude-sdk'", specifier = ">=0.1.30" },
     { name = "pydantic-settings", specifier = ">=2.1.0" },
     { name = "requests", specifier = ">=2.32.0" },
 ]
+provides-extras = ["claude-sdk"]
 
 [[package]]
 name = "hf-xet"
@@ -2373,11 +2382,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.17"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -2449,7 +2458,7 @@ wheels = [
 
 [[package]]
 name = "ipython"
-version = "9.14.0"
+version = "9.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -2464,9 +2473,9 @@ dependencies = [
     { name = "stack-data" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/c2/c0064cf15d026501a1ef70e42efd9c3f818663089399aacc5e37a82901c1/ipython-9.14.0.tar.gz", hash = "sha256:6f27ff0f1d9ea050e0551f71568bc4b34d8aba579e8f111c5b4175f44ac6b4aa", size = 4432601, upload-time = "2026-05-29T15:13:24.611Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/23/3a27530575643c8bb7bfc757a28e2e7ef80092afbf59a2bc5716320b6602/ipython-9.14.1.tar.gz", hash = "sha256:f913bf74df06d458e46ced84ca506c23797590d594b236fe60b14df213291e7b", size = 4433457, upload-time = "2026-06-05T08:12:34.921Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/a3/9e59340f02c1dc8f8c0a05b09244712b8609eb5439f9996e887e2b82f452/ipython-9.14.0-py3-none-any.whl", hash = "sha256:8fd984a3372c14b12790b084ba6b5cff5678c0cb063244a0034f06a51f20d6c2", size = 627457, upload-time = "2026-05-29T15:13:22.942Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/22/58818a63eaf8982b67632b1bc20585c811611b15a8da19d6012323dc76a5/ipython-9.14.1-py3-none-any.whl", hash = "sha256:5d4a9ecaa3b10e6e5f269dd0948bdb58ca9cb851899cd23e07c320d3eb11613c", size = 627770, upload-time = "2026-06-05T08:12:33.045Z" },
 ]
 
 [[package]]
@@ -2854,7 +2863,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.0"
+version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2867,9 +2876,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/de/679a53472c25860837e32c0442c962fa86e95317a36460e2c9d5c91b17c2/langchain_core-1.4.0.tar.gz", hash = "sha256:1dc341eed802ed9c117c0df3923c991e5e9e226571e5725c194eeb5bd93d1a7f", size = 920260, upload-time = "2026-05-11T18:42:35.919Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/c1/276a0d704440490fb0d27ce25e556872ca420d285b9d00eb823374717897/langchain_core-1.4.1.tar.gz", hash = "sha256:8234eb8cd3200f690e278159b7d7cee5976381ec90ece7b48db8d8e8850ab37d", size = 932675, upload-time = "2026-06-05T14:51:40.772Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/1a/86c38c27b81913a1c6c12448cab55defb5a1097c7dc9a4cea83f55477a2d/langchain_core-1.4.0-py3-none-any.whl", hash = "sha256:23cbbdb46e38ddd1dd5247e6167e96013eae74bea4c5949c550809970a9e565c", size = 548120, upload-time = "2026-05-11T18:42:33.992Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/79/531d8ee5dc5bf464c18cc86b087569307bc2d6b74548753f26122d08746d/langchain_core-1.4.1-py3-none-any.whl", hash = "sha256:e5dee06e70c123cb98cb0158e4416efac1e386ff47a484901ccf88555e28eec6", size = 549118, upload-time = "2026-06-05T14:51:39.038Z" },
 ]
 
 [[package]]
@@ -2999,7 +3008,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.8.8"
+version = "0.8.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -3013,9 +3022,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/93/28df12b3b3c776077983b92f1299c623592b5999695af2a755fb90ff048b/langsmith-0.8.8.tar.gz", hash = "sha256:9d00e54f54d833c1914003527ff03ad0364741034330da72f0adbeaba852b6cf", size = 4468035, upload-time = "2026-05-31T22:14:57.698Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/dd/f4c8a12987318e505b10760d30c3c2d45e8dc87ba8f47a004c753a9e7b35/langsmith-0.8.9.tar.gz", hash = "sha256:f16e37fcd5a8a2d4db30eae0e399a866a65ce5cc86218825c59409ed57a3bf53", size = 4428684, upload-time = "2026-06-03T17:56:09.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/71/94a8f2b573278a0b0b7dfd37663c0ddd36867f9e2bba69addd183de0cd56/langsmith-0.8.8-py3-none-any.whl", hash = "sha256:9d60d724c0d187c036e184b3ffdf9fa5c6822aa0bb88144a5fb898e79be645af", size = 402712, upload-time = "2026-05-31T22:14:55.908Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2f/a701663c9fb4d9630448622a684bc372b4905b9a6dbe2297d55a70fde04e/langsmith-0.8.9-py3-none-any.whl", hash = "sha256:c9519cabc75568d088df045710d1b86eae9780c91054528b2aa7e6cb1fc80c52", size = 403165, upload-time = "2026-06-03T17:56:07.226Z" },
 ]
 
 [[package]]
@@ -3102,28 +3111,28 @@ wheels = [
 
 [[package]]
 name = "lmdb"
-version = "2.2.0"
+version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/21/44/d94934efaf8f887b6959f131fde740fcaa831edfd13eb5425574637cddd5/lmdb-2.2.0.tar.gz", hash = "sha256:53020e20305c043ea6e68089bc242d744fba6073cdb268332299ba6dda2886d4", size = 933189, upload-time = "2026-03-30T01:26:19.049Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/ddef3e433950e23844fd9d82fa045637cbe84140f482120bbdf6abe6be92/lmdb-2.2.1.tar.gz", hash = "sha256:b201b416f7d6cea9bd2f977277a5f51d6e52a434d6ec511a8b34990df2b1a9c5", size = 938665, upload-time = "2026-06-04T04:46:31.461Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/a7/9604e594725e2d2d0482669cfd9cba23cc47bd288f076c7e93985e5c046c/lmdb-2.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8cc73de748070321986a3a26f51f3693bdd196c20e797d8d2ad0e860b5d2e26c", size = 113096, upload-time = "2026-03-30T01:25:48.293Z" },
-    { url = "https://files.pythonhosted.org/packages/05/cf/7b8e13c1253c77a2c41b7786659d64e97f758a13f1fafdb815cf76630eba/lmdb-2.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9b6fecb1e32c55f0a1f3585d637f221e20146bb3ea9997c50fdfa3a58c0c2e41", size = 111656, upload-time = "2026-03-30T01:25:49.36Z" },
-    { url = "https://files.pythonhosted.org/packages/94/6a/f059c48e4f3321710825fdb1cdee50d32eea90e0c097441beec1b155788f/lmdb-2.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:547e083457b6a0936fe73821f35c019be817877f9a85488be818ec8383ef47a6", size = 329003, upload-time = "2026-03-30T01:25:50.47Z" },
-    { url = "https://files.pythonhosted.org/packages/38/22/513c885f284eccd49fc8d1c0a9a9d5da6badd9efc600d482424118df2a67/lmdb-2.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd505c995a595403f69367cbf16bcd5c88cdd208c706d709ba9b1bc2f9a16f69", size = 333140, upload-time = "2026-03-30T01:25:51.68Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/9b/8b3c81009230ebbe340e59cf2996626800f291e034ed76535d754b2cf98c/lmdb-2.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:dacf737ad869c6e48e1471dfa4d3e7c6ce2d082a218c069e20c4a138804e5fd2", size = 109668, upload-time = "2026-03-30T01:25:53.091Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/68/368099745c1d82d079c490c62cdef5e99bc9a3e9132991e3b82967363d55/lmdb-2.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:653f5e183b04b9124c505c519a3ff691038b4fb459c3211b1323c67bfba53f37", size = 103760, upload-time = "2026-03-30T01:25:54.374Z" },
-    { url = "https://files.pythonhosted.org/packages/64/43/543af71e8fa4c56623bb89c358121ab806426f26685f11539fe5452deffa/lmdb-2.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36e0cbe6b7d59f6e19b448942c5f9e91674f596a802743258f82e926a9a09632", size = 113550, upload-time = "2026-03-30T01:25:55.727Z" },
-    { url = "https://files.pythonhosted.org/packages/22/2c/4702d36c0073737554b20d1d62e879a066df963482f8e514866588ddd82d/lmdb-2.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e5d7a9dfd279a5884806fd478244961e4483cc6d7eb769caed1d7019a8608c20", size = 112135, upload-time = "2026-03-30T01:25:56.809Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/43/d015fea326ed0a634107f29740b002170a462b6d2481e509105c685520f5/lmdb-2.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d0dbe7902b2cdb60bf6c893f307ef2b2a5039afd22f029515b86183f05ab1353", size = 332108, upload-time = "2026-03-30T01:25:57.907Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/c9/503e7f173994b514936badcbcb7fa9f89a07a3cfe596c6fb95b1b91b8d70/lmdb-2.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c576cdb163ae61a7ef6eecbc20a6025a4abe085491c1dc0c667d726f4926b53", size = 336017, upload-time = "2026-03-30T01:25:59.234Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/94/b3b064acfd2f8acf5aaa53fff2c43963dbc1932ba8b8df4e27d75bf6a34a/lmdb-2.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:746eebcd4c0aeaf0eb2f897028929d270c5bc80ef4918500eec16db6f26f3fcc", size = 109574, upload-time = "2026-03-30T01:26:00.324Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/10/dc7488d1effc339cd9470f9d22ec0fd7052a3d4fdfae87765ecd41cb2e59/lmdb-2.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:006153aac9fb0415a5f3e8ac88789e5730dba3dd0743cd84c95e3951ff68bc3a", size = 103810, upload-time = "2026-03-30T01:26:01.559Z" },
-    { url = "https://files.pythonhosted.org/packages/36/3f/452a81add862d99722e18c92b2a0202d9bb316fb19422150b4424ec7a983/lmdb-2.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0398fef4ab54d66f531257e7a68c03314a267da5d2fd76d75481f62a237ec28b", size = 113740, upload-time = "2026-03-30T01:26:02.632Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/73/62edf6b273d4118c0ed4b5afc5797ca68091e360daa91ef77ae8337084db/lmdb-2.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1610c601f397b0b523310b2393fd430f5973bfdb5dbec9cdc5f89510c5e887ca", size = 112192, upload-time = "2026-03-30T01:26:04.007Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/60/19c59e022e84dad27932b7af58319dd20afdb7de4f48698cac408f6066ab/lmdb-2.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc1d32c08afdbc7db1315d199c827e14c6ad8cdfc7d70872ff983f68079a5edb", size = 331709, upload-time = "2026-03-30T01:26:05.116Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/51/28a24bd3d131ecc7b74c1dac06eea9194e05efe2af5032dece703d397a67/lmdb-2.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bdba273466d099f3ff3a10a26dc1d45101ac519bf67ae23b402a2f3191965e13", size = 334891, upload-time = "2026-03-30T01:26:06.328Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/e6/3071576af6c318f76f36ac3b52f2f809b861d13193c6bbc004bdabd451de/lmdb-2.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:00a051a0d29e0d88e84035884e91a57e2e850355c7e1a3ea05c34753a56d3e12", size = 111309, upload-time = "2026-03-30T01:26:07.792Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/5d/723eabbfe716013db0d13c2015784249e91c87524cde1539c6b99daac68e/lmdb-2.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:2d2968d2a3ff6e69596d9604d2029d2d1265079aa2864eb721c27e076a1fd792", size = 106210, upload-time = "2026-03-30T01:26:09.231Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/93/4796573d885dbc0dd94ed712d070c6919a019acd12754c4708ba8a47732d/lmdb-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e6957c9346ce9e9300ca2b75625e681b9868bbaf4d257626ec96d221e8200fc4", size = 116824, upload-time = "2026-06-04T04:45:58.058Z" },
+    { url = "https://files.pythonhosted.org/packages/33/20/d3e48f1af18d67e56c2f42f82a598c2586d7d47dca7c8edda4f479e108b4/lmdb-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd3f3ab6feed2d4ca87d9d9063d2e371c8cc6d72879d54ae160a1c32758d26c0", size = 115341, upload-time = "2026-06-04T04:45:59.352Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/3e/6c3d2aa3b2250220d664a3ebb137519b6c33f94e27bf62e903130fac2cb4/lmdb-2.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9129a78af25dd1316784d689fefbd88bda6a756c82847a72b7f423bc1282dbd0", size = 333528, upload-time = "2026-06-04T04:46:00.748Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/72/64588fb1359b9a8d2fc6d3bfd98cd6a7f22adcd5fffa4252874529e72794/lmdb-2.2.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13438ad327f8bca47f1415671335eec500b653459d269556eb2cf2470cecec30", size = 338288, upload-time = "2026-06-04T04:46:02.097Z" },
+    { url = "https://files.pythonhosted.org/packages/35/19/bf3466f65c7795d44b6119cd62fa505a1fd3ebb50d71bd20b823e2b1485c/lmdb-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:e54f8705489f8b6668b648333fbd90875c06878b3226a64f3f1af58af01c3d00", size = 113598, upload-time = "2026-06-04T04:46:03.593Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/7f/214172bc46f67ec58ee0ec0cda3cf6b27ceeaef614be25c863b7da35f9a8/lmdb-2.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:84468990d6b7f50243a1eb19e7f9fbaead93eb7de0eb854b7dacc7f893c699ea", size = 107614, upload-time = "2026-06-04T04:46:04.834Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ea/65df850c0f371856eb495c018b13b16da229cb072a06236021130ce6c2f7/lmdb-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d468fa89da30515979bf35c3e5b4db0ded560f9c39449c11459559c9f85bb820", size = 117352, upload-time = "2026-06-04T04:46:06.103Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/88/94a079be5dc482cb9971da32a82046bdcf2124646e4d84c5b4412ccb8d78/lmdb-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:881e8cdde83d9130b9cf75faf3202c16cbdeb54da7ec58a0856e8adfff5d5c25", size = 115703, upload-time = "2026-06-04T04:46:07.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/73/e360c13279ea523d0caf2d231dd581c9fd0e4c6b49f33acde8613f0b653c/lmdb-2.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d54bb7ef49241602599f6fee8547ba14765b896ec459dad9620940235c550ab6", size = 336991, upload-time = "2026-06-04T04:46:08.706Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/e36baf673fb218b17c0c7a8050d1aad7bd49eb7b8fcf8cf0268ddc06507e/lmdb-2.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:12b84c38d091bb283853d8af38951338bf3eb729d8e79f0381291b098c0616f6", size = 340692, upload-time = "2026-06-04T04:46:10.326Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/de/9e13991db388343ca59caf684e1572705d9d89bc5cc681cfa912cd3b9106/lmdb-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:f68a203f45d7442527c9cc8cd9a7e10666e38b64a71775870bf5b54c30a15661", size = 113526, upload-time = "2026-06-04T04:46:11.73Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/83/2c27f9544034387badbadf577a716cf5681afd79f5fb762c2038b62af70b/lmdb-2.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:6f783cd75835eb7d4676be5b0d38f68a31961f07d74126fd6424377005fb4d04", size = 107682, upload-time = "2026-06-04T04:46:12.981Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/e0/58694bab6516a76850b702bb15a2d8775a685acd2c42caa45d4fe8eeb6b6/lmdb-2.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e87bcf94a650d0ed53f647756504cb92287e9175ae5936755d18d173401bcb11", size = 117534, upload-time = "2026-06-04T04:46:14.291Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/87/48d2d6d02c78498d101969e41068b89187a54c4dcac7d8fdcc0ff8b16f40/lmdb-2.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2e7f53effd229f71fedb524602a958f77359d4be83be9bef2434dc3e5e5159b5", size = 115769, upload-time = "2026-06-04T04:46:15.516Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8d/6918122b2fef6d42f8b3b198a95f4444be56563fd371f4ca076b1cd122f4/lmdb-2.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee64993f7e9d983c098f5281b044ffdd7d398b636c7b232f5e72276d4bfd098b", size = 336740, upload-time = "2026-06-04T04:46:16.809Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f3/d490062cc7dbeeaea38ba9a091a7c484c1173d2fe3ba522fe0190a86dd42/lmdb-2.2.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a303e0c9d2e187e0304497ad3bb361d1ac359b55ce929d1aca2caec06582c134", size = 339753, upload-time = "2026-06-04T04:46:18.205Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/06/05572263ac9aa57971b485262368081b051909ef8d5142b086681a1bcd72/lmdb-2.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:97ba48ab2db224009fa962dc84892bbbe693cdf1c367cc27c1a754ac8ec625c8", size = 115245, upload-time = "2026-06-04T04:46:19.471Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/22/c4c28854bd73bfc8e0dfc4d5228e5c9db3443e9c0fe14bbe1a2acdbd4c01/lmdb-2.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:cf6372257b90530ac853aa43d35a714e49e4a9761599523d83d0258e336c1d84", size = 109973, upload-time = "2026-06-04T04:46:20.882Z" },
 ]
 
 [[package]]
@@ -3880,7 +3889,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.40.0"
+version = "2.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3892,9 +3901,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/9f/136562ec6c3b1a50fe06eb0bb34ed21f0d7426ec0140e5cc43ac785b69a5/openai-2.40.0.tar.gz", hash = "sha256:9a756f91f274a24ad6026cbcb2042fd356c8d4a10e8f347b08d34465e585f7a2", size = 781177, upload-time = "2026-06-01T21:48:23.878Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/a6/5815fe2e2aca74b36c650d1bd43b69827cee568073d0d2d9b6fc5aaac80c/openai-2.41.0.tar.gz", hash = "sha256:db5c362acd6604b84f076abbefa66826ea4b46ecba2954ed866e6a149a1352c0", size = 783525, upload-time = "2026-06-03T22:39:40.719Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/46/180e14be801a75bc13f234cb1b594b232adeb9c84e60a9ab1832e8333591/openai-2.40.0-py3-none-any.whl", hash = "sha256:2b205637ff214477f9ce9ab035e9f494db0e3fa8f1e599008953735fbf6ff1ff", size = 1350935, upload-time = "2026-06-01T21:48:21.462Z" },
+    { url = "https://files.pythonhosted.org/packages/be/51/d82bb424e8aa372190c5233253a2ceb399a778747d18b42cff487411e663/openai-2.41.0-py3-none-any.whl", hash = "sha256:20cc7952e8501c7e5773dd2ef7be437bae9cb549044902e1041a83a54516e375", size = 1353378, upload-time = "2026-06-03T22:39:38.964Z" },
 ]
 
 [[package]]
@@ -4985,11 +4994,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.30"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4b/82/c8cd43a6e0719bf5a3b034f6726dd701f75829c08944c83d4b95d02ed0e8/python_multipart-0.0.30.tar.gz", hash = "sha256:0edfe0475c1f46ddd3ff7785a626f6118af32bdcf359bb21260367313bb32118", size = 46316, upload-time = "2026-05-31T19:24:55.198Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/fd/0318007beb234790993d3ec5afd051d1dbceb733e81e3afe2b981ece3f37/python_multipart-0.0.30-py3-none-any.whl", hash = "sha256:830964def8c90607ac5daa00514e3987815865713ade8d20febc9177ac0c3c5b", size = 29730, upload-time = "2026-05-31T19:24:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
@@ -5003,18 +5012,21 @@ wheels = [
 
 [[package]]
 name = "pywin32"
-version = "311"
+version = "312"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
-    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
-    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]
@@ -5617,10 +5629,14 @@ wheels = [
 
 [[package]]
 name = "searchfox"
-version = "0.14.0"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/94/b51b8f9441bec76da0a1a4cbbe078c46c4a4942f2a99f892bc27880f9aab/searchfox-0.14.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a44a2de92fb0e0f5a6d032472da34fe41361685c707587e25beeb544e4c47a85", size = 4211018, upload-time = "2026-05-27T12:22:58.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f9/794c31fb1e3dbc0c84d9f99f9e1222ddd8e5f15055a7c048209c4720bad7/searchfox-0.15.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6263e9aa8d49ff8c3f896c39bfab07b1459a22557e426f08a67277ad44d7401e", size = 6122839, upload-time = "2026-06-04T11:31:40.868Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f9/10d138e846ec0e824621b2a836b02408995a31e9ed0b3a295110dd66976b/searchfox-0.15.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:90039bd4c9a8821670d5dd13df0810ceb84dfb74184bb861455db8c3a4e55182", size = 5992365, upload-time = "2026-06-04T11:31:42.505Z" },
+    { url = "https://files.pythonhosted.org/packages/79/e5/d2d0946a8d56165a8f89dcbf64abf91efa725f4a49b92f77167884538dba/searchfox-0.15.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:49d105aba4a175bb19a0a4e4eec4eaceda57a80c690dded392254e9a97369e10", size = 3936464, upload-time = "2026-06-04T11:31:44.055Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/2d/96f4ebde0da8429795211c50426dd1a2020b63c057f62e11474532d94e15/searchfox-0.15.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c10b4887c1b739f8f011b45327408a0ed0567bd3d427527c9842e42a492a0ed", size = 4168622, upload-time = "2026-06-04T11:31:45.74Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d4/9a13edd62dc0ad9515e7c3992e1bec101f270219a8633e0f6f4154604bf3/searchfox-0.15.0-cp38-abi3-win_amd64.whl", hash = "sha256:64ded0ee00c5ae9b640767168f1239856fcd9edcbd7c3c255ac91ac6dc53a685", size = 5412239, upload-time = "2026-06-04T11:35:21.27Z" },
 ]
 
 [[package]]
@@ -6201,16 +6217,16 @@ wheels = [
 
 [[package]]
 name = "traitlets"
-version = "5.15.0"
+version = "5.15.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/22/40f55b26baeab80c2d7b3f1db0682f8954e4617fee7d90ce634022ef05c6/traitlets-5.15.0.tar.gz", hash = "sha256:4fead733f81cf1c4c938e06f8ca4633896833c9d89eff878159457f4d4392971", size = 163197, upload-time = "2026-05-06T08:05:58.016Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/a9/a2584b8313b89f94869ddb3c4074617a691de1812a614d2d50e32ca5a7a6/traitlets-5.15.1.tar.gz", hash = "sha256:7b1c07854fe25acb39e009bae49f11b79ff6cbb2f27999104e9110e7a6b53722", size = 163344, upload-time = "2026-06-03T12:26:06.181Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/98/a9937a969d018a23badfea0b381f66783649d48e0ea6c41923265c3cbeb3/traitlets-5.15.0-py3-none-any.whl", hash = "sha256:fb36a18867a6803deab09f3c5e0fa81bb7b26a5c9e82501c9933f759166eff40", size = 85877, upload-time = "2026-05-06T08:05:55.853Z" },
+    { url = "https://files.pythonhosted.org/packages/96/8d/1080ee4c231f361b6ce4470d556c8c435b67c7e0753aaa641497ee92f88b/traitlets-5.15.1-py3-none-any.whl", hash = "sha256:770a53705f84b81ac107e83a1b3328ff2dae16094d8fc3cfc004e4b22dfd8e92", size = 85858, upload-time = "2026-06-03T12:26:04.395Z" },
 ]
 
 [[package]]
 name = "typer"
-version = "0.26.5"
+version = "0.26.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -6218,9 +6234,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/1a/2cf40b65b1d9c254fe5814bb0519f9b8f2ac38059df0810f9b866300c04a/typer-0.26.5.tar.gz", hash = "sha256:9b9b39e35c3afc9e1e51a06f21155246e457c0911279b09b35d8210ca74b935c", size = 201494, upload-time = "2026-06-01T14:42:49.744Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/d6/baac76fc04a6532883de3d8722c7f921dae94d10965e7ffba9e38e42a251/typer-0.26.5-py3-none-any.whl", hash = "sha256:4bfd901d564e41608920134aa5d4481200f4ba76d98e982d9f9d32dcb7b84da0", size = 122451, upload-time = "2026-06-01T14:42:51.021Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
 ]
 
 [[package]]
@@ -6351,15 +6367,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.48.0"
+version = "0.49.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
 ]
 
 [package.optional-dependencies]
@@ -6547,11 +6563,11 @@ wheels = [
 
 [[package]]
 name = "wcwidth"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/44/c833e6b746ffb654e9abacf7ad6c2480a9c8c42e9637c1ae849964fb4dde/wcwidth-0.8.0.tar.gz", hash = "sha256:68a882ff6d14e3d14e0cae590b96a0551be64ce4905408112a8254434a1bdf69", size = 1305357, upload-time = "2026-06-05T21:19:35.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/17/c68b6cbcfeadbf420b3c3edaf8fda51335bc9c38732adb2d3ba8984dc607/wcwidth-0.8.0-py3-none-any.whl", hash = "sha256:8c75e6099cefd197c4bcc67a486f70b5dbc68f997c05f34a811d853910450d64", size = 324935, upload-time = "2026-06-05T21:19:33.999Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Introduce a generic mechanism that records intended actions (e.g., adding a comment to Bugzilla) to be handled later as part of the pipeline, rather than performing the action directly.