### PR TITLE
Add frontend-triage agent to hackbot-ui TriggerForm

### DIFF
--- a/services/hackbot-ui/components/TriggerForm.tsx
+++ b/services/hackbot-ui/components/TriggerForm.tsx
@@ -10,6 +10,7 @@ const AGENTS = [
   { value: "bug-fix", label: "bug-fix" },
   { value: "autowebcompat-repro", label: "autowebcompat-repro" },
   { value: "build-repair", label: "build-repair" },
+  { value: "frontend-triage", label: "frontend-triage" },
 ] as const;
 
 type AgentValue = (typeof AGENTS)[number]["value"];


### PR DESCRIPTION
The frontend-triage agent (#6254) was registered in hackbot-api but was not selectable in the demo UI, since the agent dropdown is a hardcoded list. Add it to the AGENTS array. Its inputs (required bug_id, optional model/max_turns/effort) match FrontendTriageInputs and are handled by the form's default (bug-id) branch, so no additional logic is needed.