### PR TITLE
Update CODEOWNERS to @mozilla/ai4dev

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-*                                    @mozilla/bugbug-leads
+*                                    @mozilla/ai4dev
 
 # Code owners for specific Hackbot agents
 /agents/frontend-triage/             @mozilla/hackbot-frontend


### PR DESCRIPTION
Replace the global CODEOWNERS entry from @mozilla/bugbug-leads to @mozilla/ai4dev.