### PR TITLE
Replace removed QdrantClient.search with query_points

### DIFF
--- a/bugbug/vectordb.py
+++ b/bugbug/vectordb.py
@@ -134,9 +134,12 @@ class QdrantVectorDB(VectorDB):
     ) -> Iterable[PayloadScore]:
         qdrant_filter = filter.to_qdrant_filter() if filter else None
 
-        for item in self.client.search(
-            self.collection_name, query, qdrant_filter, limit=limit
-        ):
+        for item in self.client.query_points(
+            self.collection_name,
+            query=query,
+            query_filter=qdrant_filter,
+            limit=limit,
+        ).points:
             yield PayloadScore(item.score, item.id, item.payload)
 
     def get_existing_ids(self) -> Iterable[int]:


### PR DESCRIPTION
Fixes #6202

`QdrantClient.search` was removed in recent versions of `qdrant-client`, causing `AttributeError: 'QdrantClient' object has no attribute 'search'` during code review comment lookups.

This switches `QdrantVectorDB.search` to use `query_points`, the supported replacement, which returns a response object whose `points` attribute holds the scored results. The old positional `search(collection_name, query_vector, query_filter, ...)` call is mapped to `query_points(collection_name, query=..., query_filter=..., limit=...)`.