### PR TITLE
Increase recursion limit to 100 and stop retrying on GraphRecursionError

### DIFF
--- a/bugbug/tools/code_review/agent.py
+++ b/bugbug/tools/code_review/agent.py
@@ -49,7 +49,10 @@ from bugbug.tools.code_review.utils import (
     convert_generated_comments_to_inline,
     format_patch_set,
 )
-from bugbug.tools.core.exceptions import LargeDiffError, ModelResultError
+from bugbug.tools.core.exceptions import (
+    LargeDiffError,
+    RecursionLimitError,
+)
 from bugbug.tools.core.llms import DEFAULT_ANTHROPIC_MODEL, get_tokenizer
 from bugbug.tools.core.platforms.base import Patch
 
@@ -235,11 +238,11 @@ class CodeReviewTool(GenerativeModelTool):
                 },
                 context=CodeReviewContext(patch=patch),
                 stream_mode="values",
-                config={"recursion_limit": 50},
+                config={"recursion_limit": 100},
             ):
                 result = chunk
         except GraphRecursionError as e:
-            raise ModelResultError("The model could not complete the review") from e
+            raise RecursionLimitError("The model could not complete the review") from e
 
         return result["structured_response"].comments, manifest
 

--- a/bugbug/tools/core/exceptions.py
+++ b/bugbug/tools/core/exceptions.py
@@ -27,5 +27,9 @@ class RunawayGenerationError(ModelResultError):
     """
 
 
+class RecursionLimitError(ModelResultError):
+    """Occurs when the agent exceeds the maximum number of recursive steps."""
+
+
 class LargeDiffError(Exception):
     """Occurs when the diff is too large to be processed."""

--- a/services/reviewhelper-api/app/review_processor.py
+++ b/services/reviewhelper-api/app/review_processor.py
@@ -7,7 +7,7 @@ from typing import Collection, Iterable
 from app.config import settings
 from app.database.models import GeneratedComment, ReviewRequest
 from app.enums import Platform
-from bugbug.tools.core.exceptions import LargeDiffError
+from bugbug.tools.core.exceptions import LargeDiffError, RecursionLimitError
 from bugbug.tools.core.platforms.phabricator import (
     PhabricatorPatch,
     get_phabricator_client,
@@ -80,6 +80,10 @@ async def process_review(
     except LargeDiffError as e:
         raise ReviewProcessingError(
             "The diff size exceeds the current processing limits."
+        ) from e
+    except RecursionLimitError as e:
+        raise ReviewProcessingError(
+            "Review Helper could not complete the review within the steps limit."
         ) from e
 
     generated_comments = [

--- a/services/reviewhelper-api/app/review_processor.py
+++ b/services/reviewhelper-api/app/review_processor.py
@@ -83,7 +83,7 @@ async def process_review(
         ) from e
     except RecursionLimitError as e:
         raise ReviewProcessingError(
-            "Review Helper could not complete the review within the steps limit."
+            "Review Helper could not complete the review within the configured agent step limit."
         ) from e
 
     generated_comments = [


### PR DESCRIPTION
Adds RecursionLimitError to core exceptions, raised by the agent when GraphRecursionError is hit, and caught in the API as ReviewProcessingError to prevent retries.