### PR TITLE
Switch Phabricator redaction trust group to bmo-editbugs-team

### DIFF
--- a/bugbug/tools/core/platforms/phabricator.py
+++ b/bugbug/tools/core/platforms/phabricator.py
@@ -25,8 +25,8 @@ from bugbug.tools.core.platforms.bugzilla import Bug
 
 logger = getLogger(__name__)
 
-# Trusted users group PHID (currently defined as MOCO group members)
-MOCO_GROUP_PHID = "PHID-PROJ-a2zxxknk7jm5nw4rtjsl"  # bmo-mozilla-employee-confidential
+# Trusted users group PHID (bmo-editbugs-team members)
+EDITBUGS_GROUP_PHID = "PHID-PROJ-njo5uuqyyq3oijbkhy55"  # bmo-editbugs-team
 REVIEWBOT_PHID = "PHID-USER-cje4weq32o3xyuegalpj"
 
 # Mozilla-operated bot accounts that should be treated as trusted
@@ -86,10 +86,10 @@ def _get_users_info_batch_impl(user_phids: set[str]) -> dict[str, dict]:
         constraints={"phids": list(user_phids)},
     )
 
-    # Get MOCO group members
+    # Get bmo-editbugs-team members
     moco_response = phabricator.request(
         "project.search",
-        constraints={"phids": [MOCO_GROUP_PHID]},
+        constraints={"phids": [EDITBUGS_GROUP_PHID]},
         attachments={"members": True},
     )
 
@@ -139,7 +139,7 @@ def _get_users_info_batch(user_phids: set[str]) -> dict[str, dict]:
     Returns:
         Dictionary mapping user PHID to info dict with keys:
         - email: User's email address
-        - is_trusted: Whether user is in MOCO group
+        - is_trusted: Whether user is in bmo-editbugs-team
         - real_name: User's real name
     """
     return _get_users_info_batch_with_retry(user_phids)
@@ -161,7 +161,7 @@ def _sanitize_comments(comments: list, users_info: dict[str, dict]) -> tuple[lis
     """
     from copy import copy
 
-    # Walk backwards to find last trusted comment (from MOCO)
+    # Walk backwards to find last trusted comment (from bmo-editbugs-team)
     last_trusted_index = -1
     for i in range(len(comments) - 1, -1, -1):
         comment_is_trusted = users_info.get(comments[i].author_phid, {}).get(

--- a/tests/test_phabricator_trusted_filtering.py
+++ b/tests/test_phabricator_trusted_filtering.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from bugbug.tools.core.platforms.phabricator import (
-    MOCO_GROUP_PHID,
+    EDITBUGS_GROUP_PHID,
     TRUSTED_BOT_PHIDS,
     UNTRUSTED_CONTENT_REDACTED,
     PhabricatorGeneralComment,
@@ -342,8 +342,8 @@ class TestToMdEndToEnd:
     MOCK_MOCO_GROUP = {
         "data": [
             {
-                "phid": MOCO_GROUP_PHID,
-                "fields": {"name": "bmo-mozilla-employee-confidential"},
+                "phid": EDITBUGS_GROUP_PHID,
+                "fields": {"name": "bmo-editbugs-team"},
                 "attachments": {
                     "members": {
                         "members": [
@@ -810,7 +810,7 @@ def test_get_users_info_batch_mixed_trust():
 )
 @pytest.mark.withoutresponses
 def test_moco_group_phid_is_valid():
-    """Test that `MOCO_GROUP_PHID` points to a valid project.
+    """Test that `EDITBUGS_GROUP_PHID` points to a valid project.
 
     This can only be run with an API key, to validate changes locally.
     """
@@ -818,12 +818,12 @@ def test_moco_group_phid_is_valid():
 
     resp = phabricator_client.request(
         "project.search",
-        constraints={"phids": [MOCO_GROUP_PHID]},
+        constraints={"phids": [EDITBUGS_GROUP_PHID]},
     )
 
     assert len(resp["data"]) == 1
-    assert resp["data"][0]["phid"] == MOCO_GROUP_PHID
-    assert "bmo-mozilla-employee-confidential" in resp["data"][0]["fields"]["name"]
+    assert resp["data"][0]["phid"] == EDITBUGS_GROUP_PHID
+    assert "bmo-editbugs-team" in resp["data"][0]["fields"]["name"]
 
 
 def test_phabricator_metadata_redacted_without_trusted_comment():


### PR DESCRIPTION
Change MOCO_GROUP_PHID from bmo-mozilla-employee-confidential (PHID-PROJ-a2zxxknk7jm5nw4rtjsl) to bmo-editbugs-team (PHID-PROJ-njo5uuqyyq3oijbkhy55).