### PR TITLE
Set recursion limit for the scope agent

### DIFF
--- a/bugbug/tools/code_review/agent.py
+++ b/bugbug/tools/code_review/agent.py
@@ -267,7 +267,9 @@ class CodeReviewTool(GenerativeModelTool):
             patch=format_patch_set(patch.patch_set),
             patch_summary=patch_summary,
         )
-        result = await self.scope_agent.ainvoke({"messages": [HumanMessage(prompt)]})
+        result = await self.scope_agent.ainvoke(
+            {"messages": [HumanMessage(prompt)]}, config={"recursion_limit": 100}
+        )
         return result["structured_response"].comments[:1]
 
     async def run(self, patch: Patch) -> CodeReviewToolResponse:


### PR DESCRIPTION
Fixes #6323

Pass a config with recursion_limit=100 to the scope agent, which increases the limit from the default 25 turns to 100 turns.
