### PR TITLE
Move MCP and reviewhelper-api Cloud Build configs into the repo

### DIFF
--- a/services/mcp/cloudbuild.yaml
+++ b/services/mcp/cloudbuild.yaml
@@ -1,0 +1,49 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    env:
+      - DOCKER_BUILDKIT=1
+    args:
+      - build
+      - "--no-cache"
+      - "-t"
+      - "$_IMAGE_URI"
+      - .
+      - "-f"
+      - services/mcp/Dockerfile
+    id: Build
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - "$_IMAGE_URI"
+    id: Push
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    entrypoint: gcloud
+    args:
+      - run
+      - services
+      - update
+      - $_SERVICE_NAME
+      - "--platform=managed"
+      - "--image=$_IMAGE_URI"
+      - "--labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID"
+      - "--region=$_DEPLOY_REGION"
+      - "--quiet"
+    id: Deploy
+images:
+  - "$_IMAGE_URI"
+options:
+  substitutionOption: ALLOW_LOOSE
+  dynamicSubstitutions: true
+  logging: CLOUD_LOGGING_ONLY
+substitutions:
+  _DEPLOY_REGION: us-central1
+  _AR_HOSTNAME: us-central1-docker.pkg.dev
+  _AR_REPOSITORY: cloud-run-source-deploy
+  _AR_PROJECT_ID: moz-bugbug
+  _PLATFORM: managed
+  _SERVICE_NAME: mcp-dev
+  _IMAGE_URI: "$_AR_HOSTNAME/$_AR_PROJECT_ID/$_AR_REPOSITORY/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA"
+tags:
+  - gcp-cloud-build-deploy-cloud-run
+  - gcp-cloud-build-deploy-cloud-run-managed
+  - mcp-dev

--- a/services/mcp/cloudbuild.yaml
+++ b/services/mcp/cloudbuild.yaml
@@ -23,7 +23,7 @@ steps:
       - services
       - update
       - $_SERVICE_NAME
-      - "--platform=managed"
+      - "--platform=$_PLATFORM"
       - "--image=$_IMAGE_URI"
       - "--labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID"
       - "--region=$_DEPLOY_REGION"

--- a/services/reviewhelper-api/cloudbuild.yaml
+++ b/services/reviewhelper-api/cloudbuild.yaml
@@ -1,0 +1,49 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    env:
+      - DOCKER_BUILDKIT=1
+    args:
+      - build
+      - "--no-cache"
+      - "-t"
+      - "$_IMAGE_URI"
+      - .
+      - "-f"
+      - services/reviewhelper-api/Dockerfile
+    id: Build
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - "$_IMAGE_URI"
+    id: Push
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    entrypoint: gcloud
+    args:
+      - run
+      - services
+      - update
+      - $_SERVICE_NAME
+      - "--platform=managed"
+      - "--image=$_IMAGE_URI"
+      - "--labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID"
+      - "--region=$_DEPLOY_REGION"
+      - "--quiet"
+    id: Deploy
+images:
+  - "$_IMAGE_URI"
+options:
+  substitutionOption: ALLOW_LOOSE
+  dynamicSubstitutions: true
+  logging: CLOUD_LOGGING_ONLY
+substitutions:
+  _DEPLOY_REGION: us-central1
+  _AR_HOSTNAME: us-central1-docker.pkg.dev
+  _AR_REPOSITORY: cloud-run-source-deploy
+  _AR_PROJECT_ID: moz-bugbug
+  _PLATFORM: managed
+  _SERVICE_NAME: reviewhelper-api-dev
+  _IMAGE_URI: "$_AR_HOSTNAME/$_AR_PROJECT_ID/$_AR_REPOSITORY/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA"
+tags:
+  - gcp-cloud-build-deploy-cloud-run
+  - gcp-cloud-build-deploy-cloud-run-managed
+  - reviewhelper-api-dev

--- a/services/reviewhelper-api/cloudbuild.yaml
+++ b/services/reviewhelper-api/cloudbuild.yaml
@@ -23,7 +23,7 @@ steps:
       - services
       - update
       - $_SERVICE_NAME
-      - "--platform=managed"
+      - "--platform=$_PLATFORM"
       - "--image=$_IMAGE_URI"
       - "--labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID"
       - "--region=$_DEPLOY_REGION"


### PR DESCRIPTION
These configurations are currently inlined in GCP.  Moving them here will improve the tracking.