### PR TITLE
Fix Phabricator URL action references

### DIFF
--- a/libs/hackbot-runtime/hackbot_runtime/actions/handlers/phabricator_handler.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/handlers/phabricator_handler.py
@@ -275,11 +275,11 @@ class SubmitPatchHandler:
             log.exception("Failed to submit Phabricator diff for bug %s", bug_id)
             return ActionResult.failed(str(exc))
 
+        revision_url = _revision_url(new_revision_id) if new_revision_id else None
         return ActionResult.ok(
             {
                 "revision_id": new_revision_id,
-                "revision_url": (
-                    _revision_url(new_revision_id) if new_revision_id else None
-                ),
+                "revision_url": revision_url,
+                "url": revision_url,
             }
         )

--- a/libs/hackbot-runtime/tests/test_phabricator_handler.py
+++ b/libs/hackbot-runtime/tests/test_phabricator_handler.py
@@ -76,6 +76,7 @@ async def test_submit_patch_create_wip_by_default(monkeypatch):
     assert result.result == {
         "revision_id": 555,
         "revision_url": "https://phabricator.services.mozilla.com/D555",
+        "url": "https://phabricator.services.mozilla.com/D555",
     }
 
     creatediff_call = next(c for c in calls if c[0] == "differential.creatediff")


### PR DESCRIPTION
## Summary

- expose the canonical `url` field in successful Phabricator submission results
- retain `revision_url` for compatibility with existing consumers
- cover the documented action-reference contract in the handler test

## Rationale

The `phabricator.submit_patch` action tells agents to reference a submitted revision with `{{actions.<ref>.url}}`. The apply handler returned only `revision_url`, so the placeholder resolver could not find `url` and left the literal reference in Bugzilla comments. Returning the documented alias makes those references resolvable without breaking consumers of `revision_url`.

Fixes #6330.

## Test plan

- [x] Confirmed the updated handler assertion fails before the source change
- [x] `python -m pytest libs/hackbot-runtime/tests/test_phabricator_handler.py libs/hackbot-runtime/tests/test_phabricator_actions.py -q` (18 passed)
- [x] `python -m ruff check` and `python -m ruff format --check` on the changed Python files
- [x] `python -m compileall -q libs/hackbot-runtime/hackbot_runtime/actions/handlers/phabricator_handler.py`
