### PR TITLE
Increase recursion limit for code review agent

### DIFF
--- a/bugbug/tools/code_review/agent.py
+++ b/bugbug/tools/code_review/agent.py
@@ -247,7 +247,7 @@ class CodeReviewTool(GenerativeModelTool):
                 },
                 context=CodeReviewContext(patch=patch),
                 stream_mode="values",
-                config={"recursion_limit": 100},
+                config={"recursion_limit": 500},
             ):
                 result = chunk
         except GraphRecursionError as e:


### PR DESCRIPTION
Another measure to fix #6323

Raise the generative model's recursion_limit from 100 to 500 in the code review tool configuration to allow deeper graph traversal during analysis and reduce premature GraphRecursionError.