### PR TITLE
Run libs/ test suites in CI via a new libs_tests_task

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -133,6 +133,30 @@ tasks:
 
         - $mergeDeep:
             - { $eval: default_task_definition }
+            - taskId: { $eval: as_slugid("libs_tests_task") }
+              workerType: compute-smaller
+              payload:
+                env:
+                  CODECOV_TOKEN: 66162f89-a4d9-420c-84bd-d10f12a428d9
+                command:
+                  - "/bin/bash"
+                  - "-cx"
+                  - "git clone --quiet ${repository} &&
+                    cd bugbug &&
+                    git -c advice.detachedHead=false checkout ${head_rev} &&
+                    export COVERAGE_FILE=$(pwd)/.coverage &&
+                    cd libs/agent-tools &&
+                    uv run --locked --with pytest==9.1.0 --with pytest-cov==7.1.0 --with pytest-asyncio==1.4.0 --extra bugzilla --extra firefox --extra claude-sdk pytest --cov=agent_tools --cov-append tests/ &&
+                    cd ../hackbot-runtime &&
+                    uv run --locked --with pytest==9.1.0 --with pytest-cov==7.1.0 --with pytest-asyncio==1.4.0 --extra claude-sdk pytest --cov=hackbot_runtime --cov-append tests/ &&
+                    cd ../.. &&
+                    bash <(curl -s https://codecov.io/bash)"
+              metadata:
+                name: bugbug libs tests
+                description: bugbug libs tests
+
+        - $mergeDeep:
+            - { $eval: default_task_definition }
             - taskId: { $eval: as_slugid("packaging_test_task") }
               payload:
                 env:
@@ -247,6 +271,7 @@ tasks:
                   - { $eval: as_slugid("lint_task") }
                   - { $eval: as_slugid("tests_task") }
                   - { $eval: as_slugid("http_tests_task") }
+                  - { $eval: as_slugid("libs_tests_task") }
                   - { $eval: as_slugid("frontend_build") }
                   - { $eval: as_slugid("packaging_test_task") }
                   - { $eval: as_slugid("version_check_task") }
@@ -278,6 +303,7 @@ tasks:
                   - { $eval: as_slugid("version_check_task") }
                   - { $eval: as_slugid("tests_task") }
                   - { $eval: as_slugid("http_tests_task") }
+                  - { $eval: as_slugid("libs_tests_task") }
                   - { $eval: as_slugid("frontend_build") }
                   - { $eval: as_slugid("packaging_test_task") }
                 scopes:


### PR DESCRIPTION
CI only runs the top-level tests/ and http_service/tests/ suites, so the tests under libs/agent-tools/tests/ and libs/hackbot-runtime/tests/ never run on PRs. This adds a lightweight compute-smaller Taskcluster task that syncs just those two workspace members with their required extras, injects the pinned pytest tooling via `uv run --with`, runs both suites into a single combined coverage file, and uploads to codecov. The new task is added to the PyPI-release and docker-push dependency lists so a libs test failure blocks tagged releases like the existing test tasks do.