### PR TITLE
Remove unused llama-cpp-python dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "langchain-openai>=1.1.14,<1.3.0",
     "langgraph~=1.1.3",
     "libmozdata~=0.2.12",
-    "llama-cpp-python~=0.3.19",
     "lmdb>=1.8.1,<2.3.0",
     "lxml-html-clean~=0.4.4",
     "markdown2~=2.5.5",

--- a/uv.lock
+++ b/uv.lock
@@ -525,7 +525,6 @@ dependencies = [
     { name = "langchain-openai" },
     { name = "langgraph" },
     { name = "libmozdata" },
-    { name = "llama-cpp-python" },
     { name = "lmdb" },
     { name = "lxml-html-clean" },
     { name = "markdown2" },
@@ -604,7 +603,6 @@ requires-dist = [
     { name = "langchain-openai", specifier = ">=1.1.14,<1.3.0" },
     { name = "langgraph", specifier = "~=1.1.3" },
     { name = "libmozdata", specifier = "~=0.2.12" },
-    { name = "llama-cpp-python", specifier = "~=0.3.19" },
     { name = "lmdb", specifier = ">=1.8.1,<2.3.0" },
     { name = "lxml-html-clean", specifier = "~=0.4.4" },
     { name = "markdown2", specifier = "~=2.5.5" },
@@ -1346,15 +1344,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/60/8b/32f9823da46cde7df2087faa08cd98d01b908f8dcab982cdba9c84e85355/decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82", size = 58084, upload-time = "2026-05-18T06:03:28.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c", size = 10365, upload-time = "2026-05-18T06:03:26.517Z" },
-]
-
-[[package]]
-name = "diskcache"
-version = "5.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
 ]
 
 [[package]]
@@ -3060,18 +3049,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/64/30/763b1a7155d0c0e78
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/7a/604829c4f18b2514f91dcbe5648e23af99918af07e75c22ba7042072653b/lithium_reducer-4.0.0-py3-none-any.whl", hash = "sha256:069a693b9bcccd955c907805736a18f01d25e2ad2d157d9602c3d71535cf96ec", size = 50898, upload-time = "2024-11-12T19:19:06.711Z" },
 ]
-
-[[package]]
-name = "llama-cpp-python"
-version = "0.3.25"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "diskcache" },
-    { name = "jinja2" },
-    { name = "numpy" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/fc/b488e00ebbca5c6a0b2303fb8ce3ded39a5f2293f7da3d7dfb25bcbb1bd9/llama_cpp_python-0.3.25.tar.gz", hash = "sha256:b901792eb474b3c83b07d2f6ed1668257b80133943c1fa57386d636103a66163", size = 67938860, upload-time = "2026-06-02T04:50:40.086Z" }
 
 [[package]]
 name = "llvmlite"


### PR DESCRIPTION
llama-cpp-python was listed as a direct dependency but is not imported or used anywhere in the codebase. Removing it avoids building it from source. Its orphaned transitive dependency diskcache is also dropped.