### PR TITLE
Switch uv sync to --locked

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -58,7 +58,7 @@ tasks:
                   - "git clone --quiet ${repository} &&
                     cd bugbug &&
                     git -c advice.detachedHead=false checkout ${head_rev} &&
-                    uv sync --frozen --package bugbug --only-group test &&
+                    uv sync --locked --package bugbug --only-group test &&
                     uv run pre-commit run -a --show-diff-on-failure"
               metadata:
                 name: bugbug lint
@@ -98,7 +98,7 @@ tasks:
                     cd bugbug &&
                     git -c advice.detachedHead=false checkout ${head_rev} &&
                     cp infra/hgrc /etc/mercurial/hgrc.d/bugbug.rc &&
-                    uv sync --frozen --package bugbug --group test --extra nlp --group spawn-pipeline &&
+                    uv sync --locked --package bugbug --group test --extra nlp --group spawn-pipeline &&
                     hg clone -r 50a59e00c4a76fcfae660e3feb9b79e0cd549b15 https://hg.mozilla.org/hgcustom/version-control-tools /version-control-tools/ &&
                     uv run pytest --cov=./ tests/test_*.py &&
                     bash <(curl -s https://codecov.io/bash)"
@@ -123,7 +123,7 @@ tasks:
                     cd bugbug &&
                     git -c advice.detachedHead=false checkout ${head_rev} &&
                     cp infra/hgrc /etc/mercurial/hgrc.d/bugbug.rc &&
-                    uv sync --frozen --package bugbug --package bugbug-http-service --group test &&
+                    uv sync --locked --package bugbug --package bugbug-http-service --group test &&
                     hg clone -r 50a59e00c4a76fcfae660e3feb9b79e0cd549b15 https://hg.mozilla.org/hgcustom/version-control-tools /version-control-tools/ &&
                     uv run pytest --cov=http_service http_service/tests/ -vvv &&
                     bash <(curl -s https://codecov.io/bash)"

--- a/http_service/Dockerfile
+++ b/http_service/Dockerfile
@@ -7,11 +7,11 @@ RUN --mount=type=bind,source=pyproject.toml,target=/tmp/workspace/pyproject.toml
 	--mount=type=bind,source=uv.lock,target=/tmp/workspace/uv.lock \
 	--mount=type=bind,source=VERSION,target=/tmp/workspace/VERSION \
 	--mount=type=bind,source=http_service/pyproject.toml,target=/tmp/workspace/http_service/pyproject.toml \
-	cd /tmp/workspace && uv sync --frozen --no-dev --package bugbug-http-service --no-install-project
+	cd /tmp/workspace && uv sync --locked --no-dev --package bugbug-http-service --no-install-project
 
 # Setup http service as package
 RUN --mount=type=bind,target=/tmp/workspace,rw \
-	cd /tmp/workspace && uv sync --frozen --no-dev --package bugbug-http-service --no-editable
+	cd /tmp/workspace && uv sync --locked --no-dev --package bugbug-http-service --no-editable
 
 # Run the Pulse listener in the background
 CMD (bugbug-http-pulse-listener &) && gunicorn -b 0.0.0.0:$PORT bugbug_http.app --preload --timeout 30 -w 3

--- a/http_service/Dockerfile
+++ b/http_service/Dockerfile
@@ -7,6 +7,9 @@ RUN --mount=type=bind,source=pyproject.toml,target=/tmp/workspace/pyproject.toml
 	--mount=type=bind,source=uv.lock,target=/tmp/workspace/uv.lock \
 	--mount=type=bind,source=VERSION,target=/tmp/workspace/VERSION \
 	--mount=type=bind,source=http_service/pyproject.toml,target=/tmp/workspace/http_service/pyproject.toml \
+	--mount=type=bind,source=services/hackbot-api/pyproject.toml,target=/tmp/workspace/services/hackbot-api/pyproject.toml \
+	--mount=type=bind,source=agents/bug-fix/pyproject.toml,target=/tmp/workspace/agents/bug-fix/pyproject.toml \
+	--mount=type=bind,source=libs/hackbot-runtime/pyproject.toml,target=/tmp/workspace/libs/hackbot-runtime/pyproject.toml \
 	cd /tmp/workspace && uv sync --locked --no-dev --package bugbug-http-service --no-install-project
 
 # Setup http service as package

--- a/http_service/Dockerfile.bg_worker
+++ b/http_service/Dockerfile.bg_worker
@@ -7,11 +7,11 @@ RUN --mount=type=bind,source=pyproject.toml,target=/tmp/workspace/pyproject.toml
 	--mount=type=bind,source=uv.lock,target=/tmp/workspace/uv.lock \
 	--mount=type=bind,source=VERSION,target=/tmp/workspace/VERSION \
 	--mount=type=bind,source=http_service/pyproject.toml,target=/tmp/workspace/http_service/pyproject.toml \
-	cd /tmp/workspace && uv sync --frozen --no-dev --package bugbug-http-service --no-install-project
+	cd /tmp/workspace && uv sync --locked --no-dev --package bugbug-http-service --no-install-project
 
 # Setup http service as package
 RUN --mount=type=bind,target=/tmp/workspace,rw \
-	cd /tmp/workspace && uv sync --frozen --no-dev --package bugbug-http-service --no-editable
+	cd /tmp/workspace && uv sync --locked --no-dev --package bugbug-http-service --no-editable
 
 # Copy the model loading script
 COPY http_service/ensure_models.sh /code/http_service/ensure_models.sh

--- a/http_service/Dockerfile.bg_worker
+++ b/http_service/Dockerfile.bg_worker
@@ -7,6 +7,9 @@ RUN --mount=type=bind,source=pyproject.toml,target=/tmp/workspace/pyproject.toml
 	--mount=type=bind,source=uv.lock,target=/tmp/workspace/uv.lock \
 	--mount=type=bind,source=VERSION,target=/tmp/workspace/VERSION \
 	--mount=type=bind,source=http_service/pyproject.toml,target=/tmp/workspace/http_service/pyproject.toml \
+	--mount=type=bind,source=services/hackbot-api/pyproject.toml,target=/tmp/workspace/services/hackbot-api/pyproject.toml \
+	--mount=type=bind,source=agents/bug-fix/pyproject.toml,target=/tmp/workspace/agents/bug-fix/pyproject.toml \
+	--mount=type=bind,source=libs/hackbot-runtime/pyproject.toml,target=/tmp/workspace/libs/hackbot-runtime/pyproject.toml \
 	cd /tmp/workspace && uv sync --locked --no-dev --package bugbug-http-service --no-install-project
 
 # Setup http service as package

--- a/infra/dockerfile.base
+++ b/infra/dockerfile.base
@@ -11,7 +11,7 @@ RUN --mount=type=bind,source=pyproject.toml,target=/tmp/bugbug/pyproject.toml \
 	--mount=type=bind,source=uv.lock,target=/tmp/bugbug/uv.lock \
 	apt-get update && \
 	apt-get install -y --no-install-recommends gcc g++ libgomp1 libffi-dev libjemalloc2 zstd patch git && \
-	cd /tmp/bugbug && uv sync --frozen --package bugbug --no-dev --no-install-project && \
+	cd /tmp/bugbug && uv sync --locked --package bugbug --no-dev --no-install-project && \
 	apt-get purge -y gcc g++ libffi-dev patch git && \
 	apt-get autoremove -y && \
 	rm -rf /var/lib/apt/lists/*
@@ -21,4 +21,4 @@ ENV LD_PRELOAD="libjemalloc.so.2"
 COPY infra/mozci_config.toml /root/.config/mozci/config.toml
 
 RUN --mount=type=bind,target=/tmp/bugbug,rw \
-	cd /tmp/bugbug && uv sync --frozen --package bugbug --no-dev --no-editable
+	cd /tmp/bugbug && uv sync --locked --package bugbug --no-dev --no-editable

--- a/infra/dockerfile.base
+++ b/infra/dockerfile.base
@@ -10,6 +10,10 @@ ENV UV_PROJECT_ENVIRONMENT="/opt/venv"
 RUN --mount=type=bind,source=pyproject.toml,target=/tmp/bugbug/pyproject.toml \
 	--mount=type=bind,source=uv.lock,target=/tmp/bugbug/uv.lock \
 	--mount=type=bind,source=VERSION,target=/tmp/bugbug/VERSION \
+	--mount=type=bind,source=http_service/pyproject.toml,target=/tmp/bugbug/http_service/pyproject.toml \
+	--mount=type=bind,source=services/hackbot-api/pyproject.toml,target=/tmp/bugbug/services/hackbot-api/pyproject.toml \
+	--mount=type=bind,source=agents/bug-fix/pyproject.toml,target=/tmp/bugbug/agents/bug-fix/pyproject.toml \
+	--mount=type=bind,source=libs/hackbot-runtime/pyproject.toml,target=/tmp/bugbug/libs/hackbot-runtime/pyproject.toml \
 	apt-get update && \
 	apt-get install -y --no-install-recommends gcc g++ libgomp1 libffi-dev libjemalloc2 zstd patch git && \
 	cd /tmp/bugbug && uv sync --locked --package bugbug --no-dev --no-install-project && \

--- a/infra/dockerfile.base
+++ b/infra/dockerfile.base
@@ -9,6 +9,7 @@ ENV UV_PROJECT_ENVIRONMENT="/opt/venv"
 # Setup dependencies in a cacheable step
 RUN --mount=type=bind,source=pyproject.toml,target=/tmp/bugbug/pyproject.toml \
 	--mount=type=bind,source=uv.lock,target=/tmp/bugbug/uv.lock \
+	--mount=type=bind,source=VERSION,target=/tmp/bugbug/VERSION \
 	apt-get update && \
 	apt-get install -y --no-install-recommends gcc g++ libgomp1 libffi-dev libjemalloc2 zstd patch git && \
 	cd /tmp/bugbug && uv sync --locked --package bugbug --no-dev --no-install-project && \

--- a/infra/dockerfile.spawn_pipeline
+++ b/infra/dockerfile.spawn_pipeline
@@ -9,7 +9,7 @@ ENV UV_PROJECT_ENVIRONMENT="/opt/venv"
 # Setup dependencies in a cacheable step
 RUN --mount=type=bind,source=pyproject.toml,target=/tmp/bugbug/pyproject.toml \
 	--mount=type=bind,source=uv.lock,target=/tmp/bugbug/uv.lock \
-	cd /tmp/bugbug && uv sync --frozen --package bugbug --no-dev --only-group spawn-pipeline --no-install-project
+	cd /tmp/bugbug && uv sync --locked --package bugbug --no-dev --only-group spawn-pipeline --no-install-project
 
 ADD infra/spawn_pipeline.py /code/
 

--- a/infra/dockerfile.spawn_pipeline
+++ b/infra/dockerfile.spawn_pipeline
@@ -10,6 +10,10 @@ ENV UV_PROJECT_ENVIRONMENT="/opt/venv"
 RUN --mount=type=bind,source=pyproject.toml,target=/tmp/bugbug/pyproject.toml \
 	--mount=type=bind,source=uv.lock,target=/tmp/bugbug/uv.lock \
 	--mount=type=bind,source=VERSION,target=/tmp/bugbug/VERSION \
+	--mount=type=bind,source=http_service/pyproject.toml,target=/tmp/bugbug/http_service/pyproject.toml \
+	--mount=type=bind,source=services/hackbot-api/pyproject.toml,target=/tmp/bugbug/services/hackbot-api/pyproject.toml \
+	--mount=type=bind,source=agents/bug-fix/pyproject.toml,target=/tmp/bugbug/agents/bug-fix/pyproject.toml \
+	--mount=type=bind,source=libs/hackbot-runtime/pyproject.toml,target=/tmp/bugbug/libs/hackbot-runtime/pyproject.toml \
 	cd /tmp/bugbug && uv sync --locked --package bugbug --no-dev --only-group spawn-pipeline --no-install-project
 
 ADD infra/spawn_pipeline.py /code/

--- a/infra/dockerfile.spawn_pipeline
+++ b/infra/dockerfile.spawn_pipeline
@@ -9,6 +9,7 @@ ENV UV_PROJECT_ENVIRONMENT="/opt/venv"
 # Setup dependencies in a cacheable step
 RUN --mount=type=bind,source=pyproject.toml,target=/tmp/bugbug/pyproject.toml \
 	--mount=type=bind,source=uv.lock,target=/tmp/bugbug/uv.lock \
+	--mount=type=bind,source=VERSION,target=/tmp/bugbug/VERSION \
 	cd /tmp/bugbug && uv sync --locked --package bugbug --no-dev --only-group spawn-pipeline --no-install-project
 
 ADD infra/spawn_pipeline.py /code/

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -47,7 +47,7 @@ bugbug-train backout --limit 30000 --no-download
 # Then spin the http service up
 # This part duplicates the http service Dockerfiles because we cannot easily spin Docker containers
 # up on Taskcluster
-uv sync --frozen --package bugbug-http-service --no-dev
+uv sync --locked --package bugbug-http-service --no-dev
 
 export REDIS_URL=redis://localhost:6379/4
 

--- a/uv.lock
+++ b/uv.lock
@@ -690,10 +690,10 @@ requires-dist = [
     { name = "flask", specifier = "~=3.1.3" },
     { name = "flask-apispec", specifier = "~=0.11.4" },
     { name = "flask-cors", specifier = "~=6.0.2" },
-    { name = "gunicorn", specifier = ">=25.1,<26.1" },
+    { name = "gunicorn", specifier = "~=25.1.0" },
     { name = "kombu", specifier = "~=5.6.2" },
     { name = "marshmallow", specifier = ">=3.18.0" },
-    { name = "rq", specifier = ">=2.7,<2.10" },
+    { name = "rq", specifier = "~=2.7.0" },
     { name = "rq-dashboard", specifier = "~=0.8.6" },
     { name = "sentry-sdk", extras = ["flask"], specifier = "~=2.55.0" },
 ]
@@ -2079,14 +2079,14 @@ wheels = [
 
 [[package]]
 name = "gunicorn"
-version = "26.0.0"
+version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/b7/a4a3f632f823e432ce6bc65f62961b7980c898c77f075a2f7118cb3846fe/gunicorn-26.0.0.tar.gz", hash = "sha256:ca9346f85e3a4aeeb64d491045c16b9a35647abd37ea15efe53080eb8b090baf", size = 727286, upload-time = "2026-05-05T06:38:25.529Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/13/ef67f59f6a7896fdc2c1d62b5665c5219d6b0a9a1784938eb9a28e55e128/gunicorn-25.1.0.tar.gz", hash = "sha256:1426611d959fa77e7de89f8c0f32eed6aa03ee735f98c01efba3e281b1c47616", size = 594377, upload-time = "2026-02-13T11:09:58.989Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/40/9c2384fc2be4ad25dd4a49decd5ad9ea5a3639814c11bd40ab77cb9f0a14/gunicorn-26.0.0-py3-none-any.whl", hash = "sha256:40233d26a5f0d1872916188c276e21641155111c2853f0c2cd55260aec0d24fc", size = 212009, upload-time = "2026-05-05T06:38:23.007Z" },
+    { url = "https://files.pythonhosted.org/packages/da/73/4ad5b1f6a2e21cf1e85afdaad2b7b1a933985e2f5d679147a1953aaa192c/gunicorn-25.1.0-py3-none-any.whl", hash = "sha256:d0b1236ccf27f72cfe14bce7caadf467186f19e865094ca84221424e839b8b8b", size = 197067, upload-time = "2026-02-13T11:09:57.146Z" },
 ]
 
 [[package]]
@@ -5492,16 +5492,16 @@ wheels = [
 
 [[package]]
 name = "rq"
-version = "2.9.0"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "croniter" },
     { name = "redis" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/5e/43a7a61f3ebfa79789c72bf442a47fd80bb1a743caeea47b2b833001f388/rq-2.9.0.tar.gz", hash = "sha256:db5dfc1e1fe80ef977fd557d4305107dcf99a80b33d381c9a06e8a2bb11730e5", size = 744959, upload-time = "2026-05-19T15:00:29.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/9b/93b7180220fe462b4128425e687665bcdeffddc51683d41e7fbe509c2d2e/rq-2.7.0.tar.gz", hash = "sha256:c2156fc7249b5d43dda918c4355cfbf8d0d299a5cdd3963918e9c8daf4b1e0c0", size = 679396, upload-time = "2026-02-22T11:10:50.775Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/a9/aa38ae2505e5dcb1e898f83a263e703b05829580f75ee86c5e480760ae1a/rq-2.9.0-py3-none-any.whl", hash = "sha256:665b9ad34e36ea15913e60d2a32e1775fef1e9aff907bcae297d6f70dccffed2", size = 120113, upload-time = "2026-05-19T15:00:27.511Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1a/3b64696bc0c33aa1d86d3e6add03c4e0afe51110264fd41208bd95c2665c/rq-2.7.0-py3-none-any.whl", hash = "sha256:4b320e95968208d2e249fa0d3d90ee309478e2d7ea60a116f8ff9aa343a4c117", size = 115728, upload-time = "2026-02-22T11:10:48.401Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #6117

Replace uv sync's --frozen flag with --locked across CI and build files to ensure that uv.lock is always in sync with pyproject.toml.