### PR TITLE
Do not require bug ID on docker compose up

### DIFF
--- a/agents/bug-fix/compose.yml
+++ b/agents/bug-fix/compose.yml
@@ -17,7 +17,7 @@ services:
       target: agent
     environment:
       - RUN_ID
-      - BUG_ID=${BUG_ID:?error}
+      - BUG_ID=${BUG_ID:-}
       - BUGZILLA_MCP_URL=http://bug-fix-broker:8765/mcp
       - SOURCE_REPO=/workspace/firefox
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:?error}

--- a/agents/frontend-triage/compose.yml
+++ b/agents/frontend-triage/compose.yml
@@ -17,7 +17,7 @@ services:
       target: agent
     environment:
       - RUN_ID
-      - BUG_ID=${BUG_ID:?error}
+      - BUG_ID=${BUG_ID:-}
       - BUGZILLA_MCP_URL=http://frontend-triage-broker:8765/mcp
       - SOURCE_REPO=/workspace/firefox
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:?error}


### PR DESCRIPTION
This fails other agents that don't require `BUG_ID` when running from a root compose that nicely loads `.env`.
```
FAILURE_TASKS='{"build-linux":"GFjLPsWwRDiMhtFprcwyGQ"}' docker compose up build-repair-agent --build
```