### PR TITLE
Change the Friendly view in Hackbot UI for the Test Plan Generator Agent 

### DIFF
--- a/services/hackbot-ui/app/globals.css
+++ b/services/hackbot-ui/app/globals.css
@@ -527,3 +527,109 @@ ul.chips li.chip {
   background: rgba(210, 153, 42, 0.16);
   color: var(--amber);
 }
+
+/* Purpose-built test-plan findings view. */
+.test-plan-section {
+  margin-bottom: 24px;
+}
+.test-plan-label {
+  margin: 0 0 10px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.test-plan-feature {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+.test-case-list {
+  margin: 0;
+  padding-left: 32px;
+}
+.test-case {
+  padding: 4px 0 24px 8px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 24px;
+}
+.test-case:last-child {
+  margin-bottom: 0;
+}
+.test-case::marker {
+  font-size: 18px;
+  font-weight: 700;
+}
+.test-case-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+.test-case-heading h3 {
+  margin: 0;
+  font-size: 18px;
+  line-height: 1.35;
+}
+.test-case h4,
+.test-plan-summary h4 {
+  margin: 0 0 10px;
+  font-size: 14px;
+}
+.test-case-preconditions {
+  margin-bottom: 20px;
+}
+.test-case-reason {
+  padding: 10px 12px;
+  border-left: 3px solid var(--border);
+  border-radius: 4px;
+  margin: -8px 0 20px;
+  font-size: 13px;
+}
+.test-case-reason.test-failed {
+  background: rgba(229, 83, 75, 0.1);
+  border-left-color: var(--red);
+}
+.test-case-reason.test-unsuitable {
+  background: rgba(210, 153, 42, 0.1);
+  border-left-color: var(--amber);
+}
+.test-case-reason strong {
+  display: block;
+  margin-bottom: 4px;
+}
+.test-case-reason p {
+  margin: 0;
+}
+.test-case-preconditions p,
+.test-plan-summary p {
+  margin: 0;
+}
+.test-step-list {
+  margin: 0;
+  padding-left: 28px;
+}
+.test-step-list li {
+  padding-left: 6px;
+  margin-bottom: 10px;
+}
+.test-step-list li:last-child {
+  margin-bottom: 0;
+}
+.badge.test-passed {
+  background: rgba(46, 160, 67, 0.18);
+  color: var(--green);
+}
+.badge.test-failed {
+  background: rgba(229, 83, 75, 0.18);
+  color: var(--red);
+}
+.badge.test-unsuitable {
+  background: rgba(210, 153, 42, 0.16);
+  color: var(--amber);
+}
+.test-plan-summary {
+  margin-top: 24px;
+}

--- a/services/hackbot-ui/components/FindingsView.tsx
+++ b/services/hackbot-ui/components/FindingsView.tsx
@@ -9,8 +9,9 @@ import {
   titleize,
 } from "@/lib/findings-format";
 import { Markdown } from "./Markdown";
+import { parseTestPlan, TestPlanView } from "./TestPlanView";
 
-type ViewMode = "friendly" | "raw";
+type ViewMode = "test-plan" | "friendly" | "raw";
 
 const BUGZILLA_URL = "https://bugzilla.mozilla.org/show_bug.cgi?id=";
 const MAX_DEPTH = 6;
@@ -162,8 +163,12 @@ export function FindingsView({
 }: {
   findings: Record<string, unknown>;
 }) {
-  // Default to the friendly, readable view; raw JSON is opt-in.
-  const [mode, setMode] = useState<ViewMode>("friendly");
+  const testPlan = parseTestPlan(findings);
+  // Structured test plans get a purpose built default view; all findings can
+  // still be inspected through the generic friendly and raw JSON views.
+  const [mode, setMode] = useState<ViewMode>(
+    testPlan ? "test-plan" : "friendly"
+  );
   return (
     <div className="panel">
       <div className="panel-head">
@@ -187,9 +192,22 @@ export function FindingsView({
           >
             Friendly
           </button>
+          {testPlan && (
+            <button
+              type="button"
+              role="tab"
+              aria-selected={mode === "test-plan"}
+              className={mode === "test-plan" ? "active" : ""}
+              onClick={() => setMode("test-plan")}
+            >
+              Test Plan
+            </button>
+          )}
         </div>
       </div>
-      {mode === "friendly" ? (
+      {mode === "test-plan" && testPlan ? (
+        <TestPlanView testPlan={testPlan} />
+      ) : mode === "friendly" ? (
         <FriendlyFindings findings={findings} />
       ) : (
         <pre className="log">{JSON.stringify(findings, null, 2)}</pre>

--- a/services/hackbot-ui/components/FindingsView.tsx
+++ b/services/hackbot-ui/components/FindingsView.tsx
@@ -11,7 +11,7 @@ import {
 import { Markdown } from "./Markdown";
 import { parseTestPlan, TestPlanView } from "./TestPlanView";
 
-type ViewMode = "test-plan" | "friendly" | "raw";
+type ViewMode = "friendly" | "raw";
 
 const BUGZILLA_URL = "https://bugzilla.mozilla.org/show_bug.cgi?id=";
 const MAX_DEPTH = 6;
@@ -160,15 +160,16 @@ function FriendlyFindings({ findings }: { findings: Record<string, unknown> }) {
 
 export function FindingsView({
   findings,
+  agent,
 }: {
   findings: Record<string, unknown>;
+  agent: string;
 }) {
-  const testPlan = parseTestPlan(findings);
-  // Structured test plans get a purpose built default view; all findings can
-  // still be inspected through the generic friendly and raw JSON views.
-  const [mode, setMode] = useState<ViewMode>(
-    testPlan ? "test-plan" : "friendly"
-  );
+  const testPlan =
+    agent === "test-plan-generator" ? parseTestPlan(findings) : null;
+
+  // Default to the friendly, readable view; raw JSON is opt-in.
+  const [mode, setMode] = useState<ViewMode>("friendly");
   return (
     <div className="panel">
       <div className="panel-head">
@@ -192,23 +193,14 @@ export function FindingsView({
           >
             Friendly
           </button>
-          {testPlan && (
-            <button
-              type="button"
-              role="tab"
-              aria-selected={mode === "test-plan"}
-              className={mode === "test-plan" ? "active" : ""}
-              onClick={() => setMode("test-plan")}
-            >
-              Test Plan
-            </button>
-          )}
         </div>
       </div>
-      {mode === "test-plan" && testPlan ? (
-        <TestPlanView testPlan={testPlan} />
-      ) : mode === "friendly" ? (
-        <FriendlyFindings findings={findings} />
+      {mode === "friendly" ? (
+        testPlan ? (
+          <TestPlanView testPlan={testPlan} />
+        ) : (
+          <FriendlyFindings findings={findings} />
+        )
       ) : (
         <pre className="log">{JSON.stringify(findings, null, 2)}</pre>
       )}

--- a/services/hackbot-ui/components/RunDetail.tsx
+++ b/services/hackbot-ui/components/RunDetail.tsx
@@ -202,7 +202,7 @@ export function RunDetail({ runId }: { runId: string }) {
         </div>
       )}
 
-      {hasFindings && <FindingsView findings={findings} />}
+      {hasFindings && <FindingsView findings={findings} agent={run.agent} />}
 
       {actions && actions.length > 0 && (
         <div className="panel">

--- a/services/hackbot-ui/components/TestPlanView.tsx
+++ b/services/hackbot-ui/components/TestPlanView.tsx
@@ -1,0 +1,148 @@
+import { isPlainObject, isStringArray } from "@/lib/findings-format";
+
+type TestCaseStatus = "passed" | "failed" | "unsuitable";
+
+interface GeneratedTestCase {
+  id: number;
+  title: string;
+  preconditions: string | null;
+  steps: string[];
+}
+
+interface TestCaseResult {
+  id: number;
+  status: TestCaseStatus;
+  summary: string;
+  failureReason: string | null;
+}
+
+export interface TestPlan {
+  feature: string;
+  generatedTestCases: GeneratedTestCase[];
+  results: TestCaseResult[];
+  summary: string;
+}
+
+function isStatus(value: unknown): value is TestCaseStatus {
+  return value === "passed" || value === "failed" || value === "unsuitable";
+}
+
+export function parseTestPlan(
+  findings: Record<string, unknown>
+): TestPlan | null {
+  const result = findings.result;
+  if (!isPlainObject(result) || !Array.isArray(result.generated_test_cases)) {
+    return null;
+  }
+
+  const generatedTestCases: GeneratedTestCase[] = [];
+  for (const value of result.generated_test_cases) {
+    if (
+      !isPlainObject(value) ||
+      typeof value.id !== "number" ||
+      typeof value.title !== "string" ||
+      !Array.isArray(value.steps) ||
+      !isStringArray(value.steps)
+    ) {
+      return null;
+    }
+    generatedTestCases.push({
+      id: value.id,
+      title: value.title,
+      preconditions:
+        typeof value.preconditions === "string" ? value.preconditions : null,
+      steps: value.steps,
+    });
+  }
+
+  const results: TestCaseResult[] = [];
+  if (Array.isArray(result.results)) {
+    for (const value of result.results) {
+      if (
+        isPlainObject(value) &&
+        typeof value.id === "number" &&
+        isStatus(value.status)
+      ) {
+        results.push({
+          id: value.id,
+          status: value.status,
+          summary: typeof value.summary === "string" ? value.summary : "",
+          failureReason:
+            typeof value.failure_reason === "string"
+              ? value.failure_reason
+              : null,
+        });
+      }
+    }
+  }
+
+  return {
+    feature: typeof result.feature === "string" ? result.feature : "",
+    generatedTestCases,
+    results,
+    summary: typeof result.summary === "string" ? result.summary : "",
+  };
+}
+
+export function TestPlanView({ testPlan }: { testPlan: TestPlan }) {
+  const resultsById = new Map(
+    testPlan.results.map((result) => [result.id, result])
+  );
+
+  return (
+    <div className="test-plan">
+      {testPlan.feature && (
+        <section className="test-plan-section">
+          <h3 className="test-plan-label">Feature name</h3>
+          <p className="test-plan-feature">{testPlan.feature}</p>
+        </section>
+      )}
+      <h3 className="test-plan-label">Test cases</h3>
+      <ol className="test-case-list">
+        {testPlan.generatedTestCases.map((testCase) => {
+          const result = resultsById.get(testCase.id);
+          const failureReason =
+            result && result.status !== "passed"
+              ? result.failureReason || result.summary
+              : null;
+          return (
+            <li className="test-case" key={testCase.id} value={testCase.id}>
+              <div className="test-case-heading">
+                <h3>{testCase.title}</h3>
+                {result && (
+                  <span className={`badge test-${result.status}`}>
+                    {result.status}
+                  </span>
+                )}
+              </div>
+              {failureReason && (
+                <div className={`test-case-reason test-${result?.status}`}>
+                  <strong>Reason</strong>
+                  <p>{failureReason}</p>
+                </div>
+              )}
+              {testCase.preconditions && (
+                <div className="test-case-preconditions">
+                  <h4>Preconditions</h4>
+                  <p>{testCase.preconditions}</p>
+                </div>
+              )}
+              <h4>Test steps</h4>
+              <ol className="test-step-list">
+                {testCase.steps.map((step, index) => (
+                  <li key={index}>{step}</li>
+                ))}
+              </ol>
+            </li>
+          );
+        })}
+      </ol>
+      {testPlan.summary && (
+        <div className="test-plan-summary">
+          <h4>Summary</h4>
+          <p>{testPlan.summary}</p>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request changes the friendly view for the test-plan generator agent to a new, purpose built view for structured test plan findings in the UI. 

Ref: 
<img width="1075" height="525" alt="image" src="https://github.com/user-attachments/assets/1df8f274-7c79-413e-92d0-6c2664223e0a" />
