### PR TITLE
Allow-list Review Helper bot in Phabricator MCP comment filtering

### DIFF
--- a/bugbug/tools/core/platforms/phabricator.py
+++ b/bugbug/tools/core/platforms/phabricator.py
@@ -28,9 +28,10 @@ logger = getLogger(__name__)
 # Trusted users group PHID (currently defined as MOCO group members)
 MOCO_GROUP_PHID = "PHID-PROJ-a2zxxknk7jm5nw4rtjsl"  # bmo-mozilla-employee-confidential
 REVIEWBOT_PHID = "PHID-USER-cje4weq32o3xyuegalpj"
+REVIEWHELPER_PHID = "PHID-USER-g7c2dpvg7k2uv6gacaqf"
 
 # Mozilla-operated bot accounts that should be treated as trusted
-TRUSTED_BOT_PHIDS = {REVIEWBOT_PHID}
+TRUSTED_BOT_PHIDS = {REVIEWBOT_PHID, REVIEWHELPER_PHID}
 
 # Messages used when redacting untrusted content
 UNTRUSTED_CONTENT_REDACTED = "[Content from untrusted user removed for security]"


### PR DESCRIPTION
Fixes #6168

Review Helper posts under a dedicated Phabricator account distinct from reviewbot, so its review comments were redacted by the MCP's trust filtering. Add its PHID to TRUSTED_BOT_PHIDS so its comments are shown.