### PR TITLE
Temporarily disable the bugzilla_quick_search MCP tool

### DIFF
--- a/services/mcp/src/bugbug_mcp/server.py
+++ b/services/mcp/src/bugbug_mcp/server.py
@@ -21,6 +21,10 @@ from bugbug.tools.core.platforms.phabricator import (
 
 mcp = FastMCP("Firefox Development MCP Server")
 
+# Temporarily disabled due to https://github.com/mozilla/bugbug/issues/5890.
+# Once that issue is resolved, we should re-enable the Bugzilla search tool.
+mcp.disable(names={"bugzilla_quick_search"})
+
 
 @functools.cache
 def get_code_review_tool():

--- a/services/mcp/tests/test_bugzilla_tools.py
+++ b/services/mcp/tests/test_bugzilla_tools.py
@@ -42,6 +42,10 @@ def setup_bugzilla_mock(mocker, bugs):
     return mock_bugzilla_class
 
 
+@pytest.mark.skip(
+    reason="bugzilla_quick_search tool is temporarily disabled due to "
+    "https://github.com/mozilla/bugbug/issues/5890"
+)
 class TestBugzillaQuickSearch:
     """Test the bugzilla_quick_search tool."""
 


### PR DESCRIPTION
Disable the tool at the server level via mcp.disable() and skip its tests until #5890 is resolved.