### PR TITLE
Add CODEOWNERS with team mappings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+*                                    @mozilla/bugbug-leads
+
+# Code owners for specific Hackbot agents
+/agents/frontend-triage/             @mozilla/hackbot-frontend
+/agents/autowebcompat-repro/         @mozilla/hackbot-webcompat


### PR DESCRIPTION
Introduce a new .github/CODEOWNERS file to assign default and path-specific code owners. Sets @mozilla/bugbug-leads as the default owner and adds specific owners for Hackbot agents.