### PR TITLE
Fetch latest 50 runs from API in hackbot-ui Recent Runs panel

### DIFF
--- a/services/hackbot-api/app/routers/runs.py
+++ b/services/hackbot-api/app/routers/runs.py
@@ -2,7 +2,8 @@ import json
 import logging
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import gcs, jobs
@@ -101,6 +102,15 @@ async def create_run(
     await db.commit()
 
     return RunRef.model_validate(run)
+
+
+@router.get("/runs", response_model=list[RunDoc])
+async def list_runs(
+    limit: int = Query(default=50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> list[RunDoc]:
+    result = await db.execute(select(Run).order_by(Run.created_at.desc()).limit(limit))
+    return [RunDoc.model_validate(r) for r in result.scalars()]
 
 
 @router.get("/runs/{run_id}", response_model=RunDoc)

--- a/services/hackbot-ui/app/api/runs/route.ts
+++ b/services/hackbot-ui/app/api/runs/route.ts
@@ -1,9 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { createRun, HackbotError } from "@/lib/hackbot";
+import { createRun, listRuns, HackbotError } from "@/lib/hackbot";
 import { getAuthedEmail } from "@/lib/session";
 
 export const dynamic = "force-dynamic";
+
+// GET /api/runs?limit=50
+// Returns the most recent runs from hackbot-api (no reconciliation).
+export async function GET(req: NextRequest) {
+  if (!(await getAuthedEmail())) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  try {
+    const { searchParams } = new URL(req.url);
+    const raw = Number(searchParams.get("limit") ?? 50);
+    const limit = Number.isFinite(raw) && raw > 0 ? raw : 50;
+    const runs = await listRuns(limit);
+    return NextResponse.json(runs);
+  } catch (err) {
+    const status = err instanceof HackbotError ? err.status : 500;
+    return NextResponse.json({ error: (err as Error).message }, { status });
+  }
+}
 
 // POST /api/runs  { agent: string, inputs: object }
 // Triggers a new agent run via hackbot-api.

--- a/services/hackbot-ui/components/RecentRuns.tsx
+++ b/services/hackbot-ui/components/RecentRuns.tsx
@@ -10,11 +10,46 @@ import { StatusBadge } from "./StatusBadge";
 // Polls the status of any non-terminal tracked runs so the dashboard stays live.
 const POLL_MS = 5000;
 
+function labelFromInputs(inputs: Record<string, unknown>): string {
+  if (typeof inputs.bug_id === "number") return `bug ${inputs.bug_id}`;
+  return "inline report";
+}
+
+async function fetchRuns(): Promise<TrackedRun[]> {
+  const res = await fetch("/api/runs?limit=50");
+  if (!res.ok) return [];
+  const docs = (await res.json()) as Array<{
+    run_id: string;
+    agent: string;
+    status: TrackedRun["status"];
+    inputs: Record<string, unknown>;
+    created_at: string;
+  }>;
+  return docs.map((d) => ({
+    run_id: d.run_id,
+    agent: d.agent,
+    status: d.status,
+    label: labelFromInputs(d.inputs),
+    created_at: d.created_at,
+  }));
+}
+
+function mergeRuns(
+  apiRuns: TrackedRun[],
+  localRuns: TrackedRun[]
+): TrackedRun[] {
+  const seen = new Set(apiRuns.map((r) => r.run_id));
+  const extras = localRuns.filter((r) => !seen.has(r.run_id));
+  return [...extras, ...apiRuns];
+}
+
 export function RecentRuns() {
   const [runs, setRuns] = useState<TrackedRun[] | null>(null);
 
   useEffect(() => {
-    setRuns(loadRuns());
+    fetchRuns().then((apiRuns) => {
+      setRuns(mergeRuns(apiRuns, loadRuns()));
+    });
   }, []);
 
   useEffect(() => {
@@ -37,7 +72,11 @@ export function RecentRuns() {
           // transient; try again next tick
         }
       }
-      if (changed) setRuns(loadRuns());
+      if (changed) {
+        fetchRuns().then((apiRuns) => {
+          setRuns(mergeRuns(apiRuns, loadRuns()));
+        });
+      }
     }, POLL_MS);
 
     return () => clearInterval(timer);
@@ -50,7 +89,7 @@ export function RecentRuns() {
   if (runs.length === 0) {
     return (
       <p className="muted">
-        No runs yet. Trigger the bug-fix agent above to get started.
+        No runs yet. Use the form above to trigger an agent.
       </p>
     );
   }

--- a/services/hackbot-ui/lib/hackbot.ts
+++ b/services/hackbot-ui/lib/hackbot.ts
@@ -87,6 +87,10 @@ export function getRun(runId: string): Promise<RunDoc> {
   return request<RunDoc>(`/runs/${encodeURIComponent(runId)}`);
 }
 
+export function listRuns(limit = 50): Promise<RunDoc[]> {
+  return request<RunDoc[]>(`/runs?limit=${limit}`);
+}
+
 // Ask hackbot-api for a short-lived signed download URL for one artifact.
 // `artifactName` may contain slashes; each segment is encoded individually so
 // the upstream `{artifact_path:path}` route still sees the directory structure.


### PR DESCRIPTION
Add GET /runs to hackbot-api (plain DB read, newest-first, limit 1-100). Wire it through the UI and merges with localStorage (localStorage fills in any run triggered after the fetch but before render).