### PR TITLE
Upload Hackbot agent changes as artifacts

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -90,8 +90,15 @@ the repo's root `docker-compose.yml`, so running it is three steps:
 
    Here `bug-fix-agent` is the service name defined in the agent's `compose.yml` —
    use that agent's own service name when you run a different one. Compose builds and
-   runs the agent against that bug. The run's `summary.json`, logs, and attachments are
-   written under `~/hackbot/artifacts/<run_id>` on your host (no uploader runs locally).
+   runs the agent against that bug. The run's `summary.json`, logs, attachments, and
+   source changes are written under `~/hackbot/artifacts/<run_id>` on your host (no
+   uploader runs locally).
+
+   If your agent declares a `[source]`, the runtime automatically collects whatever it
+   changed in the checkout — committed locally or not — into `changes/changes.patch`
+   (an mbox that preserves each local commit's message and author, including binary and
+   untracked files) plus a `changes/changes.json` summary. Apply it with one command:
+   `git am changes/changes.patch`.
 
 ## Telling the platform what you need (`hackbot.toml`)
 

--- a/libs/hackbot-runtime/hackbot_runtime/changes.py
+++ b/libs/hackbot-runtime/hackbot_runtime/changes.py
@@ -1,0 +1,137 @@
+"""Collect an agent's source-tree changes into a git-am patch + metadata.
+
+After an agent runs, its work may be committed locally (each commit with its own
+message/author) or left uncommitted/untracked. This module captures all of it,
+relative to the commit the checkout started from, as a single mbox patch that
+``git am`` applies in one command — preserving the local commit history — plus a
+JSON summary of the commits and files touched.
+
+Any uncommitted remainder is wrapped into one synthetic commit first, so nothing
+is lost. The checkout is ephemeral (one run per container), so mutating its index
+and creating that commit is safe.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import NamedTuple
+
+log = logging.getLogger("hackbot_runtime.changes")
+
+# Author stamped on the synthetic commit that wraps any uncommitted remainder.
+_WIP_NAME = "Hackbot Agent"
+_WIP_EMAIL = "hackbot@mozilla.tld"
+_WIP_MESSAGE = "Uncommitted agent changes"
+
+# Record separator for parsing ``git log`` output (NUL avoids clashing with
+# anything in commit messages).
+_FIELD_SEP = "\x1f"
+_RECORD_SEP = "\x1e"
+
+
+class ChangeSet(NamedTuple):
+    """The collected agent changes: an mbox patch plus its metadata."""
+
+    patch: bytes
+    metadata: dict
+
+
+def _git(repo: Path, *args: str) -> str:
+    """Run a git command in ``repo`` and return its stdout (text)."""
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def _git_bytes(repo: Path, *args: str) -> bytes:
+    """Run a git command in ``repo`` and return its stdout (bytes).
+
+    Used for ``format-patch``, whose output may contain binary diffs.
+    """
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+    ).stdout
+
+
+def base_commit(repo: Path) -> str:
+    """Return the current HEAD sha — the base the agent starts editing from."""
+    return _git(repo, "rev-parse", "HEAD").strip()
+
+
+def _has_uncommitted(repo: Path) -> bool:
+    return bool(_git(repo, "status", "--porcelain").strip())
+
+
+def _wrap_uncommitted(repo: Path) -> bool:
+    """Commit any staged/unstaged/untracked changes into one synthetic commit.
+
+    Returns ``True`` if such a commit was created, ``False`` if the tree was
+    already clean.
+    """
+    if not _has_uncommitted(repo):
+        return False
+    _git(repo, "add", "-A")
+    _git(
+        repo,
+        "-c",
+        f"user.name={_WIP_NAME}",
+        "-c",
+        f"user.email={_WIP_EMAIL}",
+        "commit",
+        "--no-verify",
+        "-m",
+        _WIP_MESSAGE,
+    )
+    return True
+
+
+def _commit_metadata(repo: Path, base: str) -> list[dict]:
+    """Structured info for each commit in ``base..HEAD`` (oldest first)."""
+    fmt = _FIELD_SEP.join(["%H", "%an", "%ae", "%aI", "%s", "%b"]) + _RECORD_SEP
+    out = _git(repo, "log", "--reverse", f"--format={fmt}", f"{base}..HEAD")
+    commits = []
+    for record in out.split(_RECORD_SEP):
+        record = record.strip("\n")
+        if not record:
+            continue
+        sha, author_name, author_email, authored_date, subject, body = record.split(
+            _FIELD_SEP
+        )
+        commits.append(
+            {
+                "sha": sha,
+                "author_name": author_name,
+                "author_email": author_email,
+                "authored_date": authored_date,
+                "subject": subject,
+                "body": body,
+            }
+        )
+    return commits
+
+
+def collect(repo: Path, base: str) -> ChangeSet | None:
+    """Collect changes in ``repo`` since ``base`` as a patch plus metadata.
+
+    Returns ``None`` when the agent made no changes at all (nothing committed and
+    a clean working tree). Otherwise returns a :class:`ChangeSet` whose ``patch``
+    is an mbox (``git format-patch`` output) applied with ``git am`` and whose
+    ``metadata`` describes the base, the commits, and the files touched.
+    """
+    wrapped = _wrap_uncommitted(repo)
+    patch = _git_bytes(repo, "format-patch", "--stdout", "--binary", f"{base}..HEAD")
+    if not patch.strip():
+        return None
+    metadata = {
+        "base_commit": base,
+        "wrapped_uncommitted": wrapped,
+        "commits": _commit_metadata(repo, base),
+    }
+    return ChangeSet(patch=patch, metadata=metadata)

--- a/libs/hackbot-runtime/hackbot_runtime/context.py
+++ b/libs/hackbot-runtime/hackbot_runtime/context.py
@@ -13,6 +13,7 @@ its capability declarations come from the agent's ``hackbot.toml``
 from __future__ import annotations
 
 import datetime
+import logging
 import os
 import tempfile
 import uuid
@@ -23,7 +24,7 @@ from typing import TYPE_CHECKING
 from pydantic import Field, PrivateAttr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from hackbot_runtime import artifacts
+from hackbot_runtime import artifacts, changes
 from hackbot_runtime.actions.recorder import ActionsRecorder
 from hackbot_runtime.config import HackbotConfig, load_config
 from hackbot_runtime.providers import AnthropicAuth
@@ -32,6 +33,8 @@ from hackbot_runtime.uploader import SignedPolicyUploader
 
 if TYPE_CHECKING:
     from agent_tools.firefox import FirefoxContext
+
+log = logging.getLogger("hackbot_runtime.context")
 
 
 def _default_run_id() -> str:
@@ -71,6 +74,10 @@ class HackbotContext(BaseSettings):
     # Capability declarations from hackbot.toml (not env); attached after
     # construction via from_config()/from_config_obj().
     _config: HackbotConfig = PrivateAttr(default_factory=HackbotConfig)
+    # The commit the source checkout started from, recorded when source_repo is
+    # prepared. Stays None for agents that never touch source, which is how
+    # publish_changes() knows there are no changes to collect.
+    _source_base: str | None = PrivateAttr(default=None)
 
     @classmethod
     def from_config(cls, config_path: Path) -> "HackbotContext":
@@ -106,6 +113,13 @@ class HackbotContext(BaseSettings):
         env_path = os.environ.get("SOURCE_REPO")
         path = Path(env_path) if env_path else self._config.source.checkout_path
         ensure_source_repo(path, self._config.source.repo_url)
+        # Record where the agent starts editing, so publish_changes() can later
+        # diff the final tree against it. Best-effort: a failure here must not
+        # break the agent's access to source — it only disables change capture.
+        try:
+            self._source_base = changes.base_commit(path)
+        except Exception:
+            log.warning("Could not record source base commit at %s", path)
         return path
 
     @cached_property
@@ -175,3 +189,30 @@ class HackbotContext(BaseSettings):
         return artifacts.publish_json(
             self.uploader, self.run_artifacts_dir, key, payload
         )
+
+    def publish_changes(
+        self,
+        patch_key: str = "changes/changes.patch",
+        meta_key: str = "changes/changes.json",
+    ) -> str | None:
+        """Collect the agent's source-tree changes and publish them as artifacts.
+
+        Produces an mbox patch (applied with ``git am``) that preserves any
+        local commits and wraps the uncommitted remainder, plus a JSON summary.
+        Returns the patch key, or ``None`` when the agent never prepared a source
+        checkout or made no changes at all.
+        """
+        if self._source_base is None:
+            return None
+        change_set = changes.collect(self.source_repo, self._source_base)
+        if change_set is None:
+            return None
+        artifacts.publish_bytes(
+            self.uploader,
+            self.run_artifacts_dir,
+            patch_key,
+            change_set.patch,
+            "text/x-patch",
+        )
+        self.publish_json(meta_key, change_set.metadata)
+        return patch_key

--- a/libs/hackbot-runtime/hackbot_runtime/runtime.py
+++ b/libs/hackbot-runtime/hackbot_runtime/runtime.py
@@ -159,6 +159,11 @@ def _finish(ctx: HackbotContext, outcome: object) -> int:
     except Exception:
         log.exception("Failed to publish agent log")
 
+    try:
+        ctx.publish_changes()
+    except Exception:
+        log.exception("Failed to publish source changes")
+
     # Upload when a signed policy is configured, else write into the local
     # artifacts dir (so local/compose/direct runs leave it on the host).
     try:


### PR DESCRIPTION
Resolves #6156

Collect whatever an agent changed in its source checkout, whether committed locally or left uncommitted/untracked, into an mbox patch (changes/changes.patch) plus a JSON summary (changes/changes.json), published automatically by the runtime for any agent that declares a [source].

The patch is produced with git format-patch, so it preserves each local commit's message and author and applies in one command with git am; any uncommitted remainder is wrapped into a single synthetic commit first so nothing is lost.