### PR TITLE
Add missing 'six' runtime dependency for bugzilla extra option

### DIFF
--- a/libs/agent-tools/pyproject.toml
+++ b/libs/agent-tools/pyproject.toml
@@ -8,7 +8,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-bugzilla = ["bugsy"]
+bugzilla = [
+    "bugsy",
+    # Workaround: bugsy imports six at runtime but doesn't declare it as a
+    # dependency (its setup.py only lists requests).
+    "six",
+]
 firefox = ["grizzly-framework", "prefpicker"]
 claude-sdk = ["claude-agent-sdk>=0.1.30"]
 searchfox = ["searchfox>=0.16.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -64,6 +64,7 @@ dependencies = [
 [package.optional-dependencies]
 bugzilla = [
     { name = "bugsy" },
+    { name = "six" },
 ]
 claude-sdk = [
     { name = "claude-agent-sdk" },
@@ -88,6 +89,7 @@ requires-dist = [
     { name = "prefpicker", marker = "extra == 'firefox'" },
     { name = "pydantic", specifier = ">=2.6.0" },
     { name = "searchfox", marker = "extra == 'searchfox'", specifier = ">=0.16.0" },
+    { name = "six", marker = "extra == 'bugzilla'" },
 ]
 provides-extras = ["bugzilla", "firefox", "claude-sdk", "searchfox", "vcs"]
 


### PR DESCRIPTION
Fixes #6273 