### PR TITLE
Include diff ID in review comment

### DIFF
--- a/services/reviewhelper-api/app/review_processor.py
+++ b/services/reviewhelper-api/app/review_processor.py
@@ -167,7 +167,8 @@ def create_main_review_comment(
     review_request: ReviewRequest, generated_comments: Collection[GeneratedComment]
 ) -> str:
     """Create the main review comment that summarizes the review results."""
-    parts = []
+    diff_url = f"{settings.phabricator_url}/D{review_request.revision_id}?id={review_request.diff_id}"
+    parts = [f"(Reviewing [Diff {review_request.diff_id}]({diff_url}))"]
 
     if review_request.summary:
         parts.append(review_request.summary)


### PR DESCRIPTION
Adds a linkified diff reference to the top of the main review comment, so reviewers can tell which diff was reviewed at a glance.

Fixes #6029