### PR TITLE
Add artifact download URL endpoint to Hackbot API

### DIFF
--- a/services/hackbot-api/app/gcs.py
+++ b/services/hackbot-api/app/gcs.py
@@ -164,3 +164,35 @@ def _list_artifacts_sync(run_id: str) -> list[ArtifactRef]:
 
 async def list_artifacts(run_id: str) -> list[ArtifactRef]:
     return await asyncio.to_thread(_list_artifacts_sync, run_id)
+
+
+def _generate_artifact_download_url_sync(
+    run_id: str, artifact_name: str, expiration_seconds: int
+) -> str | None:
+    """Mint a V4 signed GET URL for a single artifact, or None if it's missing.
+
+    Reuses the impersonated signing credentials (same `sign_bytes` path as the
+    upload POST policy), so the browser can download the object directly from
+    GCS without the bucket being public.
+    """
+    bucket = _client().bucket(settings.results_bucket)
+    blob = bucket.blob(f"{run_prefix(run_id)}{artifact_name}")
+    if not blob.exists():
+        return None
+    return blob.generate_signed_url(
+        version="v4",
+        expiration=datetime.timedelta(seconds=expiration_seconds),
+        method="GET",
+        credentials=_signing_credentials(),
+    )
+
+
+async def generate_artifact_download_url(
+    run_id: str, artifact_name: str, expiration_seconds: int = 600
+) -> str | None:
+    return await asyncio.to_thread(
+        _generate_artifact_download_url_sync,
+        run_id,
+        artifact_name,
+        expiration_seconds,
+    )

--- a/services/hackbot-api/app/routers/runs.py
+++ b/services/hackbot-api/app/routers/runs.py
@@ -116,6 +116,33 @@ async def get_run(run_id: uuid.UUID, db: AsyncSession = Depends(get_db)) -> RunD
     return RunDoc.model_validate(run)
 
 
+@router.get("/runs/{run_id}/artifacts/{artifact_path:path}")
+async def get_artifact_download_url(
+    run_id: uuid.UUID,
+    artifact_path: str,
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, str]:
+    """Return a short-lived signed URL to download one artifact.
+
+    The artifact must be one already listed on the run, which both scopes the
+    download to this run's results prefix and prevents path traversal / probing
+    of unrelated objects.
+    """
+    run = await db.get(Run, run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    known = {a.get("name") for a in (run.artifacts or [])}
+    if artifact_path not in known:
+        raise HTTPException(status_code=404, detail="Artifact not found")
+
+    url = await gcs.generate_artifact_download_url(str(run_id), artifact_path)
+    if url is None:
+        raise HTTPException(status_code=404, detail="Artifact not found")
+
+    return {"url": url}
+
+
 async def _reconcile(db: AsyncSession, run: Run) -> None:
     assert run.execution_name is not None
     try:

--- a/services/hackbot-api/app/routers/runs.py
+++ b/services/hackbot-api/app/routers/runs.py
@@ -132,6 +132,15 @@ async def get_artifact_download_url(
     if run is None:
         raise HTTPException(status_code=404, detail="Run not found")
 
+    # Refresh artifacts for runs that may have completed since the last poll,
+    # so a freshly finished run's artifacts are visible here without first
+    # requiring a GET /runs/{run_id} call.
+    if (
+        run.status not in {s.value for s in TERMINAL_STATUSES}
+        and run.execution_name is not None
+    ):
+        await _reconcile(db, run)
+
     known = {a.get("name") for a in (run.artifacts or [])}
     if artifact_path not in known:
         raise HTTPException(status_code=404, detail="Artifact not found")


### PR DESCRIPTION
Expose a GET /runs/{run_id}/artifacts/{artifact_path:path} endpoint that returns a short-lived signed GCS URL for a listed artifact.