### PR TITLE
Expose reviewer groups and project membership on PhabricatorPatch

### DIFF
--- a/bugbug/tools/core/platforms/phabricator.py
+++ b/bugbug/tools/core/platforms/phabricator.py
@@ -69,6 +69,46 @@ def get_phabricator_client(
     return PhabricatorAPI(api_key, api_url)
 
 
+@cache
+def resolve_project_phid(slug: str) -> Optional[str]:
+    """Resolve a Phabricator project slug to its PHID.
+
+    Returns None if no project matches the slug. Cached for the process
+    lifetime since project PHIDs are stable; a cold start re-resolves.
+    """
+    phabricator = get_phabricator_client()
+    response = phabricator.request(
+        "project.search",
+        constraints={"slugs": [slug]},
+    )
+    data = response.get("data") or []
+    if not data:
+        return None
+    return data[0]["phid"]
+
+
+@cache
+def get_project_members(project_phid: str) -> frozenset[str]:
+    """Return the set of user PHIDs that are members of a Phabricator project.
+
+    Cached for the process lifetime; a process restart re-fetches and picks up
+    membership changes.
+    """
+    phabricator = get_phabricator_client()
+    response = phabricator.request(
+        "project.search",
+        constraints={"phids": [project_phid]},
+        attachments={"members": True},
+    )
+    data = response.get("data") or []
+    if not data:
+        return frozenset()
+    members_data = data[0].get("attachments", {}).get("members", {})
+    return frozenset(
+        m["phid"] for m in members_data.get("members", []) if m.get("phid")
+    )
+
+
 def _get_users_info_batch_impl(user_phids: set[str]) -> dict[str, dict]:
     """Internal implementation for fetching user information.
 
@@ -87,27 +127,14 @@ def _get_users_info_batch_impl(user_phids: set[str]) -> dict[str, dict]:
         constraints={"phids": list(user_phids)},
     )
 
-    # Get bmo-editbugs-team members
-    moco_response = phabricator.request(
-        "project.search",
-        constraints={"phids": [EDITBUGS_GROUP_PHID]},
-        attachments={"members": True},
-    )
-
-    # Turn it into a set for speed, and perform membership check to determine
-    # trusted status.
-    moco_members = set()
-    if moco_response.get("data"):
-        members_data = (
-            moco_response["data"][0].get("attachments", {}).get("members", {})
-        )
-        moco_members = {m["phid"] for m in members_data.get("members", [])}
+    # Determine trusted status via bmo-editbugs-team membership.
+    trusted_members = get_project_members(EDITBUGS_GROUP_PHID)
 
     result = {}
     for user_data in users_response.get("data", []):
         user_phid = user_data["phid"]
         fields = user_data.get("fields", {})
-        is_trusted = user_phid in moco_members
+        is_trusted = user_phid in trusted_members
         is_trusted_bot = user_phid in TRUSTED_BOT_PHIDS
 
         result[user_phid] = {
@@ -532,6 +559,34 @@ class PhabricatorPatch(Patch):
     @property
     def author_phid(self) -> str:
         return self._revision_metadata["fields"]["authorPHID"]
+
+    @cached_property
+    def reviewer_phids(self) -> list[str]:
+        """PHIDs of the revision's reviewers (a mix of users and projects).
+
+        The reviewers attachment is not part of the default revision metadata,
+        so we fetch it with a dedicated ``differential.revision.search`` call.
+        """
+        phabricator = get_phabricator_client()
+        response = phabricator.request(
+            "differential.revision.search",
+            constraints={"phids": [self.revision_phid]},
+            attachments={"reviewers": True},
+        )
+        data = response.get("data") or []
+        if not data:
+            return []
+        reviewers = data[0].get("attachments", {}).get("reviewers", {})
+        return [
+            r["reviewerPHID"]
+            for r in reviewers.get("reviewers", [])
+            if r.get("reviewerPHID")
+        ]
+
+    @property
+    def reviewer_project_phids(self) -> list[str]:
+        """PHIDs of the revision's reviewer *groups* (Phabricator projects)."""
+        return [phid for phid in self.reviewer_phids if phid.startswith("PHID-PROJ-")]
 
     @property
     def diff_author_phid(self) -> str:

--- a/bugbug/tools/core/platforms/phabricator.py
+++ b/bugbug/tools/core/platforms/phabricator.py
@@ -588,6 +588,51 @@ class PhabricatorPatch(Patch):
         """PHIDs of the revision's reviewer *groups* (Phabricator projects)."""
         return [phid for phid in self.reviewer_phids if phid.startswith("PHID-PROJ-")]
 
+    @cached_property
+    def historical_reviewer_project_phids(self) -> list[str]:
+        """Reviewer-group PHIDs that were *ever* added as reviewers.
+
+        A review rotation adds a group as a reviewer, assigns an individual
+        member, then removes the group — so by review time the group is no
+        longer in the current reviewer list. Scanning the ``reviewers``
+        transactions recovers any group that was added at any point, which is
+        what reviewer-group targeting should key on.
+
+        Groups still present are included first (order-preserving); groups that
+        were added and later removed follow, deduplicated.
+        """
+        phids: list[str] = []
+        seen: set[str] = set()
+
+        def _add(phid: str) -> None:
+            if phid.startswith("PHID-PROJ-") and phid not in seen:
+                seen.add(phid)
+                phids.append(phid)
+
+        for phid in self.reviewer_project_phids:
+            _add(phid)
+
+        try:
+            transactions = self._get_transactions()
+        except Exception:
+            logger.exception(
+                "Could not fetch transactions for D%s; using current reviewers only",
+                self.revision_id,
+            )
+            return phids
+
+        for transaction in transactions:
+            if transaction.get("type") != "reviewers":
+                continue
+            operations = (transaction.get("fields") or {}).get("operations") or []
+            for operation in operations:
+                # 'add' and 'update' both indicate the reviewer was present at
+                # some point; 'remove' alone never introduces a new group.
+                if operation.get("operation") in ("add", "update"):
+                    _add(operation.get("phid") or "")
+
+        return phids
+
     @property
     def diff_author_phid(self) -> str:
         return self._diff_metadata["authorPHID"]

--- a/tests/test_phabricator.py
+++ b/tests/test_phabricator.py
@@ -322,3 +322,130 @@ def test_get_project_members_empty(monkeypatch) -> None:
     )
     assert phab_platform.get_project_members("PHID-PROJ-missing") == frozenset()
     phab_platform.get_project_members.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Rotation recovery: historical_reviewer_project_phids
+# ---------------------------------------------------------------------------
+
+
+def _patch_with(current_reviewers, transactions):
+    """A PhabricatorPatch whose current reviewers and transaction log are fixed."""
+
+    class FakePatch(phab_platform.PhabricatorPatch):
+        def __init__(self):
+            pass
+
+        @property
+        def revision_id(self):
+            return 308166
+
+        @property
+        def reviewer_phids(self):
+            return current_reviewers
+
+        def _get_transactions(self):
+            return transactions
+
+    return FakePatch()
+
+
+# The exact reviewer event sequence from D308166: Herald adds the rotation group
+# as a blocking reviewer, then phab-bot adds an individual and removes the group.
+_D308166_TRANSACTIONS = [
+    {
+        "type": "reviewers",
+        "fields": {
+            "operations": [
+                {
+                    "operation": "add",
+                    "phid": "PHID-PROJ-newtabrotation",
+                    "isBlocking": True,
+                }
+            ]
+        },
+    },
+    {
+        "type": "reviewers",
+        "fields": {
+            "operations": [
+                {"operation": "add", "phid": "PHID-USER-thecount"},
+                {"operation": "remove", "phid": "PHID-PROJ-newtabrotation"},
+            ]
+        },
+    },
+    # The group is re-added as a *subscriber*, which must be ignored.
+    {
+        "type": "subscribers",
+        "fields": {
+            "operations": [{"operation": "add", "phid": "PHID-PROJ-newtabrotation"}]
+        },
+    },
+]
+
+
+def test_historical_recovers_rotation_group_removed_after_assignment() -> None:
+    # By review time only the individual remains a reviewer.
+    patch = _patch_with(["PHID-USER-thecount"], _D308166_TRANSACTIONS)
+    assert patch.reviewer_project_phids == []
+    assert patch.historical_reviewer_project_phids == ["PHID-PROJ-newtabrotation"]
+
+
+def test_historical_includes_current_groups_first() -> None:
+    patch = _patch_with(
+        ["PHID-PROJ-current", "PHID-USER-x"],
+        [
+            {
+                "type": "reviewers",
+                "fields": {
+                    "operations": [
+                        {"operation": "add", "phid": "PHID-PROJ-older"},
+                    ]
+                },
+            }
+        ],
+    )
+    # Current group first, then the historically-added one, deduped.
+    assert patch.historical_reviewer_project_phids == [
+        "PHID-PROJ-current",
+        "PHID-PROJ-older",
+    ]
+
+
+def test_historical_ignores_users_and_remove_only() -> None:
+    patch = _patch_with(
+        [],
+        [
+            {
+                "type": "reviewers",
+                "fields": {
+                    "operations": [
+                        {"operation": "add", "phid": "PHID-USER-someone"},
+                        {"operation": "remove", "phid": "PHID-PROJ-neveradded"},
+                    ]
+                },
+            }
+        ],
+    )
+    assert patch.historical_reviewer_project_phids == []
+
+
+def test_historical_falls_back_on_transaction_error() -> None:
+    class FakePatch(phab_platform.PhabricatorPatch):
+        def __init__(self):
+            pass
+
+        @property
+        def revision_id(self):
+            return 1
+
+        @property
+        def reviewer_phids(self):
+            return ["PHID-PROJ-current"]
+
+        def _get_transactions(self):
+            raise RuntimeError("conduit down")
+
+    patch = FakePatch()
+    # Degrades to the current snapshot rather than raising.
+    assert patch.historical_reviewer_project_phids == ["PHID-PROJ-current"]

--- a/tests/test_phabricator.py
+++ b/tests/test_phabricator.py
@@ -4,8 +4,10 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from datetime import timedelta
+from unittest.mock import MagicMock
 
 from bugbug import phabricator
+from bugbug.tools.core.platforms import phabricator as phab_platform
 
 
 def test_get_first_review_time() -> None:
@@ -204,3 +206,119 @@ def test_get_first_review_time() -> None:
     assert phabricator.get_first_review_time(
         phabricator.RevisionDict({"id": 1, "transactions": transactions})
     ) == timedelta(days=11)
+
+
+# ---------------------------------------------------------------------------
+# Reviewer groups + project membership
+# ---------------------------------------------------------------------------
+
+
+def _fake_client(responses: dict) -> MagicMock:
+    """Build a fake client whose .request(method, ...) returns a canned response."""
+    client = MagicMock()
+    client.request.side_effect = lambda method, **kwargs: responses[method]
+    return client
+
+
+def test_reviewer_phids_and_project_phids(monkeypatch) -> None:
+    response = {
+        "differential.revision.search": {
+            "data": [
+                {
+                    "attachments": {
+                        "reviewers": {
+                            "reviewers": [
+                                {"reviewerPHID": "PHID-USER-alice"},
+                                {"reviewerPHID": "PHID-PROJ-ipprotection"},
+                                {"reviewerPHID": "PHID-PROJ-homenewtab"},
+                                {"reviewerPHID": None},
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+    }
+    monkeypatch.setattr(
+        phab_platform, "get_phabricator_client", lambda: _fake_client(response)
+    )
+
+    class FakePatch(phab_platform.PhabricatorPatch):
+        def __init__(self):
+            pass
+
+        @property
+        def revision_phid(self):
+            return "PHID-DREV-test"
+
+    patch = FakePatch()
+    assert patch.reviewer_phids == [
+        "PHID-USER-alice",
+        "PHID-PROJ-ipprotection",
+        "PHID-PROJ-homenewtab",
+    ]
+    assert patch.reviewer_project_phids == [
+        "PHID-PROJ-ipprotection",
+        "PHID-PROJ-homenewtab",
+    ]
+
+
+def test_resolve_project_phid(monkeypatch) -> None:
+    phab_platform.resolve_project_phid.cache_clear()
+    response = {"project.search": {"data": [{"phid": "PHID-PROJ-ipprotection"}]}}
+    monkeypatch.setattr(
+        phab_platform, "get_phabricator_client", lambda: _fake_client(response)
+    )
+    assert (
+        phab_platform.resolve_project_phid("ip-protection-reviewers")
+        == "PHID-PROJ-ipprotection"
+    )
+    phab_platform.resolve_project_phid.cache_clear()
+
+
+def test_resolve_project_phid_not_found(monkeypatch) -> None:
+    phab_platform.resolve_project_phid.cache_clear()
+    monkeypatch.setattr(
+        phab_platform,
+        "get_phabricator_client",
+        lambda: _fake_client({"project.search": {"data": []}}),
+    )
+    assert phab_platform.resolve_project_phid("does-not-exist") is None
+    phab_platform.resolve_project_phid.cache_clear()
+
+
+def test_get_project_members(monkeypatch) -> None:
+    phab_platform.get_project_members.cache_clear()
+    response = {
+        "project.search": {
+            "data": [
+                {
+                    "attachments": {
+                        "members": {
+                            "members": [
+                                {"phid": "PHID-USER-alice"},
+                                {"phid": "PHID-USER-bob"},
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+    }
+    monkeypatch.setattr(
+        phab_platform, "get_phabricator_client", lambda: _fake_client(response)
+    )
+    members = phab_platform.get_project_members("PHID-PROJ-ipprotection")
+    assert members == frozenset({"PHID-USER-alice", "PHID-USER-bob"})
+    phab_platform.get_project_members.cache_clear()
+
+
+def test_get_project_members_empty(monkeypatch) -> None:
+    phab_platform.get_project_members.cache_clear()
+    monkeypatch.setattr(
+        phab_platform,
+        "get_phabricator_client",
+        lambda: _fake_client({"project.search": {"data": []}}),
+    )
+    assert phab_platform.get_project_members("PHID-PROJ-missing") == frozenset()
+    phab_platform.get_project_members.cache_clear()


### PR DESCRIPTION
Shared plumbing that reviewer-group-targeted code review builds on. No behavior change on its own — it only adds data and helpers later PRs consume.

 - `PhabricatorPatch.reviewer_phids` / `reviewer_project_phids`: the revision's reviewers and the reviewer-*group* (PHID-PROJ-*) subset, fetched via `differential.revision.search` with the reviewers attachment.
   - `PhabricatorPatch.historical_reviewer_project_phids`: scans `reviewers` transactions to recover every group ever added — needed because a review rotation adds a group, swaps in an individual, then removes the group, so the group is gone from the point-in-time reviewer list by review time (verified on D308166). Degrades to the current snapshot if the transaction fetch fails.
   - Module-level `resolve_project_phid(slug)` and `get_project_members(phid)`, generalizing the existing MOCO-membership lookup (now reuses `get_project_members`). Both are process-lifetime cached.