### PR TITLE
Add frontend-triage agent for Hackbot

### DIFF
--- a/agents/frontend-triage/Dockerfile
+++ b/agents/frontend-triage/Dockerfile
@@ -1,0 +1,51 @@
+FROM python:3.12 AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+ENV UV_PROJECT_ENVIRONMENT=/opt/venv
+
+WORKDIR /app
+
+# Install external deps without building workspace members.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=VERSION,target=VERSION \
+    uv sync --frozen --no-dev --no-install-workspace --package hackbot-agent-frontend-triage
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,target=/app,rw \
+    uv sync --locked --no-dev --no-editable --package hackbot-agent-frontend-triage
+
+FROM python:3.12 AS base
+
+COPY --from=builder /opt/venv /opt/venv
+WORKDIR /app
+
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PATH="/opt/venv/bin:$PATH"
+
+FROM base AS agent
+
+# hackbot.toml lives at the agent root (not inside the package), so copy it into
+# the working dir; the runtime discovers it there (cwd) at startup.
+COPY agents/frontend-triage/hackbot.toml /app/hackbot.toml
+
+RUN useradd --create-home --shell /bin/bash agent \
+    && mkdir -p /workspace \
+    && chown agent:agent /workspace
+
+USER agent
+
+CMD ["python", "-m", "hackbot_agents.frontend_triage"]
+
+FROM base AS broker
+
+RUN useradd --create-home --shell /bin/bash broker
+
+USER broker
+
+EXPOSE 8765
+
+CMD ["python", "-m", "hackbot_agents.frontend_triage.broker"]

--- a/agents/frontend-triage/README.md
+++ b/agents/frontend-triage/README.md
@@ -1,0 +1,260 @@
+# frontend-triage agent
+
+A Hackbot agent that **triages Firefox desktop frontend bugs** from Bugzilla and
+produces a **root-cause analysis + a proposed fix plan**. It investigates the
+Firefox source tree read-only and writes its findings to disk; it does **not**
+build Firefox, modify source, reproduce the bug, or write anything to Bugzilla.
+
+Think of it as an experienced engineer doing first-pass triage on a UI/UX
+papercut: it reads the bug, finds the responsible code, explains the likely
+cause, and proposes how to fix it — then hands that off to a human (or a
+downstream execution agent) to actually implement and verify.
+
+It is a sibling of the reference [`bug-fix`](../bug-fix/) agent, which targets
+*crash/sanitizer* bugs and goes all the way to a verified patch. `frontend-triage`
+deliberately stops at a plan, because visual/interaction bugs can't be verified
+by the crash-reproduction loop `bug-fix` relies on.
+
+---
+
+## What it's for
+
+Good fits — Firefox desktop **frontend** defects, typically documented with a
+video/screenshot and steps to reproduce, not a crash:
+
+- `Firefox :: Tabbed Browser` / `Tabbed Browser: Split View`
+- `Firefox :: New Tab Page`
+- `Firefox :: Address Bar`, `Menus`, `Toolbars and Customization`, `Sidebar`, `Theme`
+
+Poor fits (use a different agent / manual triage):
+
+- Crashes, hangs, assertions, sanitizer reports → these belong to [`bug-fix`](../bug-fix/).
+- Backend/platform bugs with no frontend component.
+- Bugs whose fix can only be judged by *seeing* the rendered result — the agent
+  can localize and propose, but cannot visually confirm.
+
+---
+
+## What it produces
+
+For each run, in `~/hackbot/artifacts/<run_id>/`:
+
+- **`summary.json`** — the machine-readable result:
+  - `findings` → the structured plan: `summary`, `root_cause`, `proposed_fix`,
+    `target_files`, `confidence` (`high|medium|low`), plus `num_turns` and
+    `total_cost_usd`.
+  - `actions` → a single **recorded** `bugzilla.add_comment` (the human-readable
+    triage comment). "Recorded" means written to this file for review — **it is
+    not posted to Bugzilla.**
+- **Logs** of the agent's streamed reasoning.
+
+It never produces a `changes/` directory (that would mean source edits) — its
+absence is your confirmation the run stayed read-only.
+
+---
+
+## Safety guarantees (and why they hold)
+
+Nothing this agent does can write to Bugzilla or modify the source tree. This is
+enforced structurally, not just by prompt instructions:
+
+1. **No Bugzilla write tool exists.** The agent reaches Bugzilla only through the
+   broker sidecar, which exposes exactly five **read** tools (`search_bugs`,
+   `get_bugs`, `get_bug_comments`, `get_bug_attachments`, `download_attachment`
+   — see `agent_tools/bugzilla.py`). There is no update/comment/create tool in
+   the Bugzilla toolset at all. The Bugzilla API key lives only in the broker and
+   is used solely for reads.
+2. **"Actions" only record to disk.** The `bugzilla_add_comment` / `bugzilla_update_bug`
+   tools come from a separate in-process server and merely append to a list that
+   is serialized into `summary.json` (`ActionsRecorder.record`). They make no
+   network calls. Applying them to Bugzilla is a separate downstream step that is
+   **not** part of local runs.
+3. **No write/build tools are granted.** `agent.py` builds `allowed_tools` from
+   read-only inspection tools (`Read`, `Grep`, `Glob`, `Bash`, `Task`) + the
+   Bugzilla read tools + the record-only action tools. There are no `Write`/`Edit`
+   tools and no Firefox build/eval tools.
+
+`config.py` further restricts recordable actions to `bugzilla.add_comment` and
+`bugzilla.update_bug` (no attachments, no bug creation), and the system prompt
+forbids private comments and `RESOLVED` status changes.
+
+---
+
+## How it works
+
+```
+                         ┌─────────────────────────────┐
+   Bugzilla (read-only)  │  frontend-triage-broker      │
+   bugzilla.mozilla.org ─┤  (sidecar; holds API key)    │
+                         │  exposes 5 read tools (MCP)  │
+                         └──────────────┬──────────────┘
+                                        │ MCP over HTTP (read-only)
+                                        ▼
+   git clone (shallow)   ┌─────────────────────────────┐
+   mozilla-firefox/      │  frontend-triage-agent       │
+   firefox  ───────────► │                              │
+   (workspace volume)    │  Claude Agent SDK loop:      │
+                         │   - read bug + comments      │
+                         │   - read relevant rules/     │
+                         │   - investigate source       │
+                         │     (Read/Grep/Glob/Bash,    │
+                         │      + investigator subagent)│
+                         │   - record comment + plan    │
+                         └──────────────┬──────────────┘
+                                        │ records (no network write)
+                                        ▼
+                            ~/hackbot/artifacts/<run_id>/summary.json
+```
+
+**The run, step by step:**
+
+1. **Startup (runtime).** `hackbot-runtime` reads `hackbot.toml`, shallow-clones
+   the Firefox repo into the `workspace` volume (slow on first run, cached after),
+   and builds a `HackbotContext`. There is **no** `[firefox]` table, so no build
+   toolchain is prepared.
+2. **Entrypoint.** `__main__.py` reads the per-run inputs (env vars), sets a
+   read-only triage `task`, and calls `run_frontend_triage(...)`.
+3. **Agent loop.** `agent.py` wires up the Claude Agent SDK with the read-only
+   tools, the rules directory, and the action-recording server, then drives the
+   loop: fetch the bug → load the relevant ruleset(s) from `rules/` → investigate
+   the source (delegating deep searches to a read-only `investigator` subagent) →
+   record one comment with the fix plan.
+4. **Structured output.** The agent ends its final message with a fenced ```json
+   block. `agent.py` parses that into the typed `FrontendTriageResult`
+   (`root_cause`, `proposed_fix`, `target_files`, `confidence`), which the runtime
+   writes to `summary.json` under `findings`. If the block is missing/unparseable,
+   the structured fields are left null and the raw text is preserved in `result`.
+
+**Confidence semantics:** confidence reflects how clearly the agent could pin a
+**root cause** in the code, not whether the fix is verified (it never runs the
+result). Treat `high` as "trust the diagnosis, still review/verify the patch."
+
+### File layout
+
+```
+agents/frontend-triage/
+  pyproject.toml          # distribution "hackbot-agent-frontend-triage"
+  hackbot.toml            # [source] = mozilla-firefox/firefox; NO [firefox] table
+  Dockerfile              # builds the agent + broker images
+  compose.yml             # frontend-triage-{broker,agent} services for local runs
+  hackbot_agents/
+    frontend_triage/
+      __main__.py         # inputs + read-only triage task + entrypoint
+      agent.py            # the agent loop, FrontendTriageResult, plan parser
+      config.py           # tool/action allow-lists (read-only; no firefox)
+      broker.py           # Bugzilla read-only MCP broker (sidecar)
+      prompts/system.md   # system prompt: triage + fix-plan, no build/repro
+      rules/
+        README.md         # how to author rulesets
+        frontend-triage.md  # the frontend-papercut ruleset
+```
+
+### Configuration (per-run inputs)
+
+Set as environment variables (the API derives these automatically from the input
+schema; locally you pass them via `.env` / the command line):
+
+| Env var | Required | Meaning |
+|---|---|---|
+| `BUG_ID` | yes | The Bugzilla bug to triage |
+| `ANTHROPIC_API_KEY` | yes | Drives the Claude agent (billed per token) |
+| `BUGZILLA_API_URL` | yes | Bugzilla instance, e.g. `https://bugzilla.mozilla.org` |
+| `BUGZILLA_API_KEY` | yes | Held by the broker; used for **reads only** |
+| `MODEL` | no | Override the agent model (cost/quality dial) |
+| `MAX_TURNS` | no | Hard cap on agent loop iterations (runaway/cost guard; cut off if exceeded) |
+| `EFFORT` | no | Reasoning effort level |
+
+A **turn** is one iteration of the agent loop (model thinks → calls tools →
+observes results). It is not a number of fix attempts; more turns just means more
+investigation. Turns roughly track cost. `MAX_TURNS` cuts the loop off if hit.
+
+---
+
+## How to test it locally
+
+You run it with Docker Compose from the **repo root**. No cloud, no uploader —
+everything stays on your machine.
+
+**Prerequisites**
+
+- Docker Desktop running.
+- An Anthropic API key with API billing enabled.
+- A Bugzilla API key (used only for reads; you can use one from an account
+  without edit rights for extra safety).
+
+**1. Create the repo-root `.env`** (gitignored — never committed):
+
+```dotenv
+ANTHROPIC_API_KEY=sk-ant-...
+BUGZILLA_API_URL=https://bugzilla.mozilla.org
+BUGZILLA_API_KEY=...
+```
+
+**2. Run against a bug** (from `/path/to/bugbug`, the repo root):
+
+```sh
+BUG_ID=2014702 docker compose up frontend-triage-agent --build
+```
+
+The root `docker-compose.yml` includes this agent's `compose.yml`, so the
+`frontend-triage-agent` service (and its `frontend-triage-broker` sidecar) are
+available. The first run shallow-clones the Firefox repo into a Docker volume —
+expect several minutes and a large download. Subsequent runs reuse the volume and
+start quickly.
+
+**3. Read the result:**
+
+```sh
+LATEST=$(ls -t ~/hackbot/artifacts | head -1)
+cat ~/hackbot/artifacts/$LATEST/summary.json
+```
+
+Check:
+- `findings` → the structured plan (`root_cause`, `proposed_fix`, `target_files`,
+  `confidence`).
+- `actions` → exactly one `bugzilla.add_comment`, recorded (not posted). It carries
+  an `*This is an automated analysis result...*` footer.
+- **No `changes/` directory** and no build step — confirms the run stayed read-only.
+
+**Good bugs to test** (validated across the three classes this agent handles):
+
+| Bug | Class | Notes |
+|---|---|---|
+| `2014702` | Behavioral | New Tab weather widget vanishing |
+| `2014629` | Pure visual | Split View group-line CSS gap |
+| `2004297` | Regression | Print Preview shift; traces the named regressor |
+
+**A note on line numbers:** the agent cites approximate line numbers
+(e.g. `~L1234`). Those are model-asserted and can drift — trust the files and
+functions/selectors it names, and confirm exact lines against the source before
+acting.
+
+---
+
+## Tuning
+
+- **Rules** (`rules/frontend-triage.md`): the main behavior dial. Adjust which
+  components are in scope, what the comment should contain, comment brevity, and
+  the confidence thresholds for taking actions. The agent Globs `rules/` and reads
+  only the rulesets it judges relevant, so you can add more `.md` files for other
+  scopes.
+- **System prompt** (`prompts/system.md`): the standing instructions — output
+  format, the read-only mandate, the structured-JSON requirement.
+- **Cost ceiling**: set `MAX_TURNS` and/or a cheaper `MODEL` per run to bound cost
+  when batching.
+
+## Handoff to implementation
+
+The structured plan in `summary.json` `findings` is designed to be consumed
+downstream. To turn a plan into a candidate patch, feed it (e.g. via the `task` /
+extra-instructions override) into an agent that has source-write tools — either
+the existing [`bug-fix`](../bug-fix/) agent or a dedicated execution agent — which
+emits a `git am`-applyable patch. A human reviews and visually verifies the diff,
+since frontend fixes can't be auto-verified.
+
+## Registration
+
+This agent is registered with `hackbot-api` for orchestrated runs:
+`FrontendTriageInputs` in `services/hackbot-api/app/schemas.py` and the
+`frontend-triage` entry in `services/hackbot-api/app/agents.py` (job
+`hackbot-agent-frontend-triage`). Local Compose runs do not require the API.

--- a/agents/frontend-triage/README.md
+++ b/agents/frontend-triage/README.md
@@ -13,7 +13,7 @@ cause, and proposes how to fix it — then hands that off to a human (or a
 downstream execution agent) to actually implement and verify.
 
 It is a sibling of the reference [`bug-fix`](../bug-fix/) agent, which targets
-*crash/sanitizer* bugs and goes all the way to a verified patch. `frontend-triage`
+_crash/sanitizer_ bugs and goes all the way to a verified patch. `frontend-triage`
 deliberately stops at a plan, because visual/interaction bugs can't be verified
 by the crash-reproduction loop `bug-fix` relies on.
 
@@ -32,7 +32,7 @@ Poor fits (use a different agent / manual triage):
 
 - Crashes, hangs, assertions, sanitizer reports → these belong to [`bug-fix`](../bug-fix/).
 - Backend/platform bugs with no frontend component.
-- Bugs whose fix can only be judged by *seeing* the rendered result — the agent
+- Bugs whose fix can only be judged by _seeing_ the rendered result — the agent
   can localize and propose, but cannot visually confirm.
 
 **Scoping (handled automatically):** a built-in `rules/scoping.md` ruleset, applied
@@ -142,11 +142,12 @@ forbids private comments and `RESOLVED` status changes.
    to read a regressor's diff, local `Read`/`Grep` for exact bytes; deep searches
    delegated to a read-only `investigator` subagent) → record one comment with the
    fix plan.
-4. **Structured output.** The agent ends its final message with a fenced ```json
-   block. `agent.py` parses that into the typed `FrontendTriageResult`
-   (`root_cause`, `proposed_fix`, `target_files`, `confidence`), which the runtime
-   writes to `summary.json` under `findings`. If the block is missing/unparseable,
-   the structured fields are left null and the raw text is preserved in `result`.
+4. **Structured output.** The agent ends its final message with a fenced
+   ` ```json ` block. `agent.py` parses that into the typed
+   `FrontendTriageResult` (`root_cause`, `proposed_fix`, `target_files`,
+   `confidence`), which the runtime writes to `summary.json` under `findings`.
+   If the block is missing/unparsable, the structured fields are left null and
+   the raw text is preserved in `result`.
 
 **Confidence semantics:** confidence reflects how clearly the agent could pin a
 **root cause** in the code, not whether the fix is verified (it never runs the
@@ -162,7 +163,7 @@ gap; they live in the shared `libs/agent-tools/` library (`searchfox.py`,
 - **`searchfox` server** (backed by the `searchfox` client → `searchfox.org`):
   `search_identifier`, `search_text`, `find_definition`, `get_function_at_line`,
   `get_blame`, `get_file`. This is the agent's main localization aid — symbol/usage
-  lookup across the *whole* tree, far better than grep for the multi-module JS that
+  lookup across the _whole_ tree, far better than grep for the multi-module JS that
   dominates frontend bugs. The prompt directs the agent to prefer it over local
   `Grep` when tracing how a symbol/pref/state flows across files.
 - **`mozilla_vcs` server** (HTTP to `hg.mozilla.org`): `get_commit_info`,
@@ -171,7 +172,7 @@ gap; they live in the shared `libs/agent-tools/` library (`searchfox.py`,
   `get_blame`) to pinpoint what changed, which the shallow clone can't provide.
 
 Both are read-only (see Safety guarantees). Note Searchfox/HGMO reflect
-mozilla-central *tip*, which can differ slightly from the checkout — the prompt
+mozilla-central _tip_, which can differ slightly from the checkout — the prompt
 tells the agent to use them for search/history and local `Read` for exact bytes.
 
 ### File layout
@@ -206,15 +207,15 @@ explicitly), so adding them did not affect `bug-fix` or `autowebcompat-repro`.
 Set as environment variables (the API derives these automatically from the input
 schema; locally you pass them via `.env` / the command line):
 
-| Env var | Required | Meaning |
-|---|---|---|
-| `BUG_ID` | yes | The Bugzilla bug to triage |
-| `ANTHROPIC_API_KEY` | yes | Drives the Claude agent (billed per token) |
-| `BUGZILLA_API_URL` | yes | Bugzilla instance, e.g. `https://bugzilla.mozilla.org` |
-| `BUGZILLA_API_KEY` | yes | Held by the broker; used for **reads only** |
-| `MODEL` | no | Override the agent model (cost/quality dial) |
-| `MAX_TURNS` | no | Hard cap on agent loop iterations (runaway/cost guard; cut off if exceeded) |
-| `EFFORT` | no | Reasoning effort level |
+| Env var             | Required | Meaning                                                                     |
+| ------------------- | -------- | --------------------------------------------------------------------------- |
+| `BUG_ID`            | yes      | The Bugzilla bug to triage                                                  |
+| `ANTHROPIC_API_KEY` | yes      | Drives the Claude agent (billed per token)                                  |
+| `BUGZILLA_API_URL`  | yes      | Bugzilla instance, e.g. `https://bugzilla.mozilla.org`                      |
+| `BUGZILLA_API_KEY`  | yes      | Held by the broker; used for **reads only**                                 |
+| `MODEL`             | no       | Override the agent model (cost/quality dial)                                |
+| `MAX_TURNS`         | no       | Hard cap on agent loop iterations (runaway/cost guard; cut off if exceeded) |
+| `EFFORT`            | no       | Reasoning effort level                                                      |
 
 A **turn** is one iteration of the agent loop (model thinks → calls tools →
 observes results). It is not a number of fix attempts; more turns just means more
@@ -262,6 +263,7 @@ cat ~/hackbot/artifacts/$LATEST/summary.json
 ```
 
 Check:
+
 - `findings` → the structured plan (`root_cause`, `proposed_fix`, `target_files`,
   `confidence`).
 - `actions` → exactly one `bugzilla.add_comment`, recorded (not posted). It carries
@@ -274,11 +276,11 @@ Check:
 
 **Good bugs to test** (validated across the three classes this agent handles):
 
-| Bug | Class | Notes |
-|---|---|---|
-| `2014702` | Behavioral | New Tab weather widget vanishing |
-| `2014629` | Pure visual | Split View group-line CSS gap |
-| `2004297` | Regression | Print Preview shift; traces the named regressor |
+| Bug       | Class       | Notes                                           |
+| --------- | ----------- | ----------------------------------------------- |
+| `2014702` | Behavioral  | New Tab weather widget vanishing                |
+| `2014629` | Pure visual | Split View group-line CSS gap                   |
+| `2004297` | Regression  | Print Preview shift; traces the named regressor |
 
 **A note on line numbers:** the agent cites approximate line numbers
 (e.g. `~L1234`). Those are model-asserted and can drift — trust the files and
@@ -323,7 +325,7 @@ This agent is registered with `hackbot-api` for orchestrated runs:
 - **Evaluate the official Mozilla MCP server (`moz`).** Firefox's `.mcp.json`
   defines a hosted HTTP MCP server (`https://mcp-dev.moz.tools/mcp`) exposing
   `get_bugzilla_bug` (with **change history**, which our broker lacks),
-  `get_phabricator_revision`, and `read_fx_doc_section`. These are *complementary*
+  `get_phabricator_revision`, and `read_fx_doc_section`. These are _complementary_
   to (not duplicated by) our Searchfox/VCS tools — it has no code-search or VCS
   tools. Wiring it in as an extra `http` MCP server could add Phabricator-patch
   awareness ("has a fix already landed?"), Firefox docs, and Bugzilla bug history.

--- a/agents/frontend-triage/README.md
+++ b/agents/frontend-triage/README.md
@@ -51,7 +51,10 @@ For each run, in `~/hackbot/artifacts/<run_id>/`:
 - **`summary.json`** — the machine-readable result:
   - `findings` → the structured plan: `summary`, `root_cause`, `proposed_fix`,
     `target_files`, `confidence` (`high|medium|low`), plus `num_turns` and
-    `total_cost_usd`.
+    `total_cost_usd`. Handoff fields for a downstream executor: `actionable`
+    (`false` for out-of-scope/skipped bugs), `regressor_node` (hg node of the
+    introducing changeset when found), and `relevant_tests` (existing tests
+    covering the area — the executor's verification anchor; `[]` if none exist).
   - `actions` → a single **recorded** `bugzilla.add_comment` (the human-readable
     triage comment). "Recorded" means written to this file for review — **it is
     not posted to Bugzilla.**

--- a/agents/frontend-triage/README.md
+++ b/agents/frontend-triage/README.md
@@ -2,8 +2,10 @@
 
 A Hackbot agent that **triages Firefox desktop frontend bugs** from Bugzilla and
 produces a **root-cause analysis + a proposed fix plan**. It investigates the
-Firefox source tree read-only and writes its findings to disk; it does **not**
-build Firefox, modify source, reproduce the bug, or write anything to Bugzilla.
+Firefox source tree read-only — navigating the codebase with **Searchfox** and
+inspecting regressor changesets via Mozilla's Mercurial server (**HGMO**) — and
+writes its findings to disk; it does **not** build Firefox, modify source,
+reproduce the bug, or write anything to Bugzilla.
 
 Think of it as an experienced engineer doing first-pass triage on a UI/UX
 papercut: it reads the bug, finds the responsible code, explains the likely
@@ -32,6 +34,13 @@ Poor fits (use a different agent / manual triage):
 - Backend/platform bugs with no frontend component.
 - Bugs whose fix can only be judged by *seeing* the rendered result — the agent
   can localize and propose, but cannot visually confirm.
+
+**Scoping (handled automatically):** a built-in `rules/scoping.md` ruleset, applied
+first, has the agent skip non-defects (enhancements/tasks), tracking/`meta` bugs,
+and intermittent/test-infra failures — it records a short out-of-scope note instead
+of inventing a fix plan — and flags accessibility (`access`) bugs as a specialized
+lane. This keeps the agent from spending a full investigation on bugs it can't
+meaningfully fix-plan.
 
 ---
 
@@ -70,9 +79,15 @@ enforced structurally, not just by prompt instructions:
    network calls. Applying them to Bugzilla is a separate downstream step that is
    **not** part of local runs.
 3. **No write/build tools are granted.** `agent.py` builds `allowed_tools` from
-   read-only inspection tools (`Read`, `Grep`, `Glob`, `Bash`, `Task`) + the
-   Bugzilla read tools + the record-only action tools. There are no `Write`/`Edit`
-   tools and no Firefox build/eval tools.
+   read-only inspection tools (`Read`, `Grep`, `Glob`, `Bash`, `Task`), the
+   Bugzilla read tools, the **read-only** Searchfox and Mozilla-VCS tools, and the
+   record-only action tools. There are no `Write`/`Edit` tools and no Firefox
+   build/eval tools.
+4. **The new investigation tools are read-only too.** Searchfox (`searchfox.org`)
+   and Mozilla VCS (`hg.mozilla.org`) are queried over HTTP for public code-search
+   and changeset data only — no writes, no auth, no mutation. They need outbound
+   network from the agent container (which it already has, since the runtime clones
+   the repo at startup).
 
 `config.py` further restricts recordable actions to `bugzilla.add_comment` and
 `bugzilla.update_bug` (no attachments, no bug creation), and the system prompt
@@ -90,14 +105,15 @@ forbids private comments and `RESOLVED` status changes.
                          └──────────────┬──────────────┘
                                         │ MCP over HTTP (read-only)
                                         ▼
-   git clone (shallow)   ┌─────────────────────────────┐
-   mozilla-firefox/      │  frontend-triage-agent       │
-   firefox  ───────────► │                              │
-   (workspace volume)    │  Claude Agent SDK loop:      │
-                         │   - read bug + comments      │
-                         │   - read relevant rules/     │
+   git clone (shallow)   ┌─────────────────────────────┐   in-process MCP tools
+   mozilla-firefox/      │  frontend-triage-agent       │   (read-only HTTP):
+   firefox  ───────────► │                              │ ─► searchfox.org
+   (workspace volume)    │  Claude Agent SDK loop:      │    (code search/blame)
+                         │   - read bug + comments      │ ─► hg.mozilla.org
+                         │   - read relevant rules/     │    (regressor diffs)
                          │   - investigate source       │
-                         │     (Read/Grep/Glob/Bash,    │
+                         │     (Read/Grep/Glob/Bash +   │
+                         │      Searchfox + VCS tools,  │
                          │      + investigator subagent)│
                          │   - record comment + plan    │
                          └──────────────┬──────────────┘
@@ -115,10 +131,14 @@ forbids private comments and `RESOLVED` status changes.
 2. **Entrypoint.** `__main__.py` reads the per-run inputs (env vars), sets a
    read-only triage `task`, and calls `run_frontend_triage(...)`.
 3. **Agent loop.** `agent.py` wires up the Claude Agent SDK with the read-only
-   tools, the rules directory, and the action-recording server, then drives the
-   loop: fetch the bug → load the relevant ruleset(s) from `rules/` → investigate
-   the source (delegating deep searches to a read-only `investigator` subagent) →
-   record one comment with the fix plan.
+   tools (Bugzilla read tools via the broker, plus two in-process MCP servers —
+   `searchfox` and `mozilla_vcs` — built with `build_sdk_server`), the rules
+   directory, and the action-recording server. It then drives the loop: apply
+   `scoping.md` → fetch the bug → load the relevant ruleset(s) from `rules/` →
+   investigate the source (Searchfox for cross-file symbol tracing, the VCS tools
+   to read a regressor's diff, local `Read`/`Grep` for exact bytes; deep searches
+   delegated to a read-only `investigator` subagent) → record one comment with the
+   fix plan.
 4. **Structured output.** The agent ends its final message with a fenced ```json
    block. `agent.py` parses that into the typed `FrontendTriageResult`
    (`root_cause`, `proposed_fix`, `target_files`, `confidence`), which the runtime
@@ -128,6 +148,28 @@ forbids private comments and `RESOLVED` status changes.
 **Confidence semantics:** confidence reflects how clearly the agent could pin a
 **root cause** in the code, not whether the fix is verified (it never runs the
 result). Treat `high` as "trust the diagnosis, still review/verify the patch."
+
+### Investigation tools (Searchfox + Mozilla VCS)
+
+The local checkout is a **shallow** clone (`--depth=1`) — no git history, and
+`Grep` only sees the checked-out files. Two in-process MCP tool servers fill that
+gap; they live in the shared `libs/agent-tools/` library (`searchfox.py`,
+`mozilla_vcs.py`) and are wired in by `agent.py`:
+
+- **`searchfox` server** (backed by the `searchfox` client → `searchfox.org`):
+  `search_identifier`, `search_text`, `find_definition`, `get_function_at_line`,
+  `get_blame`, `get_file`. This is the agent's main localization aid — symbol/usage
+  lookup across the *whole* tree, far better than grep for the multi-module JS that
+  dominates frontend bugs. The prompt directs the agent to prefer it over local
+  `Grep` when tracing how a symbol/pref/state flows across files.
+- **`mozilla_vcs` server** (HTTP to `hg.mozilla.org`): `get_commit_info`,
+  `get_commit_diff`, `file_history`. Used for **regression** bugs — read the actual
+  diff of a known regressor changeset (found via a bug's `regressed_by` field or
+  `get_blame`) to pinpoint what changed, which the shallow clone can't provide.
+
+Both are read-only (see Safety guarantees). Note Searchfox/HGMO reflect
+mozilla-central *tip*, which can differ slightly from the checkout — the prompt
+tells the agent to use them for search/history and local `Read` for exact bytes.
 
 ### File layout
 
@@ -141,13 +183,20 @@ agents/frontend-triage/
     frontend_triage/
       __main__.py         # inputs + read-only triage task + entrypoint
       agent.py            # the agent loop, FrontendTriageResult, plan parser
-      config.py           # tool/action allow-lists (read-only; no firefox)
+      config.py           # tool/action allow-lists (read-only; bugzilla+searchfox+vcs)
       broker.py           # Bugzilla read-only MCP broker (sidecar)
       prompts/system.md   # system prompt: triage + fix-plan, no build/repro
       rules/
         README.md         # how to author rulesets
+        scoping.md        # applied first: skip/flag out-of-scope bugs
         frontend-triage.md  # the frontend-papercut ruleset
 ```
+
+The Searchfox and VCS tools themselves are **not** in this folder — they're shared
+modules in `libs/agent-tools/agent_tools/` (`searchfox.py`, `mozilla_vcs.py`),
+pulled in via the `searchfox` and `vcs` extras of the `agent-tools` dependency in
+`pyproject.toml`. They are inert for other agents (each agent wires tools
+explicitly), so adding them did not affect `bug-fix` or `autowebcompat-repro`.
 
 ### Configuration (per-run inputs)
 
@@ -215,6 +264,10 @@ Check:
 - `actions` → exactly one `bugzilla.add_comment`, recorded (not posted). It carries
   an `*This is an automated analysis result...*` footer.
 - **No `changes/` directory** and no build step — confirms the run stayed read-only.
+- **Tool usage** (in `logs/agent.log`): expect `mcp__searchfox__*` calls during
+  investigation, and `mcp__mozilla_vcs__*` calls on regression bugs. On an
+  out-of-scope bug (a `meta`/enhancement), expect a short "out of scope" comment
+  with `confidence: low` / `root_cause: null` rather than a fabricated plan.
 
 **Good bugs to test** (validated across the three classes this agent handles):
 
@@ -233,15 +286,18 @@ acting.
 
 ## Tuning
 
-- **Rules** (`rules/frontend-triage.md`): the main behavior dial. Adjust which
-  components are in scope, what the comment should contain, comment brevity, and
-  the confidence thresholds for taking actions. The agent Globs `rules/` and reads
-  only the rulesets it judges relevant, so you can add more `.md` files for other
-  scopes.
+- **Rules** (`rules/`): the main behavior dial. `scoping.md` controls what gets
+  skipped/flagged; `frontend-triage.md` controls in-scope components, comment
+  content/brevity, and the confidence thresholds for actions. The agent Globs
+  `rules/` and reads only the rulesets it judges relevant, so you can add more
+  `.md` files for other scopes.
 - **System prompt** (`prompts/system.md`): the standing instructions — output
-  format, the read-only mandate, the structured-JSON requirement.
+  format, the read-only mandate, the structured-JSON requirement, and the guidance
+  to prefer Searchfox over local grep for cross-file tracing.
 - **Cost ceiling**: set `MAX_TURNS` and/or a cheaper `MODEL` per run to bound cost
-  when batching.
+  when batching. Note: Searchfox results are token-heavy, so a tool-using run can
+  cost more than a grep-only one even with fewer turns — narrowing queries (use
+  `path_filter`, modest `limit`) is the lever if cost matters at scale.
 
 ## Handoff to implementation
 
@@ -258,3 +314,15 @@ This agent is registered with `hackbot-api` for orchestrated runs:
 `FrontendTriageInputs` in `services/hackbot-api/app/schemas.py` and the
 `frontend-triage` entry in `services/hackbot-api/app/agents.py` (job
 `hackbot-agent-frontend-triage`). Local Compose runs do not require the API.
+
+## Future work
+
+- **Evaluate the official Mozilla MCP server (`moz`).** Firefox's `.mcp.json`
+  defines a hosted HTTP MCP server (`https://mcp-dev.moz.tools/mcp`) exposing
+  `get_bugzilla_bug` (with **change history**, which our broker lacks),
+  `get_phabricator_revision`, and `read_fx_doc_section`. These are *complementary*
+  to (not duplicated by) our Searchfox/VCS tools — it has no code-search or VCS
+  tools. Wiring it in as an extra `http` MCP server could add Phabricator-patch
+  awareness ("has a fix already landed?"), Firefox docs, and Bugzilla bug history.
+  Before depending on it for automated runs, confirm whether there's a
+  stable/production endpoint (the current URL is a `mcp-dev` one).

--- a/agents/frontend-triage/compose.yml
+++ b/agents/frontend-triage/compose.yml
@@ -1,0 +1,36 @@
+services:
+  frontend-triage-broker:
+    build:
+      context: ../..
+      dockerfile: agents/frontend-triage/Dockerfile
+      target: broker
+    environment:
+      BUGZILLA_API_URL: ${BUGZILLA_API_URL}
+      BUGZILLA_API_KEY: ${BUGZILLA_API_KEY}
+    expose:
+      - "8765"
+
+  frontend-triage-agent:
+    build:
+      context: ../..
+      dockerfile: agents/frontend-triage/Dockerfile
+      target: agent
+    environment:
+      - RUN_ID
+      - BUG_ID=${BUG_ID:?error}
+      - BUGZILLA_MCP_URL=http://frontend-triage-broker:8765/mcp
+      - SOURCE_REPO=/workspace/firefox
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:?error}
+      # No uploader locally: summary/logs/attachments are written under
+      # /artifacts/<run_id>, bind-mounted to the host's ~/hackbot/artifacts so
+      # compose and direct runs land in the same user-scoped location.
+      - ARTIFACTS_DIR=/artifacts
+    volumes:
+      - workspace:/workspace
+      - ${HOME}/hackbot/artifacts:/artifacts
+    depends_on:
+      frontend-triage-broker:
+        condition: service_started
+
+volumes:
+  workspace:

--- a/agents/frontend-triage/hackbot.toml
+++ b/agents/frontend-triage/hackbot.toml
@@ -1,0 +1,6 @@
+[source]
+repo_url = "https://github.com/mozilla-firefox/firefox.git"
+checkout_path = "/workspace/firefox"
+
+# No [firefox] table: this agent does read-only triage and planning. It never
+# builds Firefox or runs testcases, so the build toolchain is not prepared.

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/__main__.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/__main__.py
@@ -1,0 +1,47 @@
+from hackbot_runtime import HackbotContext, run_async
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from .agent import FrontendTriageResult, run_frontend_triage
+
+TRIAGE_TASK = (
+    "Triage this Firefox desktop frontend bug. Investigate the source tree "
+    "READ-ONLY (Read/Grep/Glob/Bash) to determine the likely root cause, then "
+    "produce a concrete proposed fix plan: the target files and the approach. "
+    "Do NOT build, run, or modify the source, and do NOT attempt to reproduce "
+    "the bug by running Firefox. Record your findings and plan as a single brief "
+    "Bugzilla comment."
+)
+
+
+class AgentInputs(BaseSettings):
+    bug_id: int
+    bugzilla_mcp_url: str
+    model: str | None = None
+    max_turns: int | None = None
+    effort: str | None = None
+
+    model_config = SettingsConfigDict(extra="ignore")
+
+
+async def main(ctx: HackbotContext) -> FrontendTriageResult:
+    inputs = AgentInputs()
+
+    return await run_frontend_triage(
+        task=TRIAGE_TASK,
+        bugzilla_mcp_server={
+            "type": "http",
+            "url": inputs.bugzilla_mcp_url,
+        },
+        source_repo=ctx.source_repo,
+        bug=inputs.bug_id,
+        model=inputs.model,
+        max_turns=inputs.max_turns,
+        effort=inputs.effort,
+        log=ctx.log_path,
+        verbose=True,
+        actions_recorder=ctx.actions,
+    )
+
+
+if __name__ == "__main__":
+    run_async(main)

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
@@ -1,0 +1,221 @@
+"""Frontend triage tool -- a read-only Bugzilla triage + fix-planning agent.
+
+Orchestrates a Claude agent that triages Firefox desktop *frontend* bugs
+according to rulesets in the rules/ directory. The agent investigates the
+source repository READ-ONLY (no build, no source edits, no reproduction) and
+produces a root-cause analysis plus a proposed fix plan, which it records as a
+Bugzilla comment for a human (or a downstream execution agent) to act on.
+
+It reaches Bugzilla via an out-of-process MCP broker (HTTP transport) that holds
+the Bugzilla token -- the agent process itself never sees it.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+from claude_agent_sdk import (
+    AgentDefinition,
+    ClaudeAgentOptions,
+    ClaudeSDKClient,
+    McpServerConfig,
+    ResultMessage,
+)
+from hackbot_runtime import ActionsRecorder, AgentError, HackbotAgentResult
+from hackbot_runtime.actions import ACTIONS_SERVER_NAME
+from hackbot_runtime.actions.claude_sdk import actions_server_for, actions_to_tool_names
+from hackbot_runtime.claude import Reporter
+
+from .config import BUGZILLA_READ_TOOLS, ENABLED_ACTION_TYPES
+
+HERE = Path(__file__).resolve().parent
+
+# The agent is asked to end its final message with a fenced ```json block
+# carrying the structured plan. We parse the last such block so the result is
+# machine-consumable for downstream handoff (summary.json -> execution agent).
+_JSON_BLOCK = re.compile(r"```json\s*(\{.*?\})\s*```", re.DOTALL)
+
+
+class FrontendTriageResult(HackbotAgentResult):
+    bug_id: int
+    # Structured plan (best-effort, parsed from the agent's final message).
+    summary: str | None = None
+    root_cause: str | None = None
+    proposed_fix: str | None = None
+    target_files: list[str] | None = None
+    confidence: str | None = None
+    # The agent's full final message, always present as a fallback.
+    result: str | None = None
+
+
+def load_system_prompt(rules_dir: Path, extra: str) -> str:
+    tmpl = (HERE / "prompts" / "system.md").read_text()
+
+    return tmpl.format(
+        rules_dir=str(rules_dir.resolve()),
+        extra_instructions=extra or "(none)",
+    )
+
+
+def make_investigator() -> AgentDefinition:
+    """Create a single generic, read-only investigator subagent definition."""
+    return AgentDefinition(
+        description=(
+            "Focused investigator for answering a specific question about "
+            "a bug or the source tree. The main agent writes your complete "
+            "instructions at spawn time -- follow them precisely and return "
+            "only what was asked for."
+        ),
+        prompt=(
+            "You are a focused investigator subagent. You will be given a "
+            "self-contained task by the triage agent. Complete it and return "
+            "a concise answer. You have read-only access only: do not modify "
+            "the source tree or Bugzilla. Do not speculate beyond what you can "
+            "verify."
+        ),
+        tools=[
+            "Read",
+            "Grep",
+            "Glob",
+            "Bash",
+            *BUGZILLA_READ_TOOLS,
+        ],
+        model="inherit",
+    )
+
+
+def parse_plan(text: str | None) -> dict:
+    """Extract the structured plan from the agent's final message, if present.
+
+    Returns an empty dict when no parseable ```json block is found -- the raw
+    text is still preserved in ``FrontendTriageResult.result``.
+    """
+    if not text:
+        return {}
+    matches = _JSON_BLOCK.findall(text)
+    if not matches:
+        return {}
+    try:
+        data = json.loads(matches[-1])
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    files = data.get("target_files")
+    if isinstance(files, str):
+        files = [files]
+    elif not isinstance(files, list):
+        files = None
+    return {
+        "summary": data.get("summary"),
+        "root_cause": data.get("root_cause"),
+        "proposed_fix": data.get("proposed_fix"),
+        "target_files": files,
+        "confidence": data.get("confidence"),
+    }
+
+
+async def run_frontend_triage(
+    *,
+    bugzilla_mcp_server: McpServerConfig,
+    source_repo: Path,
+    bug: int,
+    instructions: str = "",
+    task: str | None = None,
+    rules_dir: Path | None = None,
+    model: str | None = None,
+    max_turns: int | None = None,
+    effort: str | None = None,
+    verbose: bool = False,
+    log: Path | None = None,
+    actions_recorder: ActionsRecorder | None = None,
+) -> FrontendTriageResult:
+    """Triage and plan a fix for a single Bugzilla frontend bug (read-only).
+
+    Returns a :class:`FrontendTriageResult` on success; raises
+    :class:`AgentError` if the agent ends in an error.
+    """
+    if rules_dir is None:
+        rules_dir = HERE / "rules"
+
+    print(f"[frontend_triage] triaging bug {bug}", file=sys.stderr)
+
+    # Action-recording MCP server (in-process). Standalone/script runs pass
+    # actions_recorder=None and get a local recorder (no uploader).
+    actions_recorder, actions_server = actions_server_for(
+        actions_recorder, types=ENABLED_ACTION_TYPES
+    )
+    enabled_action_tools = actions_to_tool_names(ENABLED_ACTION_TYPES)
+
+    system_prompt = load_system_prompt(rules_dir, instructions)
+
+    options = ClaudeAgentOptions(
+        system_prompt=system_prompt,
+        mcp_servers={
+            "bugzilla": bugzilla_mcp_server,
+            ACTIONS_SERVER_NAME: actions_server,
+        },
+        agents={"investigator": make_investigator()},
+        cwd=str(source_repo.resolve()),
+        add_dirs=[str(rules_dir.resolve())],
+        permission_mode="bypassPermissions",
+        # Read-only investigation tools only: no Write/Edit (source is never
+        # modified) and no firefox build/eval tools.
+        allowed_tools=[
+            "Read",
+            "Grep",
+            "Glob",
+            "Bash",
+            "Task",
+            *BUGZILLA_READ_TOOLS,
+            *enabled_action_tools,
+        ],
+        model=model,
+        max_turns=max_turns,
+        **({"effort": effort} if effort else {}),
+        setting_sources=[],
+    )
+
+    rules_path = rules_dir.resolve()
+    if task:
+        user_prompt = (
+            f"Bug to work on: {bug}\n\n"
+            f"Task: {task}\n\n"
+            f"The rules in {rules_path} are available if the task "
+            f"calls for them, but the task above is your primary "
+            f"directive -- it overrides the default triage workflow."
+        )
+    else:
+        user_prompt = (
+            f"Triage bug {bug}.\n\nConsult the relevant rules in {rules_path}."
+        )
+
+    result_msg: ResultMessage | None = None
+    with Reporter(verbose=verbose, log_path=log) as reporter:
+        reporter.header(f"bug {bug}")
+        async with ClaudeSDKClient(options=options) as client:
+            await client.query(user_prompt)
+            async for msg in client.receive_response():
+                reporter.message(msg)
+                if isinstance(msg, ResultMessage):
+                    result_msg = msg
+
+    if result_msg is None:
+        raise AgentError(f"bug {bug}: agent produced no result message")
+    if result_msg.is_error:
+        raise AgentError(
+            f"bug {bug} triage failed: {result_msg.result or result_msg.subtype}"
+        )
+
+    plan = parse_plan(result_msg.result)
+
+    return FrontendTriageResult(
+        bug_id=bug,
+        result=result_msg.result,
+        num_turns=result_msg.num_turns,
+        total_cost_usd=result_msg.total_cost_usd,
+        **plan,
+    )

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
@@ -57,6 +57,10 @@ class FrontendTriageResult(HackbotAgentResult):
     proposed_fix: str | None = None
     target_files: list[str] | None = None
     confidence: str | None = None
+    # Handoff fields for a downstream executor agent.
+    actionable: bool | None = None  # false => out of scope / nothing to fix-plan
+    regressor_node: str | None = None  # hg node of the introducing changeset, if found
+    relevant_tests: list[str] | None = None  # existing tests covering the area (verify anchor)
     # The agent's full final message, always present as a fallback.
     result: str | None = None
 
@@ -116,17 +120,23 @@ def parse_plan(text: str | None) -> dict:
         return {}
     if not isinstance(data, dict):
         return {}
-    files = data.get("target_files")
-    if isinstance(files, str):
-        files = [files]
-    elif not isinstance(files, list):
-        files = None
+    def _as_list(value):
+        if isinstance(value, str):
+            return [value]
+        return value if isinstance(value, list) else None
+
+    actionable = data.get("actionable")
+    if not isinstance(actionable, bool):
+        actionable = None
     return {
         "summary": data.get("summary"),
         "root_cause": data.get("root_cause"),
         "proposed_fix": data.get("proposed_fix"),
-        "target_files": files,
+        "target_files": _as_list(data.get("target_files")),
         "confidence": data.get("confidence"),
+        "actionable": actionable,
+        "regressor_node": data.get("regressor_node"),
+        "relevant_tests": _as_list(data.get("relevant_tests")),
     }
 
 

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
@@ -17,6 +17,10 @@ import re
 import sys
 from pathlib import Path
 
+from agent_tools import mozilla_vcs, searchfox
+from agent_tools.claude_sdk import build_sdk_server
+from agent_tools.mozilla_vcs import MozillaVcsContext
+from agent_tools.searchfox import SearchfoxContext
 from claude_agent_sdk import (
     AgentDefinition,
     ClaudeAgentOptions,
@@ -28,8 +32,14 @@ from hackbot_runtime import ActionsRecorder, AgentError, HackbotAgentResult
 from hackbot_runtime.actions import ACTIONS_SERVER_NAME
 from hackbot_runtime.actions.claude_sdk import actions_server_for, actions_to_tool_names
 from hackbot_runtime.claude import Reporter
+from searchfox import AsyncSearchfoxClient
 
-from .config import BUGZILLA_READ_TOOLS, ENABLED_ACTION_TYPES
+from .config import (
+    BUGZILLA_READ_TOOLS,
+    ENABLED_ACTION_TYPES,
+    MOZILLA_VCS_TOOLS,
+    SEARCHFOX_TOOLS,
+)
 
 HERE = Path(__file__).resolve().parent
 
@@ -82,6 +92,8 @@ def make_investigator() -> AgentDefinition:
             "Glob",
             "Bash",
             *BUGZILLA_READ_TOOLS,
+            *SEARCHFOX_TOOLS,
+            *MOZILLA_VCS_TOOLS,
         ],
         model="inherit",
     )
@@ -150,12 +162,22 @@ async def run_frontend_triage(
     )
     enabled_action_tools = actions_to_tool_names(ENABLED_ACTION_TYPES)
 
+    # In-process MCP servers for read-only code investigation. Searchfox and HGMO
+    # are public (no credentials), so they run in-process rather than via a
+    # brokered sidecar.
+    searchfox_server = build_sdk_server(
+        "searchfox", SearchfoxContext(client=AsyncSearchfoxClient()), searchfox.TOOLS
+    )
+    vcs_server = build_sdk_server("mozilla_vcs", MozillaVcsContext(), mozilla_vcs.TOOLS)
+
     system_prompt = load_system_prompt(rules_dir, instructions)
 
     options = ClaudeAgentOptions(
         system_prompt=system_prompt,
         mcp_servers={
             "bugzilla": bugzilla_mcp_server,
+            "searchfox": searchfox_server,
+            "mozilla_vcs": vcs_server,
             ACTIONS_SERVER_NAME: actions_server,
         },
         agents={"investigator": make_investigator()},
@@ -171,6 +193,8 @@ async def run_frontend_triage(
             "Bash",
             "Task",
             *BUGZILLA_READ_TOOLS,
+            *SEARCHFOX_TOOLS,
+            *MOZILLA_VCS_TOOLS,
             *enabled_action_tools,
         ],
         model=model,

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
@@ -60,7 +60,9 @@ class FrontendTriageResult(HackbotAgentResult):
     # Handoff fields for a downstream executor agent.
     actionable: bool | None = None  # false => out of scope / nothing to fix-plan
     regressor_node: str | None = None  # hg node of the introducing changeset, if found
-    relevant_tests: list[str] | None = None  # existing tests covering the area (verify anchor)
+    relevant_tests: list[str] | None = (
+        None  # existing tests covering the area (verify anchor)
+    )
     # The agent's full final message, always present as a fallback.
     result: str | None = None
 
@@ -120,6 +122,7 @@ def parse_plan(text: str | None) -> dict:
         return {}
     if not isinstance(data, dict):
         return {}
+
     def _as_list(value):
         if isinstance(value, str):
             return [value]

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/broker.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/broker.py
@@ -1,0 +1,71 @@
+"""Bugzilla MCP broker.
+
+Sidecar container that holds the Bugzilla API key and serves the
+bugzilla MCP tools over HTTP. The agent process (in a sibling container
+in the same Cloud Run Job task) reaches us at `127.0.0.1:<port>/mcp`.
+The agent container itself binds no Bugzilla credentials.
+"""
+
+import logging
+from contextlib import asynccontextmanager
+
+import bugsy
+import uvicorn
+from agent_tools import bugzilla
+from agent_tools.bugzilla import BugzillaContext
+from agent_tools.claude_sdk import build_sdk_server
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from starlette.applications import Starlette
+from starlette.routing import Mount
+
+log = logging.getLogger("bugzilla-broker")
+
+
+class BrokerInputs(BaseSettings):
+    bugzilla_api_url: str
+    bugzilla_api_key: str
+    host: str = "0.0.0.0"
+    port: int = 8765
+
+    model_config = SettingsConfigDict(extra="ignore")
+
+
+def build_app(inputs: BrokerInputs) -> Starlette:
+    client = bugsy.Bugsy(
+        api_key=inputs.bugzilla_api_key, bugzilla_url=inputs.bugzilla_api_url
+    )
+    ctx = BugzillaContext(client=client)
+    sdk_config = build_sdk_server("bugzilla", ctx, bugzilla.TOOLS)
+    mcp_server = sdk_config["instance"]
+
+    manager = StreamableHTTPSessionManager(app=mcp_server, stateless=True)
+
+    @asynccontextmanager
+    async def lifespan(app):
+        async with manager.run():
+            log.info(
+                "bugzilla broker ready on %s:%d (read-only)",
+                inputs.host,
+                inputs.port,
+            )
+            yield
+
+    async def mcp_handler(scope, receive, send):
+        await manager.handle_request(scope, receive, send)
+
+    return Starlette(routes=[Mount("/mcp", app=mcp_handler)], lifespan=lifespan)
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    inputs = BrokerInputs()
+    app = build_app(inputs)
+    uvicorn.run(app, host=inputs.host, port=inputs.port, log_config=None)
+
+
+if __name__ == "__main__":
+    main()

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/config.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/config.py
@@ -8,6 +8,27 @@ BUGZILLA_READ_TOOLS = [
 ]
 
 
+# Searchfox code-search tools (in-process MCP server "searchfox"). Symbol/def/
+# text lookup + blame across mozilla-central — the agent's main code-navigation
+# capability for localizing behavioral bugs.
+SEARCHFOX_TOOLS = [
+    "mcp__searchfox__search_identifier",
+    "mcp__searchfox__search_text",
+    "mcp__searchfox__find_definition",
+    "mcp__searchfox__get_function_at_line",
+    "mcp__searchfox__get_blame",
+    "mcp__searchfox__get_file",
+]
+
+# Mozilla VCS / HGMO tools (in-process MCP server "mozilla_vcs"). Read a known
+# regressor changeset's diff/metadata and recent file history over HTTP.
+MOZILLA_VCS_TOOLS = [
+    "mcp__mozilla_vcs__get_commit_info",
+    "mcp__mozilla_vcs__get_commit_diff",
+    "mcp__mozilla_vcs__file_history",
+]
+
+
 # Recordable action types the agent may take, by dotted id. This agent triages
 # and plans only: it records a comment with its findings/plan and, at high
 # confidence, may propose field updates (e.g. keyword/severity). It never

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/config.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/config.py
@@ -1,0 +1,18 @@
+# Bugzilla MCP tool names as exposed to the agent (mcp__<server>__<tool>).
+BUGZILLA_READ_TOOLS = [
+    "mcp__bugzilla__search_bugs",
+    "mcp__bugzilla__get_bugs",
+    "mcp__bugzilla__get_bug_comments",
+    "mcp__bugzilla__get_bug_attachments",
+    "mcp__bugzilla__download_attachment",
+]
+
+
+# Recordable action types the agent may take, by dotted id. This agent triages
+# and plans only: it records a comment with its findings/plan and, at high
+# confidence, may propose field updates (e.g. keyword/severity). It never
+# creates bugs or attaches files.
+ENABLED_ACTION_TYPES = [
+    "bugzilla.add_comment",
+    "bugzilla.update_bug",
+]

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/prompts/system.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/prompts/system.md
@@ -30,6 +30,8 @@ Use **only** these tools for accessing Bugzilla, nothing else.
 
 Your working directory is the Firefox source repository. You have Read, Grep, Glob, and Bash (read-only — do not modify files) to inspect it. Use this to localize the bug: find the components, JS/JSM modules, CSS, and XUL/HTML involved, the relevant prefs (often under `modules/libpref/init/all.js`), and any existing tests that cover the area. Frontend code mostly lives under `browser/`, `toolkit/`, and `devtools/`.
 
+**Always look for an existing test that exercises the affected area** (browser-chrome mochitests usually live in a component's `tests/browser/` directory; also check `tests/`/`test/` and xpcshell tests). Record what you find in the `relevant_tests` field — it is the downstream executor's verification anchor. If you searched and there is no covering test, say so (empty `relevant_tests`).
+
 When you reference a cause or a fix target, cite concrete paths (and ideally functions/selectors), e.g. `browser/components/tabbrowser/content/tabgroup.js`.
 
 # Code-search & history tools
@@ -84,7 +86,7 @@ Always be **brief** and to the point. Developers have limited time. Do **not** r
 
 # Final message: structured plan
 
-After recording your comment, end your final message with a fenced ```json block carrying the structured plan, so it can be consumed programmatically. Use exactly these keys:
+After recording your comment, end your final message with a fenced ```json block carrying the structured plan, so it can be consumed programmatically (a downstream executor agent reads these fields). Use exactly these keys:
 
 ```json
 {{
@@ -92,11 +94,20 @@ After recording your comment, end your final message with a fenced ```json block
   "root_cause": "the likely cause, or null if undetermined",
   "proposed_fix": "the approach a developer should take",
   "target_files": ["path/one.js", "path/two.css"],
-  "confidence": "high | medium | low"
+  "confidence": "high | medium | low",
+  "actionable": true,
+  "regressor_node": "hg node of the introducing changeset, or null",
+  "relevant_tests": ["browser/.../tests/browser/browser_foo.js"]
 }}
 ```
 
-If you could not localize a root cause, set `root_cause` to null, keep `confidence` low, and have your comment ask the specific open questions that block triage.
+Field guidance for the handoff:
+
+- **`actionable`** — `false` when the bug is out of scope or skipped per the scoping rules (meta/tracking, intermittent/test-infra, enhancement/task), or when there is simply nothing to fix-plan; `true` when you produced a real fix plan. The executor uses this to decide whether to act.
+- **`regressor_node`** — when the bug is a regression and you identified/confirmed the introducing changeset (via the `mozilla_vcs` tools or `get_blame`), put its hg node here so the executor has a direct pointer; otherwise `null`.
+- **`relevant_tests`** — existing tests that cover the affected area (typically browser-chrome mochitests under a component's `tests/browser/` dir, or xpcshell tests). These are the executor's **verification anchor** — it can run them. Use `[]` if you searched and found none (a signal that the executor should add a test).
+
+If you could not localize a root cause, set `root_cause` to null, keep `confidence` low, set `actionable` accordingly, and have your comment ask the specific open questions that block triage.
 
 # Additional instructions for this run
 

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/prompts/system.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/prompts/system.md
@@ -1,0 +1,80 @@
+You are an autonomous triage agent for Firefox **desktop frontend** bugs, operating against a Bugzilla instance.
+
+# Your job
+
+You are given a bug ID. Your job is to triage it and produce a **proposed fix plan** — you do **not** write, build, or run code. Specifically:
+
+1. **Fetch** the bug (fields + comments) using the `bugzilla` MCP tools.
+2. **Read the relevant triage rules** from `{rules_dir}` — Glob the directory and Read only the rulesets that apply to this bug. Do not assume all rules apply to all bugs.
+3. **Assess** what the rules say should happen, and whether the bug has open questions in its comments.
+4. **Investigate** the source tree (read-only) to localize the cause — delegate deep searches to the `investigator` subagent (see below).
+5. **Produce a fix plan**: the likely root cause, the specific files to change, and the approach. Record it as a brief Bugzilla comment.
+
+# This agent is READ-ONLY
+
+You have **no** ability to build Firefox, run testcases, or edit the source tree, and you must not try. There are no `firefox` build/eval tools and no Write/Edit tools. Your value is a precise, well-localized plan a developer (or a downstream execution agent) can act on — not a patch.
+
+Do not claim to have "verified" or "tested" a fix. You are reasoning from the code, not running it. Be honest about your confidence.
+
+# Bugzilla MCP tools — important quirks
+
+- **Always request `whiteboard` and `keywords` explicitly** in `include_fields`. This Bugzilla proxy drops them from `_all` / `_default`.
+- **The history endpoint is not exposed** on this proxy. Do not try to fetch change history — infer it from comments if you need it.
+- **Bulk fetch whenever possible.** `get_bugs` takes a list of IDs and makes one request. Do not call `get_bugs` in a loop with single IDs.
+- **Inaccessible bugs are silently dropped.** `get_bugs` reports them under `inaccessible` — log and skip those.
+- **Search parameters are ANDed.** `search_bugs` with multiple fields returns bugs matching all of them.
+
+Use **only** these tools for accessing Bugzilla, nothing else.
+
+# Source repository
+
+Your working directory is the Firefox source repository. You have Read, Grep, Glob, and Bash (read-only — do not modify files) to inspect it. Use this to localize the bug: find the components, JS/JSM modules, CSS, and XUL/HTML involved, the relevant prefs (often under `modules/libpref/init/all.js`), and any existing tests that cover the area. Frontend code mostly lives under `browser/`, `toolkit/`, and `devtools/`.
+
+When you reference a cause or a fix target, cite concrete paths (and ideally functions/selectors), e.g. `browser/components/tabbrowser/content/tabgroup.js`.
+
+# Delegating to the investigator subagent
+
+You have one generic subagent type: `investigator`. It has the same read-only tools you do (source repo + bugzilla read tools). **You write its full instructions dynamically** each time you spawn it — there is no fixed investigator behaviour.
+
+Use it when:
+
+- An assessment requires deep source-code reading that would pollute your main context
+- You need a focused answer to a specific question ("where is the split-view group line drawn?")
+- You want to parallelise independent investigations
+
+When you spawn an investigator via the Task tool, write a complete, self-contained prompt: what to look at, what question to answer, what format to return. The investigator has no memory of previous spawns.
+
+# Recording actions
+
+The `actions` MCP tools (`bugzilla_add_comment`, `bugzilla_update_bug`) do **not** mutate Bugzilla directly. They record an intended action into the run's `summary.json` for a human reviewer (or a downstream apply step) to enact. Treat each recorded action as a final, irrevocable proposal.
+
+Before calling any action tool, state in your response:
+
+- **What** action you are recording and **why** (cite the specific rule)
+- **Your confidence**: high / medium / low
+
+Record exactly one `bugzilla_add_comment` with your fix plan. Only record a `bugzilla_update_bug` (e.g. keyword/severity) when confidence is **high** and a specific triage rule directs it. Never record `status: RESOLVED`.
+
+The `reasoning` parameter on every action tool is required and stored alongside the recorded action. Fill it properly.
+
+Always be **brief** and to the point. Developers have limited time. Do **not** record private comments — all developers on the bug need to see them.
+
+# Final message: structured plan
+
+After recording your comment, end your final message with a fenced ```json block carrying the structured plan, so it can be consumed programmatically. Use exactly these keys:
+
+```json
+{{
+  "summary": "one-line restatement of the bug",
+  "root_cause": "the likely cause, or null if undetermined",
+  "proposed_fix": "the approach a developer should take",
+  "target_files": ["path/one.js", "path/two.css"],
+  "confidence": "high | medium | low"
+}}
+```
+
+If you could not localize a root cause, set `root_cause` to null, keep `confidence` low, and have your comment ask the specific open questions that block triage.
+
+# Additional instructions for this run
+
+{extra_instructions}

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/prompts/system.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/prompts/system.md
@@ -32,6 +32,29 @@ Your working directory is the Firefox source repository. You have Read, Grep, Gl
 
 When you reference a cause or a fix target, cite concrete paths (and ideally functions/selectors), e.g. `browser/components/tabbrowser/content/tabgroup.js`.
 
+# Code-search & history tools
+
+Your local checkout is **shallow** (no git history), so for anything beyond the current file contents use these network-backed tools. They query Mozilla's live infrastructure and reflect mozilla-central tip (which may differ slightly from the checkout — prefer them for symbol search and history, and local Read/Grep for the exact checked-out bytes).
+
+**`searchfox` MCP tools — code navigation across the whole tree (your main localization aid):**
+
+**Prefer Searchfox over local `Grep` when tracing how a symbol/pref/state flows across files** — e.g. "where is `system.showWeatherOptIn` read, written, or defaulted?". Your local checkout is shallow, so `Grep` only sees the files already in it and will miss cross-directory definitions and usages. For behavioral / state-flow bugs especially, reach for `search_identifier` / `find_definition` **first**; use local `Read` mainly to read the exact bytes of a file Searchfox has already pointed you to. Don't settle for a single-file grep hit when the behavior plausibly spans modules.
+
+- `search_identifier(identifier, path_filter?)` — exact symbol/pref/attribute lookup. Best first move to find where something is declared and used. Far better than grep across this large JS codebase.
+- `search_text(query, path_filter?, regexp?)` — full-text/regex search; use for UI strings, error text, or CSS selectors quoted in the bug.
+- `find_definition(name, path_filter?)` — the source of a function/method/class definition.
+- `get_function_at_line(file_path, line)` — the enclosing function for a line (e.g. from a stack trace).
+- `get_blame(file_path, lines)` — the changeset that last modified each line (HASH/DATE/MESSAGE). Use to find the change — and thus the bug — that introduced a line.
+- `get_file(file_path, revision?)` — full file content, optionally at a past revision.
+
+**`mozilla_vcs` MCP tools — inspect a specific changeset (regression triage):**
+
+- When the bug is a **regression** — it has a `regressed_by` bug, or a comment names a regressor, or `get_blame` points you at a changeset — read what actually changed: `get_commit_info(node)` for metadata + changed files, then `get_commit_diff(node)` for the diff. Pinpoint the introducing change and propose a fix relative to it.
+- `file_history(path)` — recent changesets touching a file, for when a regression's cause is unknown.
+- A bug's `regressed_by` is a **bug number**, not a changeset; find the landing changeset (hg node) from that bug's comments, then pass it here.
+
+Use these to raise your confidence and precision — but you still cannot build or run, so do not claim the fix is verified.
+
 # Delegating to the investigator subagent
 
 You have one generic subagent type: `investigator`. It has the same read-only tools you do (source repo + bugzilla read tools). **You write its full instructions dynamically** each time you spawn it — there is no fixed investigator behaviour.

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/rules/README.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/rules/README.md
@@ -1,0 +1,16 @@
+# Triage rules
+
+Drop `.md` files in this directory. Each file is one ruleset (e.g.
+`frontend-triage.md`).
+
+The agent does **not** load everything automatically — it Globs this
+directory and Reads only the rulesets it judges relevant to the bug at
+hand. Name your files descriptively and start each one with a short
+paragraph explaining when it applies (e.g. "These rules apply to Firefox
+frontend defects with a video or steps-to-reproduce but no crash.").
+
+Rules are free-form prose. Be explicit about:
+
+- **When** the rule applies (which products/components/keywords/states)
+- **What** field changes or comments the agent should make
+- **What confidence threshold** is needed before acting

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/rules/frontend-triage.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/rules/frontend-triage.md
@@ -1,0 +1,50 @@
+# Frontend papercut triage
+
+These rules apply to **Firefox desktop frontend defects** — UI/UX papercuts in
+the browser chrome and built-in pages. Typical components: `Firefox :: Tabbed
+Browser`, `Firefox :: Tabbed Browser: Split View`, `Firefox :: New Tab Page`,
+`Firefox :: Address Bar`, `Firefox :: Menus`, `Firefox :: Toolbars and
+Customization`, `Firefox :: Sidebar`, `Firefox :: Theme`. These are usually
+documented with a **video or screenshot** and steps to reproduce, and are
+**not** crashes, hangs, or sanitizer reports.
+
+If the bug is a crash/assertion/sanitizer report, or is not a frontend bug, this
+ruleset does not apply — note that and stop.
+
+## What to produce
+
+1. **Localize the cause in the source.** Frontend code lives mostly under
+   `browser/`, `toolkit/`, and `devtools/`. Find the JS/JSM module, the CSS, the
+   XUL/HTML, and any relevant pref (often `modules/libpref/init/all.js`) that
+   governs the behaviour. Use the `investigator` subagent for deep searches.
+2. **Confirm the area is still live.** Check the referenced code/strings still
+   exist and aren't already changed by a recent commit. If the bug looks already
+   fixed (e.g. cannot reproduce on a newer version per comments, or the code path
+   was changed), say so in the comment and propose marking accordingly instead of
+   inventing a fix.
+3. **Write a fix plan**: root cause, the specific files/functions/selectors to
+   change, and the approach. Prefer a comprehensive fix at the right level over a
+   spot fix.
+
+## Comment
+
+Record a single brief comment (a few sentences) with: the suspected root cause,
+the target file(s), and the proposed approach. Cite concrete paths. Do not
+restate the whole bug. Do not claim the fix is verified — you did not run it.
+
+## Confidence and field changes
+
+- **High** (you found the specific code and the cause is clear): record the
+  plan comment. If a rule or convention clearly applies, you may also record a
+  `bugzilla_update_bug` for an obviously-correct field (e.g. adding a relevant
+  keyword). Do not change `status`/`resolution`.
+- **Medium** (plausible area, cause not pinned down): record the comment with
+  your best hypothesis and the open questions that would confirm it.
+- **Low** (could not localize): record a comment stating what you checked and
+  the specific information needed to proceed. Set `confidence` to low and
+  `root_cause` to null in the structured output.
+
+## Already-fixed / duplicate
+
+If the bug appears fixed by another change, name the likely bug/commit in the
+comment so a human can mark it properly. Do not propose a redundant fix.

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/rules/scoping.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/rules/scoping.md
@@ -7,7 +7,8 @@ fix plan) on bugs that aren't actionable frontend defects.
 ## Skip-or-flag (do not produce a fix plan)
 
 For these, record a brief comment stating why it's out of scope and set the structured
-output's `confidence` to `low` with `root_cause` = null. Do **not** invent a fix plan.
+output's `actionable` to `false`, `confidence` to `low`, and `root_cause` to null. Do
+**not** invent a fix plan.
 
 - **Not a defect.** `type` is `enhancement` or `task` — this agent triages defects
   (bugs in existing behavior), not feature work or chores.

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/rules/scoping.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/rules/scoping.md
@@ -1,0 +1,34 @@
+# Scoping — what to triage vs. skip
+
+This ruleset applies to **every** bug this agent receives. Apply it **first**, before
+the `frontend-triage` ruleset. Its job is to avoid spending a deep investigation (and a
+fix plan) on bugs that aren't actionable frontend defects.
+
+## Skip-or-flag (do not produce a fix plan)
+
+For these, record a brief comment stating why it's out of scope and set the structured
+output's `confidence` to `low` with `root_cause` = null. Do **not** invent a fix plan.
+
+- **Not a defect.** `type` is `enhancement` or `task` — this agent triages defects
+  (bugs in existing behavior), not feature work or chores.
+- **Tracking/meta bugs.** Keyword `meta`, or a summary like `[meta]`/`[tracking]` — these
+  coordinate other bugs and have no single fix.
+- **Intermittent / test-infrastructure failures.** Keywords `intermittent-failure`,
+  `intermittent-testcase`, `test-verify-fail`, or summaries that are CI/test failures
+  (e.g. `Intermittent <testfile> | ...`). These need test-infra expertise, not a UX fix.
+- **Already resolved or a developer already attached a fix.** State that and stop.
+
+## Flag, then proceed with care
+
+- **Accessibility** (keyword `access`, or component-tagged a11y). These are in-scope but
+  specialized — proceed, but note in the comment that a11y review is advisable and keep
+  confidence calibrated to how well you can localize without a11y-specific knowledge.
+
+## Proceed normally
+
+Everything else — a `defect` in a frontend component (Bookmarks & History, New Tab Page,
+Session Restore, Sidebar, Tabbed Browser: Split View / Tab Groups, Toolbars and
+Customization, …) without the skip signals above — is in scope. Continue to the
+`frontend-triage` ruleset.
+
+When in doubt about scope, prefer a short clarifying comment over a speculative fix plan.

--- a/agents/frontend-triage/pyproject.toml
+++ b/agents/frontend-triage/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "hackbot-agent-frontend-triage"
+version = "0.1.0"
+description = "Cloud Run Job image that runs the frontend-triage agent for hackbot-api"
+requires-python = ">=3.12"
+dependencies = [
+    "hackbot-runtime[claude-sdk]",
+    "agent-tools[bugzilla]",
+    "bugsy",
+    "claude-agent-sdk>=0.1.30",
+    "mcp>=1.0.0",
+    "starlette>=0.36.0",
+    "uvicorn>=0.27.0",
+]
+
+[tool.uv.sources]
+hackbot-runtime = { workspace = true }
+agent-tools = { workspace = true }
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["hackbot_agents"]

--- a/agents/frontend-triage/pyproject.toml
+++ b/agents/frontend-triage/pyproject.toml
@@ -5,7 +5,7 @@ description = "Cloud Run Job image that runs the frontend-triage agent for hackb
 requires-python = ">=3.12"
 dependencies = [
     "hackbot-runtime[claude-sdk]",
-    "agent-tools[bugzilla]",
+    "agent-tools[bugzilla,searchfox,vcs]",
     "bugsy",
     "claude-agent-sdk>=0.1.30",
     "mcp>=1.0.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ version: "3.8"
 include:
   - path: agents/bug-fix/compose.yml
   - path: agents/build-repair/compose.yml
+  - path: agents/frontend-triage/compose.yml
 
 services:
   bugbug-base:

--- a/libs/agent-tools/agent_tools/mozilla_vcs.py
+++ b/libs/agent-tools/agent_tools/mozilla_vcs.py
@@ -1,0 +1,154 @@
+"""Read-only Mozilla VCS tools backed by hg.mozilla.org (HGMO).
+
+Framework-neutral HTTP tools for inspecting changesets on Mozilla's Mercurial
+server. The primary use is reading the **diff** of a known regressor changeset to
+pinpoint what changed — something Searchfox blame alone does not provide. HGMO is
+public, so this holds no credentials. It issues plain HTTP GETs (no local clone),
+so it works regardless of how shallow the agent's checkout is. Failures surface as
+a structured :class:`~agent_tools.registry.ToolError`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Annotated
+
+import httpx
+from pydantic import Field
+
+from agent_tools.registry import ToolError, tool, tools_in
+
+
+@dataclass
+class MozillaVcsContext:
+    """Configuration for HGMO access (no credentials — HGMO is public)."""
+
+    base_url: str = "https://hg.mozilla.org"
+    default_repo: str = "mozilla-central"
+    user_agent: str = "bugbug-frontend-triage"
+    timeout: float = 30.0
+    # Cap diff size so a huge changeset can't blow up the agent's context.
+    max_diff_bytes: int = 60_000
+
+
+async def _get(ctx: MozillaVcsContext, path: str, *, as_json: bool):
+    url = f"{ctx.base_url}/{path}"
+    headers = {"User-Agent": ctx.user_agent}
+    try:
+        async with httpx.AsyncClient(
+            timeout=ctx.timeout, follow_redirects=True
+        ) as client:
+            resp = await client.get(url, headers=headers)
+    except httpx.HTTPError as e:
+        raise ToolError(
+            f"request failed: {e}",
+            payload={"error": "http_error", "url": url, "message": str(e)},
+        ) from e
+    if resp.status_code == 404:
+        raise ToolError(
+            "changeset or path not found",
+            payload={"error": "not_found", "url": url},
+        )
+    if resp.status_code >= 400:
+        raise ToolError(
+            f"HTTP {resp.status_code}",
+            payload={"error": "http_status", "status": resp.status_code, "url": url},
+        )
+    return resp.json() if as_json else resp.text
+
+
+@tool
+async def get_commit_info(
+    ctx: MozillaVcsContext,
+    node: Annotated[
+        str, Field(description="Changeset hash (hg node), e.g. '6b8a3f804789'.")
+    ],
+    repo: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Repo name; defaults to mozilla-central. Other common values: "
+                "'autoland', 'mozilla-unified'."
+            )
+        ),
+    ] = None,
+) -> dict:
+    """Return metadata for a changeset: author, date, description, parents, files.
+
+    Use this to understand a known regressor changeset (e.g. the landing of the bug
+    referenced in a bug's 'regressed_by' field) before reading its diff.
+    """
+    repo = repo or ctx.default_repo
+    data = await _get(ctx, f"{repo}/json-rev/{node}", as_json=True)
+    return {
+        "node": data.get("node"),
+        "repo": repo,
+        "author": data.get("user"),
+        "date": data.get("date"),
+        "pushdate": data.get("pushdate"),
+        "desc": data.get("desc"),
+        "parents": data.get("parents"),
+        "files": data.get("files"),
+    }
+
+
+@tool
+async def get_commit_diff(
+    ctx: MozillaVcsContext,
+    node: Annotated[str, Field(description="Changeset hash (hg node).")],
+    repo: Annotated[
+        str | None,
+        Field(description="Repo name; defaults to mozilla-central."),
+    ] = None,
+) -> dict:
+    """Return the unified diff (hg export) of a changeset.
+
+    The key tool for regression triage: read exactly what a regressor changeset
+    changed so you can localize the fix precisely. Large diffs are truncated (see
+    the 'truncated' flag); narrow with a follow-up if needed.
+    """
+    repo = repo or ctx.default_repo
+    text = await _get(ctx, f"{repo}/raw-rev/{node}", as_json=False)
+    raw = text.encode("utf-8")
+    truncated = len(raw) > ctx.max_diff_bytes
+    if truncated:
+        text = raw[: ctx.max_diff_bytes].decode("utf-8", "ignore")
+    return {"node": node, "repo": repo, "truncated": truncated, "diff": text}
+
+
+@tool
+async def file_history(
+    ctx: MozillaVcsContext,
+    path: Annotated[str, Field(description="Repo-relative file path.")],
+    repo: Annotated[
+        str | None,
+        Field(description="Repo name; defaults to mozilla-central."),
+    ] = None,
+    limit: Annotated[int, Field(description="Max changesets to return.")] = 20,
+) -> dict:
+    """Return recent changesets that modified a file (newest first).
+
+    Useful when a bug is a regression but its 'regressed_by' field is empty: scan
+    the recent history of the suspected file to find a likely introducing change.
+    """
+    repo = repo or ctx.default_repo
+    data = await _get(ctx, f"{repo}/json-log/tip/{path}", as_json=True)
+    entries = data.get("entries", []) if isinstance(data, dict) else []
+    changesets = [
+        {
+            "node": e.get("node"),
+            "date": e.get("date"),
+            "author": e.get("user"),
+            "desc": (e.get("desc") or "").splitlines()[0] if e.get("desc") else "",
+        }
+        for e in entries[:limit]
+    ]
+    return {
+        "repo": repo,
+        "path": path,
+        "count": len(changesets),
+        "changesets": changesets,
+    }
+
+
+TOOLS = tools_in(__name__)

--- a/libs/agent-tools/agent_tools/searchfox.py
+++ b/libs/agent-tools/agent_tools/searchfox.py
@@ -77,12 +77,15 @@ async def search_text(
         str, Field(description="Text or regular expression to search for.")
     ],
     path_filter: Annotated[
-        str | None, Field(description="Optional path prefix, e.g. 'browser/components'.")
+        str | None,
+        Field(description="Optional path prefix, e.g. 'browser/components'."),
     ] = None,
     regexp: Annotated[
         bool, Field(description="Treat the query as a regular expression.")
     ] = False,
-    case_sensitive: Annotated[bool, Field(description="Case-sensitive matching.")] = False,
+    case_sensitive: Annotated[
+        bool, Field(description="Case-sensitive matching.")
+    ] = False,
     limit: Annotated[int, Field(description="Max results.")] = 50,
 ) -> str:
     """Full-text / regex search across mozilla-central.
@@ -169,8 +172,7 @@ async def get_blame(
     if not results:
         return "No blame information found."
     return "\n".join(
-        f"{line}: {hash_} ({date}) {message}"
-        for line, hash_, message, date in results
+        f"{line}: {hash_} ({date}) {message}" for line, hash_, message, date in results
     )
 
 

--- a/libs/agent-tools/agent_tools/searchfox.py
+++ b/libs/agent-tools/agent_tools/searchfox.py
@@ -1,0 +1,195 @@
+"""Read-only Searchfox code-search tools for Firefox (mozilla-central).
+
+Framework-neutral: each tool is a ``@tool``-decorated handler whose first
+parameter is a :class:`SearchfoxContext`. Backed by the standalone ``searchfox``
+client (the ``searchfox`` optional extra) — this module deliberately does NOT
+import the ``bugbug`` package, so it stays light enough to ship in an agent
+image. Network/request failures surface as a structured
+:class:`~agent_tools.registry.ToolError`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Annotated
+
+from pydantic import Field
+from searchfox import (
+    AsyncSearchfoxClient,
+    SearchfoxNetworkError,
+    SearchfoxRequestError,
+)
+
+from agent_tools.registry import ToolError, tool, tools_in
+
+
+@dataclass
+class SearchfoxContext:
+    """Holds a shared async Searchfox client (one connection pool per run)."""
+
+    client: AsyncSearchfoxClient
+
+
+def _sf_error(e: Exception, what: str) -> ToolError:
+    """Render a searchfox client failure as a structured, machine-parseable error."""
+    return ToolError(
+        f"{what}: {e}",
+        payload={"error": "searchfox_error", "what": what, "message": str(e)},
+    )
+
+
+def _fmt_hits(results) -> str:
+    """Format ``(path, line, content)`` search hits into one line each."""
+    if not results:
+        return "No results found."
+    return "\n".join(f"{path}:{line}: {content}" for path, line, content in results)
+
+
+@tool
+async def search_identifier(
+    ctx: SearchfoxContext,
+    identifier: Annotated[
+        str,
+        Field(description="Exact identifier/symbol to find, e.g. 'showWeatherOptIn'."),
+    ],
+    path_filter: Annotated[
+        str | None,
+        Field(description="Optional path prefix, e.g. 'browser/components/newtab'."),
+    ] = None,
+    limit: Annotated[int, Field(description="Max results.")] = 50,
+) -> str:
+    """Search for an exact identifier across mozilla-central.
+
+    Best first step for localizing where a symbol (pref name, function, variable,
+    DOM attribute, CSS class) is declared and used. Returns 'path:line: content'.
+    """
+    try:
+        results = await ctx.client.search(id=identifier, path=path_filter, limit=limit)
+    except (SearchfoxNetworkError, SearchfoxRequestError) as e:
+        raise _sf_error(e, "identifier search failed") from e
+    return _fmt_hits(results)
+
+
+@tool
+async def search_text(
+    ctx: SearchfoxContext,
+    query: Annotated[
+        str, Field(description="Text or regular expression to search for.")
+    ],
+    path_filter: Annotated[
+        str | None, Field(description="Optional path prefix, e.g. 'browser/components'.")
+    ] = None,
+    regexp: Annotated[
+        bool, Field(description="Treat the query as a regular expression.")
+    ] = False,
+    case_sensitive: Annotated[bool, Field(description="Case-sensitive matching.")] = False,
+    limit: Annotated[int, Field(description="Max results.")] = 50,
+) -> str:
+    """Full-text / regex search across mozilla-central.
+
+    Use for strings the user/bug quotes (UI labels, error text, CSS selectors).
+    Returns 'path:line: content' entries.
+    """
+    try:
+        results = await ctx.client.search(
+            query=query,
+            path=path_filter,
+            regexp=regexp,
+            case=case_sensitive,
+            limit=limit,
+        )
+    except (SearchfoxNetworkError, SearchfoxRequestError) as e:
+        raise _sf_error(e, "text search failed") from e
+    return _fmt_hits(results)
+
+
+@tool
+async def find_definition(
+    ctx: SearchfoxContext,
+    name: Annotated[
+        str,
+        Field(
+            description=(
+                "Symbol name (function/method/class), partial (e.g. 'WeatherFeed') "
+                "or fully-qualified (e.g. 'WeatherFeed.checkOptInRegion')."
+            )
+        ),
+    ],
+    path_filter: Annotated[
+        str | None, Field(description="Optional path prefix to disambiguate.")
+    ] = None,
+) -> str:
+    """Return the source of a symbol's definition."""
+    try:
+        return await ctx.client.get_definition(name, path_filter)
+    except (SearchfoxNetworkError, SearchfoxRequestError) as e:
+        raise _sf_error(e, "definition lookup failed") from e
+
+
+@tool
+async def get_function_at_line(
+    ctx: SearchfoxContext,
+    file_path: Annotated[
+        str,
+        Field(
+            description=(
+                "Repo-relative path, e.g. "
+                "'browser/components/newtab/lib/WeatherFeed.sys.mjs'."
+            )
+        ),
+    ],
+    line: Annotated[int, Field(description="1-based line number inside the function.")],
+) -> str:
+    """Return the source of the innermost function enclosing a given line.
+
+    Useful when you have a line number (e.g. from a stack trace or blame) and want
+    the full enclosing function without knowing its name.
+    """
+    try:
+        return await ctx.client.get_function_at_line(file_path, line)
+    except (SearchfoxNetworkError, SearchfoxRequestError) as e:
+        raise _sf_error(e, "function lookup failed") from e
+
+
+@tool
+async def get_blame(
+    ctx: SearchfoxContext,
+    file_path: Annotated[str, Field(description="Repo-relative path.")],
+    lines: Annotated[list[int], Field(description="1-based line numbers to look up.")],
+) -> str:
+    """Return the changeset that last modified each given line.
+
+    Format: 'LINE: HASH (DATE) MESSAGE'. Use this to find the change (and thus the
+    bug) that introduced a line — e.g. to confirm a suspected regressor.
+    """
+    try:
+        results = await ctx.client.get_blame_for_lines(file_path, lines)
+    except (SearchfoxNetworkError, SearchfoxRequestError) as e:
+        raise _sf_error(e, "blame fetch failed") from e
+    if not results:
+        return "No blame information found."
+    return "\n".join(
+        f"{line}: {hash_} ({date}) {message}"
+        for line, hash_, message, date in results
+    )
+
+
+@tool
+async def get_file(
+    ctx: SearchfoxContext,
+    file_path: Annotated[str, Field(description="Repo-relative path.")],
+    revision: Annotated[
+        str | None,
+        Field(description="Optional hg revision/node; omit for the current tip."),
+    ] = None,
+) -> str:
+    """Return the full content of a file (at HEAD, or at a specific revision)."""
+    try:
+        if revision:
+            return await ctx.client.get_file_at_revision(file_path, revision)
+        return await ctx.client.get_file(file_path)
+    except (SearchfoxNetworkError, SearchfoxRequestError) as e:
+        raise _sf_error(e, "file fetch failed") from e
+
+
+TOOLS = tools_in(__name__)

--- a/libs/agent-tools/pyproject.toml
+++ b/libs/agent-tools/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
 bugzilla = ["bugsy"]
 firefox = ["grizzly-framework", "prefpicker"]
 claude-sdk = ["claude-agent-sdk>=0.1.30"]
+searchfox = ["searchfox>=0.16.0"]
+vcs = ["httpx"]
 
 [build-system]
 requires = ["hatchling"]

--- a/services/hackbot-api/app/agents.py
+++ b/services/hackbot-api/app/agents.py
@@ -4,7 +4,12 @@ from dataclasses import dataclass
 
 from pydantic import BaseModel
 
-from app.schemas import AutowebcompatReproInputs, BugFixInputs, BuildRepairInputs
+from app.schemas import (
+    AutowebcompatReproInputs,
+    BugFixInputs,
+    BuildRepairInputs,
+    FrontendTriageInputs,
+)
 
 
 @dataclass(frozen=True)
@@ -62,5 +67,11 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
         description="Analyze a Firefox build failure at a specific commit and produce a candidate fix patch.",
         job_name="hackbot-agent-build-repair",
         input_schema=BuildRepairInputs,
+    ),
+    "frontend-triage": AgentSpec(
+        name="frontend-triage",
+        description="Triage a Firefox desktop frontend bug (read-only) and produce a root-cause analysis and proposed fix plan.",
+        job_name="hackbot-agent-frontend-triage",
+        input_schema=FrontendTriageInputs,
     ),
 }

--- a/services/hackbot-api/app/schemas.py
+++ b/services/hackbot-api/app/schemas.py
@@ -90,3 +90,10 @@ class BuildRepairInputs(BaseModel):
     run_try_push: bool = False
     model: str | None = None
     max_turns: int | None = None
+
+
+class FrontendTriageInputs(BaseModel):
+    bug_id: int
+    model: str | None = None
+    max_turns: int | None = None
+    effort: str | None = None

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,7 @@ members = [
     "hackbot-agent-autowebcompat-repro",
     "hackbot-agent-bug-fix",
     "hackbot-agent-build-repair",
+    "hackbot-agent-frontend-triage",
     "hackbot-api",
     "hackbot-runtime",
     "reviewhelper-api",
@@ -70,16 +71,24 @@ firefox = [
     { name = "grizzly-framework" },
     { name = "prefpicker" },
 ]
+searchfox = [
+    { name = "searchfox" },
+]
+vcs = [
+    { name = "httpx" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "bugsy", marker = "extra == 'bugzilla'" },
     { name = "claude-agent-sdk", marker = "extra == 'claude-sdk'", specifier = ">=0.1.30" },
     { name = "grizzly-framework", marker = "extra == 'firefox'" },
+    { name = "httpx", marker = "extra == 'vcs'" },
     { name = "prefpicker", marker = "extra == 'firefox'" },
     { name = "pydantic", specifier = ">=2.6.0" },
+    { name = "searchfox", marker = "extra == 'searchfox'", specifier = ">=0.16.0" },
 ]
-provides-extras = ["bugzilla", "firefox", "claude-sdk"]
+provides-extras = ["bugzilla", "firefox", "claude-sdk", "searchfox", "vcs"]
 
 [[package]]
 name = "aiofile"
@@ -2481,6 +2490,31 @@ requires-dist = [
     { name = "weave", marker = "extra == 'eval'" },
 ]
 provides-extras = ["eval"]
+
+[[package]]
+name = "hackbot-agent-frontend-triage"
+version = "0.1.0"
+source = { editable = "agents/frontend-triage" }
+dependencies = [
+    { name = "agent-tools", extra = ["bugzilla", "searchfox", "vcs"] },
+    { name = "bugsy" },
+    { name = "claude-agent-sdk" },
+    { name = "hackbot-runtime", extra = ["claude-sdk"] },
+    { name = "mcp" },
+    { name = "starlette" },
+    { name = "uvicorn" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "agent-tools", extras = ["bugzilla", "searchfox", "vcs"], editable = "libs/agent-tools" },
+    { name = "bugsy" },
+    { name = "claude-agent-sdk", specifier = ">=0.1.30" },
+    { name = "hackbot-runtime", extras = ["claude-sdk"], editable = "libs/hackbot-runtime" },
+    { name = "mcp", specifier = ">=1.0.0" },
+    { name = "starlette", specifier = ">=0.36.0" },
+    { name = "uvicorn", specifier = ">=0.27.0" },
+]
 
 [[package]]
 name = "hackbot-api"


### PR DESCRIPTION
This tool will help users with triaging bugs, providing root cause analysis and a natural language description of a proposed fix if possible.