### PR TITLE
code_review: use adaptive thinking instead of deprecated enabled + budget

### DIFF
--- a/bugbug/tools/code_review/agent.py
+++ b/bugbug/tools/code_review/agent.py
@@ -159,7 +159,7 @@ class CodeReviewTool(GenerativeModelTool):
                 DEFAULT_ANTHROPIC_MODEL,
                 max_tokens=40_000,
                 temperature=None,
-                thinking={"type": "enabled", "budget_tokens": 10_000},
+                thinking={"type": "adaptive"},
             )
 
         if "patch_summarizer" not in kwargs:


### PR DESCRIPTION
`claude-opus-4-6` deprecated `thinking.type=enabled` in favour of adaptive thiking. `budget_tokens` is also unused with adaptive thinking and has been removed.

https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking provides some details. Not stipulating anything means "high" (the default). We should do this for some time and see what it does and if we want to spend more, but we need observability.

Fixes #5999