### PR TITLE
code_review: tolerate double-encoded enum tool args

### DIFF
--- a/bugbug/tools/code_review/langchain_tools.py
+++ b/bugbug/tools/code_review/langchain_tools.py
@@ -8,7 +8,7 @@
 from dataclasses import dataclass
 from functools import cache
 from logging import getLogger
-from typing import Literal, Optional
+from typing import Annotated, Literal, Optional
 
 import httpx
 import tenacity
@@ -19,6 +19,7 @@ from searchfox import AsyncSearchfoxClient
 from bugbug.tools.code_review.data_types import Skill, SkillLoadError
 from bugbug.tools.core.platforms.base import Patch
 from bugbug.tools.core.platforms.patch_apply import get_file_after_stack
+from bugbug.tools.core.validators import StripEnumQuotes
 
 logger = getLogger(__name__)
 
@@ -34,10 +35,13 @@ def _tool_error(message: str, *, fatal: bool = False) -> str:
     return f"{prefix}: {message}"
 
 
-LangStr = Literal[
-    "cpp", "c", "js", "webidl", "java", "kotlin", "rust", "python", "html", "css"
+LangStr = Annotated[
+    Literal[
+        "cpp", "c", "js", "webidl", "java", "kotlin", "rust", "python", "html", "css"
+    ],
+    StripEnumQuotes,
 ]
-Tests = Optional[Literal["only", "exclude"]]
+Tests = Optional[Annotated[Literal["only", "exclude"], StripEnumQuotes]]
 
 
 @dataclass

--- a/bugbug/tools/core/validators.py
+++ b/bugbug/tools/core/validators.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Reusable pydantic helpers for tolerating malformed LLM tool arguments."""
+
+from pydantic import BeforeValidator
+
+
+def strip_enum_quotes(value):
+    """Strip surrounding quotes/whitespace models sometimes add to enum args.
+
+    LLMs occasionally double-encode string arguments, sending e.g. the literal
+    '"exclude"' (quotes included) instead of 'exclude', which then fails enum
+    validation. See https://github.com/mozilla/bugbug/issues/6140.
+    """
+    if isinstance(value, str):
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+            value = value[1:-1].strip()
+    return value
+
+
+# Reusable ``BeforeValidator`` for ``Literal`` tool parameters fed by an LLM.
+#
+# Use as ``Annotated[Literal[...], StripEnumQuotes]`` so the value is unwrapped
+# before validation. The generated JSON schema is unchanged (still an
+# ``enum``), so strict-mode validation still rejects genuinely-invalid values
+# at the API layer; only the parsing of the supplied value is relaxed.
+StripEnumQuotes = BeforeValidator(strip_enum_quotes)

--- a/tests/test_code_review.py
+++ b/tests/test_code_review.py
@@ -10,7 +10,12 @@ from unidiff import PatchSet
 
 from bugbug.tools.code_review import data_types, langchain_tools
 from bugbug.tools.code_review.data_types import Skill, _strip_frontmatter
-from bugbug.tools.code_review.langchain_tools import _fetch_file, create_load_skill_tool
+from bugbug.tools.code_review.langchain_tools import (
+    _fetch_file,
+    create_load_skill_tool,
+    search_identifier,
+    search_text,
+)
 from bugbug.tools.code_review.utils import find_comment_scope
 from bugbug.tools.core.platforms.patch_apply import (
     apply_patched_file,
@@ -480,3 +485,42 @@ def test_fetch_file_skips_revision_when_none():
     result = asyncio.run(_fetch_file("f.txt", None, client, patch))
     assert result == "latest content"
     client.get_file_at_revision.assert_not_called()
+
+
+def _mock_search_client():
+    client = MagicMock()
+    client.search = AsyncMock(return_value=[("dom/a.cpp", 1, "match")])
+    return client
+
+
+@pytest.mark.asyncio
+async def test_search_text_accepts_double_encoded_tests_value():
+    """Models sometimes send '"exclude"' (quotes included); it must validate.
+
+    Regression test for https://github.com/mozilla/bugbug/issues/6140.
+    """
+    client = _mock_search_client()
+    with patch.object(langchain_tools, "_get_client", return_value=client):
+        result = await search_text.ainvoke({"query": "foo", "tests": '"exclude"'})
+    assert "dom/a.cpp:1: match" in result
+    assert client.search.await_args.kwargs["tests"] == "exclude"
+
+
+@pytest.mark.asyncio
+async def test_search_text_accepts_double_encoded_langs_value():
+    client = _mock_search_client()
+    with patch.object(langchain_tools, "_get_client", return_value=client):
+        result = await search_text.ainvoke({"query": "foo", "langs": ['"cpp"']})
+    assert "dom/a.cpp:1: match" in result
+    assert client.search.await_args.kwargs["langs"] == ["cpp"]
+
+
+@pytest.mark.asyncio
+async def test_search_identifier_accepts_double_encoded_tests_value():
+    client = _mock_search_client()
+    with patch.object(langchain_tools, "_get_client", return_value=client):
+        result = await search_identifier.ainvoke(
+            {"identifier": "Foo", "tests": "'only'"}
+        )
+    assert "dom/a.cpp:1: match" in result
+    assert client.search.await_args.kwargs["tests"] == "only"

--- a/tests/test_tools_core_validators.py
+++ b/tests/test_tools_core_validators.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from typing import Annotated, Literal, Optional
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from bugbug.tools.core.validators import StripEnumQuotes, strip_enum_quotes
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ('"exclude"', "exclude"),
+        ("'only'", "only"),
+        ('  "exclude" ', "exclude"),
+        ("exclude", "exclude"),
+        ("only", "only"),
+        ("", ""),
+        ('"', '"'),  # lone quote: not a wrapping pair, left untouched
+        (None, None),
+        (42, 42),  # non-str passthrough
+    ],
+)
+def test_strip_enum_quotes(value, expected):
+    assert strip_enum_quotes(value) == expected
+
+
+class _Model(BaseModel):
+    value: Optional[Annotated[Literal["only", "exclude"], StripEnumQuotes]] = None
+
+
+def test_strip_enum_quotes_validator_accepts_double_encoded_value():
+    assert _Model(value='"exclude"').value == "exclude"
+    assert _Model(value="'only'").value == "only"
+    assert _Model(value="exclude").value == "exclude"
+    assert _Model().value is None
+
+
+def test_strip_enum_quotes_validator_still_rejects_invalid_value():
+    with pytest.raises(ValidationError):
+        _Model(value="nonsense")
+
+
+def test_strip_enum_quotes_schema_still_emits_enum():
+    """Strict-mode validation relies on the JSON schema keeping the enum."""
+    schema = _Model.model_json_schema()
+    enum = schema["properties"]["value"]["anyOf"][0]["enum"]
+    assert enum == ["only", "exclude"]


### PR DESCRIPTION
Models occasionally send enum tool arguments double-encoded, e.g. the literal '"exclude"' (quotes included) for the search_text/search_identifier 'tests' parameter, which failed pydantic Literal validation and crashed the tool call with a ValidationError.

Add a reusable bugbug.tools.core.validators module exposing strip_enum_quotes and a StripEnumQuotes BeforeValidator, used as Annotated[Literal[...], StripEnumQuotes] so any LLM-fed enum param can opt in. The 'tests' and 'langs' params now strip surrounding quotes/whitespace before the Literal check. The JSON schema sent to Anthropic is unchanged (still emits the enum), so strict-mode validation is preserved.

Fixes #6140