### PR TITLE
Analyze all commits from the push in build repair

### DIFF
--- a/agents/build-repair/README.md
+++ b/agents/build-repair/README.md
@@ -12,9 +12,11 @@ It also optionally bootstraps Firefox build if needed.
 
 ## Input
 
-- `BUG_ID` - Optional Bugzilla bug ID
-- `GIT_COMMIT` - Firefox Git commit that failed the build
-- `FAILURE_TASKS` - a dictionary of failed Taskcluster tasks {task_name: taskcluster_task_id}
+- `FAILURE_TASKS` - a dictionary of failed Taskcluster tasks {task_name: taskcluster_task_id}.
+  The agent resolves the push from them: the failure commit (checked out) plus the other
+  commits in the push, and blames the one that introduced the failure.
+- `GIT_COMMIT` - Optional override for the failure commit (skips the hg->git lookup).
+- `BUG_ID` - Optional Bugzilla bug id.
 
 ## Output
 
@@ -23,17 +25,19 @@ First stage - analysis:
 - `summary.md` - a quick summary for a developer
 - `analysis.md` - detailed analysis
 - `planning.md` - intermediate file that outlines fixing steps for the second stage
+- `blame.json` - the commit that introduced the failure (`blamed_commit`, `reason`); written
+  only when the push has more than one commit
 
 Second stage - fixing:
 
 - A patch in Hackbot format
 
+The result reports `blamed_commit` so the caller can attribute the failure to a developer.
+
 ## Test the agent
 
 ```sh
-BUG_ID=1987675 GIT_COMMIT=5477e3882d4e18f93de9f56b31e90533fd23b0d1 \
-FAILURE_TASKS='{"build-linux":"XyU4b_BIRdO_IeK6z_kcQg"}' \
-  docker compose up build-repair-agent --build
+FAILURE_TASKS='{"build-linux":"XyU4b_BIRdO_IeK6z_kcQg"}' docker compose up build-repair-agent --build
 ```
 
 Artifacts are written to `~/hackbot/artifacts/`.

--- a/agents/build-repair/evals/eval.py
+++ b/agents/build-repair/evals/eval.py
@@ -120,7 +120,7 @@ class BuildRepairModel(weave.Model):
                 source_repo=worktree_path,
                 fx_ctx=fx_ctx,
                 bug_id=bug_id,
-                git_commit=failure_commit,
+                git_commits=gh_failure_commits,
                 failure_tasks={f["task_name"]: f["task_id"] for f in failures},
                 run_try_push=not self.no_try_push,
             )

--- a/agents/build-repair/hackbot.toml
+++ b/agents/build-repair/hackbot.toml
@@ -1,7 +1,7 @@
 [source]
 repo_url = "https://github.com/mozilla-firefox/firefox.git"
 checkout_path = "/workspace/firefox"
-# The failure commit is supplied per run via SOURCE_REF (from the git_commit input).
+# The failure commit is supplied per run via SOURCE_REF (resolved from a failure task).
 
 [firefox]
 enabled = true

--- a/agents/build-repair/hackbot_agents/build_repair/__main__.py
+++ b/agents/build-repair/hackbot_agents/build_repair/__main__.py
@@ -4,26 +4,39 @@ from hackbot_runtime import HackbotContext, run_async
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from .agent import BuildRepairResult, run_build_repair
+from .resolve import resolve_git_commits
 
 
 class AgentInputs(BaseSettings):
-    bug_id: int | None = None
-    git_commit: str
     failure_tasks: dict[str, str]
+    git_commit: str | None = None
+    bug_id: int | None = None
     bugzilla_mcp_url: str
     run_try_push: bool = False
     model: str | None = None
     max_turns: int | None = None
 
-    model_config = SettingsConfigDict(extra="ignore")
+    # Compose passes unset per-run inputs as empty strings (``${BUG_ID:-}``);
+    # treat those as absent so optional fields fall back to their defaults.
+    model_config = SettingsConfigDict(extra="ignore", env_ignore_empty=True)
 
 
 async def main(ctx: HackbotContext) -> BuildRepairResult:
     inputs = AgentInputs()
 
-    # The build failure lives at this commit; pin the checkout there before the
-    # runtime prepares the source tree (consumed in HackbotContext.source_repo).
-    os.environ.setdefault("SOURCE_REF", inputs.git_commit)
+    if not inputs.failure_tasks:
+        raise ValueError("failure_tasks must contain at least one task")
+    # Resolve the push commits from any of the failing tasks (all share a push).
+    # The first is the failure commit the tree is checked out at; the rest let
+    # the agent blame the culprit.
+    task_id = next(iter(inputs.failure_tasks.values()))
+    git_commits = resolve_git_commits(task_id, inputs.git_commit)
+
+    # Pin the checkout to the failure commit and fetch deep enough to include the
+    # whole push, so the agent can `git show` every commit in it. Both are read
+    # when the runtime prepares the source tree (HackbotContext.source_repo).
+    os.environ.setdefault("SOURCE_REF", git_commits[0])
+    os.environ.setdefault("SOURCE_DEPTH", str(len(git_commits) + 1))
 
     return await run_build_repair(
         bugzilla_mcp_server={
@@ -33,7 +46,7 @@ async def main(ctx: HackbotContext) -> BuildRepairResult:
         source_repo=ctx.source_repo,
         fx_ctx=ctx.firefox,
         bug_id=inputs.bug_id,
-        git_commit=inputs.git_commit,
+        git_commits=git_commits,
         failure_tasks=inputs.failure_tasks,
         run_try_push=inputs.run_try_push,
         model=inputs.model,

--- a/agents/build-repair/hackbot_agents/build_repair/agent.py
+++ b/agents/build-repair/hackbot_agents/build_repair/agent.py
@@ -50,9 +50,12 @@ from .config import (
 )
 from .prompts import (
     ANALYSIS_TEMPLATE,
+    BLAME_STEP,
     BUG_ANALYSIS_STEP,
     BUG_CONTEXT,
     FIX_TEMPLATE,
+    PUSH_COMMIT_LINE,
+    PUSH_CONTEXT,
     TRY_PUSH_INSTRUCTIONS,
 )
 
@@ -68,6 +71,9 @@ class BuildRepairResult(HackbotAgentResult):
     try_build_passed: bool | None = None
     lando_job_id: str | None = None
     treeherder_url: str | None = None
+    # Which commit in the push introduced the failure. Equals ``git_commit`` when
+    # the push has a single commit; chosen by the agent otherwise.
+    blamed_commit: str | None = None
 
 
 def _result_text(block: ToolResultBlock) -> str:
@@ -136,7 +142,7 @@ async def run_build_repair(
     source_repo: Path,
     fx_ctx: FirefoxContext,
     bug_id: int | None = None,
-    git_commit: str,
+    git_commits: list[str],
     failure_tasks: dict[str, str],
     run_try_push: bool = False,
     model: str | None = None,
@@ -150,8 +156,11 @@ async def run_build_repair(
     Returns a :class:`BuildRepairResult`; raises :class:`AgentError` if a stage
     ends in an error or produces no result.
     """
-    label = f"bug {bug_id}" if bug_id is not None else f"commit {git_commit[:12]}"
-    print(f"[build_repair] repairing {label} at {git_commit}", file=sys.stderr)
+    if not git_commits:
+        raise AgentError("git_commits must contain at least one commit")
+    failure_commit = git_commits[0]
+    label = f"bug {bug_id}" if bug_id is not None else f"commit {failure_commit[:12]}"
+    print(f"[build_repair] repairing {label} at {failure_commit}", file=sys.stderr)
 
     scratch_dir = Path(tempfile.mkdtemp(prefix=f"build-repair-{bug_id or 'nobug'}-"))
     scratch_in = scratch_dir / "in"
@@ -182,7 +191,9 @@ async def run_build_repair(
     task_name = next(iter(failure_tasks), "")
     analysis_prompt = ANALYSIS_TEMPLATE.format(
         target_software=TARGET_SOFTWARE,
-        git_commit=git_commit,
+        git_commit=failure_commit,
+        push_context=_push_context(git_commits),
+        blame_step=_blame_step(git_commits, scratch_out),
         failure_logs=failure_logs,
         scratch_out=scratch_out,
         bug_context=BUG_CONTEXT.format(bug_id=bug_id) if bug_id is not None else "",
@@ -248,16 +259,18 @@ async def run_build_repair(
 
     build_result = captured.get(BUILD_TOOL)
     try_result = captured.get(TRY_PUSH_TOOL, {})
+    blamed_commit = _resolve_blame(scratch_out, git_commits)
 
     return BuildRepairResult(
         bug_id=bug_id,
-        git_commit=git_commit,
+        git_commit=failure_commit,
         summary=summary,
         analysis=analysis,
         local_build_verified=build_result.get("success") if build_result else None,
         try_build_passed=try_result.get("try_build_passed"),
         lando_job_id=try_result.get("lando_job_id"),
         treeherder_url=try_result.get("treeherder_url"),
+        blamed_commit=blamed_commit,
         num_turns=total_turns,
         total_cost_usd=total_cost,
     )
@@ -324,3 +337,52 @@ def _read_doc(
     if publish_file is not None:
         publish_file(f"{key}.md", path, "text/markdown")
     return path.read_text()
+
+
+def _push_context(git_commits: list[str]) -> str:
+    """List the push commits for the analysis prompt, or "" for a single commit."""
+    if len(git_commits) <= 1:
+        return ""
+    commit_lines = "\n".join(PUSH_COMMIT_LINE.format(commit=c) for c in git_commits)
+    return PUSH_CONTEXT.format(commit_lines=commit_lines)
+
+
+def _blame_step(git_commits: list[str], scratch_out: Path) -> str:
+    """The blame.json instruction, only when the push has more than one commit."""
+    if len(git_commits) <= 1:
+        return ""
+    return BLAME_STEP.format(scratch_out=scratch_out)
+
+
+def _match_commit(sha: str | None, git_commits: list[str]) -> str | None:
+    """Match a (possibly abbreviated) git sha against the push commits."""
+    if not sha:
+        return None
+    for c in git_commits:
+        if c.startswith(sha) or sha.startswith(c):
+            return c
+    return None
+
+
+def _resolve_blame(scratch_out: Path, git_commits: list[str]) -> str | None:
+    """Return the commit the agent blamed for the failure.
+
+    Single-commit pushes are trivially blamed on that commit. Otherwise the agent
+    records its choice in ``blame.json``; we normalize it to a full hash from
+    ``git_commits`` and fall back to the failure commit when the file is missing
+    or unparsable.
+    """
+    if not git_commits:
+        return None
+    failure_commit = git_commits[0]
+    if len(git_commits) == 1:
+        return failure_commit
+
+    blamed: str | None = None
+    path = scratch_out / "blame.json"
+    if path.exists():
+        try:
+            blamed = (json.loads(path.read_text()).get("blamed_commit") or "").strip()
+        except (ValueError, OSError):
+            blamed = None
+    return _match_commit(blamed, git_commits) or failure_commit

--- a/agents/build-repair/hackbot_agents/build_repair/prompts.py
+++ b/agents/build-repair/hackbot_agents/build_repair/prompts.py
@@ -7,22 +7,37 @@
 
 ANALYSIS_TEMPLATE = """You are an expert {target_software} engineer tasked with analyzing and fixing a build failure.
 
-Investigate why commit {git_commit} broke the {target_software} build. The source tree
+Investigate why the {target_software} build broke at commit {git_commit}. The source tree
 is already checked out at that commit (your working directory).
-{bug_context}
+{push_context}{bug_context}
 Analyze the following:
 1. The git diff of commit {git_commit} (use `git show {git_commit}`).
 {bug_step}{logs_num}. The Taskcluster build failure logs. Each failing task has a sanitized log (only the ERROR -/FATAL - lines) and the full log. Start from the sanitized log -- it usually pinpoints the failing file and line. The full log can be tens of thousands of lines, so grep it for that file/line rather than reading it sequentially:
 {failure_logs}
 
-Create three separate documents:
+Create these documents:
 1. {scratch_out}/analysis.md with your detailed analysis of what caused the failure
 2. {scratch_out}/planning.md with a fixing plan
 3. {scratch_out}/summary.md with a brief one-paragraph summary of the analysis and plan
    that can point a developer in the right direction
-
+{blame_step}
 Do not prompt to edit those documents. Do not write any code yet. Work fully
 autonomously and do not ask any questions.
+"""
+
+PUSH_CONTEXT = """
+This commit landed in the same push as the commits below. Any of them may have
+introduced the failure -- the checked-out commit is not necessarily the culprit:
+{commit_lines}
+Inspect each commit (`git show <commit>`) and correlate with the failure logs to
+determine which single commit introduced the build failure.
+"""
+
+PUSH_COMMIT_LINE = "- {commit}"
+
+BLAME_STEP = """4. {scratch_out}/blame.json identifying the single commit that introduced the failure,
+   as JSON: {{"blamed_commit": "<full git sha>", "reason": "<one sentence>"}}. Choose
+   blamed_commit from the push commits listed above.
 """
 
 BUG_CONTEXT = "\nThe commit attempted to fix Bugzilla bug {bug_id}.\n"

--- a/agents/build-repair/hackbot_agents/build_repair/resolve.py
+++ b/agents/build-repair/hackbot_agents/build_repair/resolve.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Resolve a Taskcluster build-failure task into the commits to repair.
+
+Given a failing build task id, look up its push: the failure (head) commit the
+tree is checked out at, plus the other commits that landed in the same push so
+the agent can blame the one that broke the build. Uses the same public
+Taskcluster / lando / pushlog lookups the pulse listener does, so the agent
+derives the commits itself from a task id.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+_TC_TASK_URL = "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/{task_id}"
+_LANDO_HG2GIT = "https://lando.moz.tools/api/hg2git/firefox/{rev}"
+_HG_BASE = "https://hg.mozilla.org"
+# Taskcluster ``project`` tag -> hg pushlog repository path. Unknown projects
+# fall back to a same-named repo under the hg base url.
+_REPO_PATHS = {
+    "autoland": "integration/autoland",
+    "mozilla-central": "mozilla-central",
+    "mozilla-beta": "releases/mozilla-beta",
+    "mozilla-release": "releases/mozilla-release",
+    "try": "try",
+}
+_HEADERS = {"User-Agent": "hackbot-build-repair/1.0"}
+_TIMEOUT = 30
+
+
+def _get_json(url: str) -> dict:
+    resp = requests.get(url, headers=_HEADERS, timeout=_TIMEOUT)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _hg_to_git(rev: str) -> str:
+    return _get_json(_LANDO_HG2GIT.format(rev=rev))["git_hash"]
+
+
+def _push_git_commits(project: str, rev: str) -> list[str]:
+    """Git hashes of the push that landed ``rev`` (pushlog order, oldest first).
+
+    The pushlog exposes a ``git_changesets`` array parallel to ``changesets``;
+    when a git hash is missing we map that changeset via lando.
+    """
+    path = _REPO_PATHS.get(project, project)
+    url = f"{_HG_BASE}/{path}/json-pushes?changeset={rev}&full=1&version=2"
+    pushes = _get_json(url).get("pushes") or {}
+    push = next(iter(pushes.values()), None)
+    if not push:
+        return []
+    git_changesets = push.get("git_changesets") or []
+    changesets = push.get("changesets") or []
+    commits = []
+    for i, cs in enumerate(changesets):
+        git_commit = git_changesets[i] if i < len(git_changesets) else None
+        if not git_commit:
+            node = cs.get("node") if isinstance(cs, dict) else cs
+            git_commit = _hg_to_git(node) if node else None
+        if git_commit:
+            commits.append(git_commit)
+    return commits
+
+
+def resolve_git_commits(task_id: str, git_commit: str | None = None) -> list[str]:
+    """Resolve a failing task into its push commits, failure commit first.
+
+    ``git_commit`` overrides the failure commit (skipping the lando lookup); the
+    task is still fetched for its revision. Raises on network errors or when the
+    failure commit cannot be determined.
+    """
+    task = _get_json(_TC_TASK_URL.format(task_id=task_id))
+    tags = task.get("tags") or {}
+    project = tags.get("project")
+    hg_rev = (task.get("payload") or {}).get("env", {}).get("GECKO_HEAD_REV")
+
+    push = _push_git_commits(project, hg_rev) if hg_rev and project else []
+
+    failure_commit = git_commit
+    if not failure_commit:
+        if not hg_rev:
+            raise ValueError(
+                f"task {task_id} has no GECKO_HEAD_REV and no git_commit override"
+            )
+        failure_commit = _hg_to_git(hg_rev)
+
+    return [failure_commit] + [c for c in push if c != failure_commit]

--- a/libs/hackbot-runtime/hackbot_runtime/context.py
+++ b/libs/hackbot-runtime/hackbot_runtime/context.py
@@ -113,7 +113,9 @@ class HackbotContext(BaseSettings):
         env_path = os.environ.get("SOURCE_REPO")
         path = Path(env_path) if env_path else self._config.source.checkout_path
         ref = os.environ.get("SOURCE_REF") or self._config.source.ref
-        ensure_source_repo(path, self._config.source.repo_url, ref)
+        depth_env = os.environ.get("SOURCE_DEPTH")
+        depth = int(depth_env) if depth_env else None
+        ensure_source_repo(path, self._config.source.repo_url, ref, depth)
         # Record where the agent starts editing, so publish_changes() can later
         # diff the final tree against it. Best-effort: a failure here must not
         # break the agent's access to source — it only disables change capture.

--- a/libs/hackbot-runtime/hackbot_runtime/source.py
+++ b/libs/hackbot-runtime/hackbot_runtime/source.py
@@ -11,7 +11,7 @@ log = logging.getLogger("hackbot_runtime.source")
 
 
 def ensure_source_repo(
-    source_repo: Path, repo_url: str, ref: str | None = None
+    source_repo: Path, repo_url: str, ref: str | None = None, depth: int | None = None
 ) -> None:
     """Ensure a shallow checkout of ``repo_url`` exists at ``source_repo``.
 
@@ -29,8 +29,12 @@ def ensure_source_repo(
     fetch_target = ref if ref else "HEAD"
     # A pinned commit needs its parent too so the commit's own diff can be
     # computed (e.g. `git show <commit>`); depth=1 would fetch only the commit
-    # itself with no parent to diff against.
-    depth = "--depth=2" if ref else "--depth=1"
+    # itself with no parent to diff against. An explicit ``depth`` (e.g. to cover
+    # every commit in a push so each is showable) overrides the default.
+    if depth is not None:
+        depth_flag = f"--depth={depth}"
+    else:
+        depth_flag = "--depth=2" if ref else "--depth=1"
     git_dir = source_repo / ".git"
     if git_dir.exists():
         # An earlier run killed mid-fetch (e.g. the container was stopped)
@@ -66,7 +70,7 @@ def ensure_source_repo(
                 "-C",
                 str(source_repo),
                 "fetch",
-                depth,
+                depth_flag,
                 "origin",
                 fetch_target,
             ],
@@ -99,7 +103,7 @@ def ensure_source_repo(
             stderr=sys.stderr,
         )
         subprocess.run(
-            ["git", "-C", str(source_repo), "fetch", depth, "origin", ref],
+            ["git", "-C", str(source_repo), "fetch", depth_flag, "origin", ref],
             check=True,
             stdout=sys.stderr,
             stderr=sys.stderr,

--- a/libs/hackbot-runtime/tests/test_context.py
+++ b/libs/hackbot-runtime/tests/test_context.py
@@ -39,8 +39,10 @@ def test_firefox_disabled_raises(tmp_path):
 def test_source_repo_prepares_and_honors_env_override(tmp_path, monkeypatch):
     calls = []
 
-    def fake_ensure(path: Path, repo_url: str, ref: str | None = None) -> None:
-        calls.append((path, repo_url, ref))
+    def fake_ensure(
+        path: Path, repo_url: str, ref: str | None = None, depth: int | None = None
+    ) -> None:
+        calls.append((path, repo_url, ref, depth))
 
     monkeypatch.setattr("hackbot_runtime.context.ensure_source_repo", fake_ensure)
     monkeypatch.setenv("SOURCE_REPO", str(tmp_path / "from-env"))
@@ -55,14 +57,16 @@ def test_source_repo_prepares_and_honors_env_override(tmp_path, monkeypatch):
     hb = _hb(tmp_path, cfg)
 
     assert hb.source_repo == tmp_path / "from-env"
-    assert calls == [(tmp_path / "from-env", "https://example.com/r.git", None)]
+    assert calls == [(tmp_path / "from-env", "https://example.com/r.git", None, None)]
 
 
 def test_source_repo_honors_source_ref_env(tmp_path, monkeypatch):
     calls = []
 
-    def fake_ensure(path: Path, repo_url: str, ref: str | None = None) -> None:
-        calls.append((path, repo_url, ref))
+    def fake_ensure(
+        path: Path, repo_url: str, ref: str | None = None, depth: int | None = None
+    ) -> None:
+        calls.append((path, repo_url, ref, depth))
 
     monkeypatch.setattr("hackbot_runtime.context.ensure_source_repo", fake_ensure)
     monkeypatch.delenv("SOURCE_REPO", raising=False)
@@ -74,7 +78,7 @@ def test_source_repo_honors_source_ref_env(tmp_path, monkeypatch):
     hb = _hb(tmp_path, cfg)
 
     assert hb.source_repo == Path("/from/toml")
-    assert calls == [(Path("/from/toml"), "r", "deadbeef")]
+    assert calls == [(Path("/from/toml"), "r", "deadbeef", None)]
 
 
 def test_source_repo_uses_toml_path_without_env(tmp_path, monkeypatch):

--- a/libs/hackbot-runtime/tests/test_source.py
+++ b/libs/hackbot-runtime/tests/test_source.py
@@ -92,3 +92,23 @@ def test_pinned_ref_includes_parent_for_diff(tmp_path):
     )
     assert "hello" in show.stdout
     assert "world" in show.stdout
+
+
+def test_depth_reaches_older_push_ancestors(tmp_path):
+    remote = tmp_path / "remote"
+    _make_remote(remote)
+    (remote / "README.md").write_text("second")
+    _commit(remote, "second")
+    (remote / "README.md").write_text("third")
+    third = _commit(remote, "third")
+    dest = tmp_path / "dest"
+    # depth=3 fetches the whole 3-commit chain, so the root commit is present and
+    # showable -- a depth=2 fetch (the default for a pinned ref) would not reach it.
+    ensure_source_repo(dest, f"file://{remote}", ref=third, depth=3)
+    count = subprocess.run(
+        ["git", "-C", str(dest), "rev-list", "--count", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert int(count.stdout.strip()) == 3

--- a/services/hackbot-api/app/schemas.py
+++ b/services/hackbot-api/app/schemas.py
@@ -97,9 +97,11 @@ class AutowebcompatReproInputs(BaseModel):
 
 
 class BuildRepairInputs(BaseModel):
-    bug_id: int | None = None
-    git_commit: str
+    # Failing Taskcluster build tasks {task_name: task_id}; the agent resolves the
+    # push commits from them. git_commit / bug_id are optional overrides.
     failure_tasks: dict[str, str]
+    git_commit: str | None = None
+    bug_id: int | None = None
     run_try_push: bool = False
     model: str | None = None
     max_turns: int | None = None


### PR DESCRIPTION
- make Task ID the only required input
- resolve the push commits by task ID in the agent deterministically
- prompt the agent to do root cause analysis and output the blamed commit (will be later used by pulse listener to notify the author)
- keep compatible with current evals (optional git_commits and bug_id)

Part 1 of #6316. It should be deployed first; then we can test Part 2 (the pulse listener)

[Trace of the tested example](https://wandb.ai/moz-bugbug/hackbot-test/weave/agents?convTurn=1&chatTrace=69891a0aaaa61edd8c12661e1594dbe5&dashConv=1a6b795b-6b15-4547-b700-6c6e551145be)