### PR TITLE
Fail patch summary generation on runaway LLM output

### DIFF
--- a/bugbug/tools/core/exceptions.py
+++ b/bugbug/tools/core/exceptions.py
@@ -18,5 +18,14 @@ class HunkNotInPatchError(ModelResultError):
     """Occurs when the hunk in the model result is not part of the patch."""
 
 
+class RunawayGenerationError(ModelResultError):
+    """Occurs when the model produces a degenerate output.
+
+    This typically happens when the model gets stuck in a next-token loop and
+    repeats the same word or phrase many times, or otherwise emits an
+    excessively long result (see https://github.com/mozilla/bugbug/issues/5995).
+    """
+
+
 class LargeDiffError(Exception):
     """Occurs when the diff is too large to be processed."""

--- a/bugbug/tools/core/text.py
+++ b/bugbug/tools/core/text.py
@@ -14,11 +14,8 @@ garbage.
 """
 
 import re
-from logging import getLogger
 
 from bugbug.tools.core.exceptions import RunawayGenerationError
-
-logger = getLogger(__name__)
 
 # Upper bound on the length (in characters) of any LLM-generated text we post.
 # A genuine patch summary or review comment is comfortably within this; anything

--- a/bugbug/tools/core/text.py
+++ b/bugbug/tools/core/text.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Guardrails for LLM-generated text that gets posted publicly.
+
+LLMs occasionally get stuck in a degenerate next-token loop and emit the same
+word or short phrase thousands of times (see
+https://github.com/mozilla/bugbug/issues/5995). When such output is posted as a
+review comment it produces a massive, useless comment. The helpers here detect
+that pathological output so the caller can fail (and retry) instead of posting
+garbage.
+"""
+
+import re
+from logging import getLogger
+
+from bugbug.tools.core.exceptions import RunawayGenerationError
+
+logger = getLogger(__name__)
+
+# Upper bound on the length (in characters) of any LLM-generated text we post.
+# A genuine patch summary or review comment is comfortably within this; anything
+# larger is almost certainly a runaway generation.
+MAX_GENERATED_TEXT_LENGTH = 10_000
+
+# If a short chunk of text repeats this many times back-to-back, we treat the
+# output as a degenerate model loop.
+MIN_REPETITIONS = 10
+
+# Longest chunk we look for when detecting consecutive repetition. This covers
+# both single repeated words ("prevent prevent ...") and short repeated phrases
+# ("not converting not converting ..."). Keeping it small also bounds the cost
+# of the backreference-based search.
+_MAX_REPEATING_CHUNK_LENGTH = 60
+
+# Matches a chunk of up to ``_MAX_REPEATING_CHUNK_LENGTH`` characters that
+# repeats at least ``MIN_REPETITIONS`` times in a row.
+_REPETITION_RE = re.compile(
+    r"(.{1,%d}?)\1{%d,}" % (_MAX_REPEATING_CHUNK_LENGTH, MIN_REPETITIONS - 1),
+    re.DOTALL,
+)
+
+
+def find_runaway_repetition(text: str) -> int | None:
+    """Locate a degenerate repetition loop in the text.
+
+    Args:
+        text: The text to inspect.
+
+    Returns:
+        The character offset where the repetition begins, or ``None`` if no
+        runaway repetition was found.
+    """
+    match = _REPETITION_RE.search(text)
+    return match.start() if match else None
+
+
+def check_runaway_generation(
+    text: str, label: str = "text", max_length: int = MAX_GENERATED_TEXT_LENGTH
+) -> None:
+    """Fail fast when LLM-generated text looks like a runaway generation.
+
+    Detects the two symptoms of a model stuck in a degenerate loop: an
+    excessively long output, or a short word/phrase repeated many times in a
+    row. Either one raises :class:`RunawayGenerationError` so the caller can
+    fail the generation (and let it be retried) rather than posting garbage.
+
+    Args:
+        text: The raw text produced by the model.
+        label: A human-readable name for the text, used in the error message.
+        max_length: The maximum number of characters to allow.
+
+    Raises:
+        RunawayGenerationError: If the text is too long or excessively repetitive.
+    """
+    if not text:
+        return
+
+    # Check the length first so the repetition search below only ever runs on a
+    # bounded string, regardless of how large the original generation was.
+    if len(text) > max_length:
+        raise RunawayGenerationError(
+            f"Generated {label} is too long: {len(text)} characters "
+            f"(limit is {max_length})."
+        )
+
+    offset = find_runaway_repetition(text)
+    if offset is not None:
+        raise RunawayGenerationError(
+            f"Generated {label} contains excessive repetition "
+            f"starting at offset {offset}."
+        )

--- a/bugbug/tools/patch_summarization/agent.py
+++ b/bugbug/tools/patch_summarization/agent.py
@@ -6,6 +6,7 @@ from bugbug.tools.base import GenerativeModelTool
 from bugbug.tools.code_review.utils import format_patch_set
 from bugbug.tools.core.llms import DEFAULT_ANTHROPIC_MODEL
 from bugbug.tools.core.platforms.base import Patch
+from bugbug.tools.core.text import check_runaway_generation
 from bugbug.tools.patch_summarization.prompts import PROMPT_TEMPLATE_SUMMARIZATION
 
 
@@ -51,5 +52,7 @@ class PatchSummarizationTool(GenerativeModelTool):
         idx = summary.rfind("<budget:token")
         if idx != -1:
             summary = summary[:idx].strip()
+
+        check_runaway_generation(summary, label="patch summary")
 
         return summary

--- a/tests/test_tools_core_text.py
+++ b/tests/test_tools_core_text.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from bugbug.tools.core.exceptions import RunawayGenerationError
+from bugbug.tools.core.text import check_runaway_generation, find_runaway_repetition
+
+
+def test_short_text_passes():
+    text = "## Summary\n\nThis is a perfectly normal, concise review comment."
+    # Should not raise.
+    check_runaway_generation(text)
+
+
+def test_empty_text_passes():
+    check_runaway_generation("")
+
+
+def test_single_word_repetition_raises():
+    # The exact failure mode from issue #5995.
+    text = "The change is good. " + "prevent " * 5000
+    with pytest.raises(RunawayGenerationError):
+        check_runaway_generation(text)
+
+
+def test_phrase_repetition_raises():
+    text = "Here is the issue: " + "not converting " * 5000
+    with pytest.raises(RunawayGenerationError):
+        check_runaway_generation(text)
+
+
+def test_excessive_length_raises():
+    text = "a. " * 100_000  # No single chunk repeats, but it is enormous.
+    with pytest.raises(RunawayGenerationError):
+        check_runaway_generation(text)
+
+
+def test_legitimate_short_repetition_passes():
+    # A handful of repeated words is not a runaway loop and should be allowed.
+    check_runaway_generation("no no no, this is fine")
+
+
+def test_custom_max_length():
+    text = "abcdefghijklmnopqrstuvwxyz" * 4
+    with pytest.raises(RunawayGenerationError):
+        check_runaway_generation(text, max_length=10)
+
+
+def test_error_message_includes_label():
+    text = "x " + "loop " * 100
+    with pytest.raises(RunawayGenerationError, match="patch summary"):
+        check_runaway_generation(text, label="patch summary")
+
+
+def test_find_runaway_repetition_returns_offset():
+    text = "Intro. " + "spam " * 50
+    offset = find_runaway_repetition(text)
+    # The loop starts right after the intro (the detector may include the
+    # preceding space as part of the repeating chunk).
+    assert offset is not None
+    assert offset in (len("Intro."), len("Intro. "))
+
+
+def test_find_runaway_repetition_returns_none_for_clean_text():
+    assert find_runaway_repetition("A clean and normal summary.") is None

--- a/tests/test_tools_core_text.py
+++ b/tests/test_tools_core_text.py
@@ -6,7 +6,11 @@
 import pytest
 
 from bugbug.tools.core.exceptions import RunawayGenerationError
-from bugbug.tools.core.text import check_runaway_generation, find_runaway_repetition
+from bugbug.tools.core.text import (
+    MAX_GENERATED_TEXT_LENGTH,
+    check_runaway_generation,
+    find_runaway_repetition,
+)
 
 
 def test_short_text_passes():
@@ -20,15 +24,18 @@ def test_empty_text_passes():
 
 
 def test_single_word_repetition_raises():
-    # The exact failure mode from issue #5995.
-    text = "The change is good. " + "prevent " * 5000
-    with pytest.raises(RunawayGenerationError):
+    # The exact failure mode from issue #5995. Kept under MAX_GENERATED_TEXT_LENGTH
+    # so the repetition detector (not the length guard) is what triggers.
+    text = "The change is good. " + "prevent " * 100
+    assert len(text) < MAX_GENERATED_TEXT_LENGTH
+    with pytest.raises(RunawayGenerationError, match="repetition"):
         check_runaway_generation(text)
 
 
 def test_phrase_repetition_raises():
-    text = "Here is the issue: " + "not converting " * 5000
-    with pytest.raises(RunawayGenerationError):
+    text = "Here is the issue: " + "not converting " * 100
+    assert len(text) < MAX_GENERATED_TEXT_LENGTH
+    with pytest.raises(RunawayGenerationError, match="repetition"):
         check_runaway_generation(text)
 
 


### PR DESCRIPTION
Fixes #5995

LLMs occasionally get stuck in a degenerate next-token loop and repeat the same word or phrase thousands of times, producing a massive, useless review comment. Detect this in PatchSummarizationTool and raise RunawayGenerationError (a retryable ModelResultError) instead of posting the garbage summary.