### PR TITLE
UI enhancements to Hackbot Launchpad

### DIFF
--- a/services/hackbot-api/app/routers/runs.py
+++ b/services/hackbot-api/app/routers/runs.py
@@ -109,9 +109,26 @@ async def create_run(
 @router.get("/runs", response_model=list[RunDoc])
 async def list_runs(
     limit: int = Query(default=50, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    agent: str | None = Query(default=None),
+    # Aliased so the query param is `status` without shadowing fastapi.status.
+    status_filter: RunStatus | None = Query(default=None, alias="status"),
     db: AsyncSession = Depends(get_db),
 ) -> list[RunDoc]:
-    result = await db.execute(select(Run).order_by(Run.created_at.desc()).limit(limit))
+    stmt = select(Run)
+    if agent is not None:
+        stmt = stmt.where(Run.agent == agent)
+    if status_filter is not None:
+        stmt = stmt.where(Run.status == status_filter.value)
+    # created_at is the sort key; run_id is a deterministic tiebreaker so offset
+    # paging is stable when timestamps collide. (agent/status/created_at are all
+    # indexed, so filtering + ordering stay index-backed.)
+    stmt = (
+        stmt.order_by(Run.created_at.desc(), Run.run_id.desc())
+        .offset(offset)
+        .limit(limit)
+    )
+    result = await db.execute(stmt)
     return [RunDoc.model_validate(r) for r in result.scalars()]
 
 

--- a/services/hackbot-api/tests/test_list_runs_api.py
+++ b/services/hackbot-api/tests/test_list_runs_api.py
@@ -1,5 +1,4 @@
-"""Tests for GET /runs listing: agent/status filtering, offset paging, ordering,
-and finalized_at exposure.
+"""Tests for GET /runs listing: filtering, offset paging, and ordering.
 
 Follows this suite's fake-DB style — the handler is called directly with a fake
 session that captures the SQLAlchemy statement, so we can assert the query it

--- a/services/hackbot-api/tests/test_list_runs_api.py
+++ b/services/hackbot-api/tests/test_list_runs_api.py
@@ -1,0 +1,93 @@
+"""Tests for GET /runs listing: agent/status filtering, offset paging, ordering,
+and finalized_at exposure.
+
+Follows this suite's fake-DB style — the handler is called directly with a fake
+session that captures the SQLAlchemy statement, so we can assert the query it
+builds (WHERE / ORDER BY / OFFSET) without a real Postgres.
+"""
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from app.routers import runs as runs_router
+from app.schemas import RunStatus
+from sqlalchemy.dialects import postgresql
+
+
+class _Result:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return self._rows
+
+
+class _CapturingDB:
+    """Records the statement passed to execute() and returns canned rows."""
+
+    def __init__(self, rows):
+        self._rows = rows
+        self.stmt = None
+
+    async def execute(self, stmt):
+        self.stmt = stmt
+        return _Result(self._rows)
+
+
+def _fake_run(**overrides):
+    base = dict(
+        run_id=uuid.uuid4(),
+        agent="frontend-triage",
+        status="succeeded",
+        inputs={"bug_id": 123},
+        created_at=datetime(2026, 7, 21, 12, 0, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 7, 21, 12, 5, tzinfo=timezone.utc),
+        execution_name=None,
+        results_prefix="results/abc/",
+        summary=None,
+        artifacts=[],
+        error=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _sql(stmt) -> str:
+    return str(stmt.compile(dialect=postgresql.dialect()))
+
+
+async def test_list_runs_default_orders_and_pages():
+    db = _CapturingDB([_fake_run()])
+    out = await runs_router.list_runs(
+        limit=50, offset=0, agent=None, status_filter=None, db=db
+    )
+    sql = _sql(db.stmt)
+    assert "FROM runs" in sql
+    assert "WHERE" not in sql  # no filters applied
+    assert "ORDER BY runs.created_at DESC" in sql
+    assert "runs.run_id DESC" in sql  # deterministic tiebreaker
+    assert "LIMIT" in sql
+    assert "OFFSET" in sql
+    assert len(out) == 1 and out[0].agent == "frontend-triage"
+
+
+async def test_list_runs_filters_by_agent_and_status():
+    db = _CapturingDB([])
+    await runs_router.list_runs(
+        limit=10, offset=20, agent="bug-fix", status_filter=RunStatus.failed, db=db
+    )
+    sql = _sql(db.stmt)
+    assert "runs.agent =" in sql
+    assert "runs.status =" in sql
+    assert "OFFSET" in sql
+
+
+async def test_list_runs_filters_by_agent_only():
+    db = _CapturingDB([])
+    await runs_router.list_runs(
+        limit=50, offset=0, agent="frontend-triage", status_filter=None, db=db
+    )
+    sql = _sql(db.stmt)
+    assert "runs.agent =" in sql
+    assert "runs.status =" not in sql

--- a/services/hackbot-ui/app/api/runs/route.ts
+++ b/services/hackbot-ui/app/api/runs/route.ts
@@ -5,17 +5,22 @@ import { getAuthedEmail } from "@/lib/session";
 
 export const dynamic = "force-dynamic";
 
-// GET /api/runs?limit=50
-// Returns the most recent runs from hackbot-api (no reconciliation).
+// GET /api/runs?limit=50&offset=0&agent=<name>&status=<status>
+// Returns a page of runs from hackbot-api (newest first), optionally filtered
+// by agent and/or status.
 export async function GET(req: NextRequest) {
   if (!(await getAuthedEmail())) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   try {
     const { searchParams } = new URL(req.url);
-    const raw = Number(searchParams.get("limit") ?? 50);
-    const limit = Number.isFinite(raw) && raw > 0 ? raw : 50;
-    const runs = await listRuns(limit);
+    const rawLimit = Number(searchParams.get("limit") ?? 50);
+    const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? rawLimit : 50;
+    const rawOffset = Number(searchParams.get("offset") ?? 0);
+    const offset = Number.isFinite(rawOffset) && rawOffset > 0 ? rawOffset : 0;
+    const agent = searchParams.get("agent") || undefined;
+    const status = searchParams.get("status") || undefined;
+    const runs = await listRuns({ limit, offset, agent, status });
     return NextResponse.json(runs);
   } catch (err) {
     const status = err instanceof HackbotError ? err.status : 500;

--- a/services/hackbot-ui/app/globals.css
+++ b/services/hackbot-ui/app/globals.css
@@ -172,6 +172,24 @@ button.secondary {
 table.runs {
   width: 100%;
   border-collapse: collapse;
+  /* Fixed layout keeps the columns from re-balancing (and the last column from
+     ballooning) when the visible rows change, e.g. when a filter is applied. */
+  table-layout: fixed;
+}
+table.runs th:nth-child(1) {
+  width: 12%;
+}
+table.runs th:nth-child(2) {
+  width: 22%;
+}
+table.runs th:nth-child(3) {
+  width: 28%;
+}
+table.runs th:nth-child(4) {
+  width: 14%;
+}
+table.runs th:nth-child(5) {
+  width: 24%;
 }
 table.runs th,
 table.runs td {
@@ -179,6 +197,7 @@ table.runs td {
   padding: 10px 8px;
   border-bottom: 1px solid var(--border);
   font-size: 14px;
+  overflow-wrap: anywhere;
 }
 table.runs th {
   color: var(--muted);
@@ -190,6 +209,71 @@ table.runs th {
 table.runs td.mono {
   font-family: var(--mono);
   font-size: 13px;
+}
+/* Wide runs table scrolls horizontally inside its panel on narrow screens,
+   so it never forces a page-level horizontal scrollbar. */
+.table-scroll {
+  overflow-x: auto;
+}
+
+/* Failed runs show their error on a full-width row beneath the run, so the
+   columns stay roomy and the message can wrap in full. */
+table.runs tr.has-error > td {
+  border-bottom: none;
+}
+table.runs tr.run-error-row > td {
+  padding-top: 2px;
+  padding-bottom: 12px;
+  white-space: normal;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+/* Clamp the error preview to a few lines so a huge message (e.g. a stack
+   trace) can't fill the page — the full text lives on the run's detail page.
+   A dim left accent marks it as an error without the loud red text. */
+.run-error-text {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  padding-left: 10px;
+  border-left: 2px solid rgba(229, 83, 75, 0.4);
+}
+.run-error-tag {
+  display: inline-block;
+  margin-right: 8px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+/* Recent-runs filter controls: sit on the right of the panel header, inline
+   with the "Recent runs" title and the Clear button. */
+.runs-filters {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.runs-filters select {
+  width: auto;
+  min-width: 150px;
+  padding: 6px 10px;
+  font-size: 13px;
+}
+.runs-filters button.secondary {
+  padding: 6px 12px;
+}
+
+/* "Load more" affordance under the runs table. */
+.runs-loadmore {
+  display: flex;
+  justify-content: center;
+  margin-top: 16px;
 }
 
 .muted {

--- a/services/hackbot-ui/app/globals.css
+++ b/services/hackbot-ui/app/globals.css
@@ -222,7 +222,7 @@ pre.log {
 
 dl.kv {
   display: grid;
-  grid-template-columns: 160px 1fr;
+  grid-template-columns: 160px minmax(0, 1fr);
   gap: 8px 16px;
   margin: 0;
 }
@@ -232,6 +232,7 @@ dl.kv dt {
 }
 dl.kv dd {
   margin: 0;
+  min-width: 0;
   font-family: var(--mono);
   font-size: 13px;
   word-break: break-word;
@@ -359,8 +360,30 @@ dl.kv dd {
 dl.kv.findings-kv > dt {
   padding-top: 2px;
 }
-dl.kv dd > dl.kv {
-  grid-template-columns: 140px 1fr;
+/* Nested key/value lists keep a normal label|value grid (a slightly narrower
+   label column than the top level). They have room because an object-valued
+   field renders as a full-width section rather than sitting in a value column
+   (see .kv-section-* below). */
+dl.kv dd > dl.kv,
+.finding-card > dl.kv {
+  grid-template-columns: 140px minmax(0, 1fr);
+}
+
+/* An object- or array-of-objects-valued field renders as a full-width titled
+   SECTION: the key becomes a heading spanning both columns, and its (often
+   large) contents flow beneath it using the whole panel width, indented with a
+   rule to show nesting — instead of being pushed into the narrow value column. */
+dl.kv > dt.kv-section-title {
+  grid-column: 1 / -1;
+  color: var(--text);
+  font-weight: 600;
+  padding-top: 6px;
+}
+dl.kv > dd.kv-section-body {
+  grid-column: 1 / -1;
+  margin-top: 4px;
+  padding-left: 12px;
+  border-left: 2px solid var(--border);
 }
 
 /* Long / multi-line string values, rendered as markdown */
@@ -491,18 +514,25 @@ ul.chips li.chip {
   border-radius: 6px;
   padding: 2px 8px;
   word-break: break-all;
+  overflow-wrap: anywhere;
 }
 
 /* Nested object / array-of-objects cards */
+.finding-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
 .finding-card {
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 12px 14px;
-  margin-bottom: 8px;
   background: var(--panel-2);
 }
-.finding-card:last-child {
-  margin-bottom: 0;
+/* Cards nested inside cards: tighter and one shade lighter to convey hierarchy. */
+.finding-card .finding-card {
+  padding: 10px 12px;
+  background: var(--panel);
 }
 .finding-card > .finding-index {
   font-size: 11px;

--- a/services/hackbot-ui/app/page.tsx
+++ b/services/hackbot-ui/app/page.tsx
@@ -14,8 +14,9 @@ export default function HomePage() {
       </div>
 
       <div className="panel">
-        <h2>Recent runs</h2>
-        <RecentRuns />
+        <Suspense fallback={<p className="muted">Loading…</p>}>
+          <RecentRuns />
+        </Suspense>
       </div>
     </>
   );

--- a/services/hackbot-ui/components/FindingsView.tsx
+++ b/services/hackbot-ui/components/FindingsView.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 
 import {
+  dropHoistedDuplicates,
   isPlainObject,
   isScalar,
   isStringArray,
@@ -42,7 +43,7 @@ function StringValue({ value }: { value: string }) {
   if (!trimmed.includes("\n") && trimmed.length <= INLINE_STRING_MAX) {
     return <span>{trimmed}</span>;
   }
-  return <Markdown text={value} />;
+  return <Markdown text={value} dropJsonBlocks />;
 }
 
 function StringChips({ items }: { items: string[] }) {
@@ -55,6 +56,23 @@ function StringChips({ items }: { items: string[] }) {
       ))}
     </ul>
   );
+}
+
+// A `[label, details]` pair (e.g. reproductions' `["nightly", {...}]`) reads
+// better as a card headed by the label than as a nested #1/#2 pair. Returns the
+// unpacked pair when `value` matches that shape, otherwise null.
+function asLabeledTuple(
+  value: unknown,
+): { label: string; body: Record<string, unknown> } | null {
+  if (
+    Array.isArray(value) &&
+    value.length === 2 &&
+    typeof value[0] === "string" &&
+    isPlainObject(value[1])
+  ) {
+    return { label: value[0], body: value[1] as Record<string, unknown> };
+  }
+  return null;
 }
 
 // Recursive dispatcher: narrows `unknown` at runtime and renders each value
@@ -98,13 +116,16 @@ function FindingValue({
       return <StringChips items={value.map((v) => String(v))} />;
     }
     return (
-      <div>
-        {value.map((item, i) => (
-          <div className="finding-card" key={i}>
-            <div className="finding-index">#{i + 1}</div>
-            <FindingValue value={item} depth={depth + 1} />
-          </div>
-        ))}
+      <div className="finding-cards">
+        {value.map((item, i) => {
+          const tuple = asLabeledTuple(item);
+          return (
+            <div className="finding-card" key={i}>
+              <div className="finding-index">{tuple ? tuple.label : `#${i + 1}`}</div>
+              <FindingValue value={tuple ? tuple.body : item} depth={depth + 1} />
+            </div>
+          );
+        })}
       </div>
     );
   }
@@ -125,6 +146,17 @@ function FindingValue({
   return <span>{String(value)}</span>;
 }
 
+// A value that renders as a large block (a nested object, or an array of
+// objects → cards) reads better as a full-width titled section than as a
+// label|value row. Scalars, text, and scalar/string arrays (chips) stay rows.
+function rendersAsBlock(value: unknown): boolean {
+  if (isPlainObject(value)) return Object.keys(value).length > 0;
+  if (Array.isArray(value)) {
+    return value.length > 0 && !isStringArray(value) && !value.every(isScalar);
+  }
+  return false;
+}
+
 function FindingRow({
   fieldKey,
   value,
@@ -134,10 +166,13 @@ function FindingRow({
   value: unknown;
   depth: number;
 }) {
+  const section = rendersAsBlock(value);
   return (
     <>
-      <dt>{titleize(fieldKey)}</dt>
-      <dd>
+      <dt className={section ? "kv-section-title" : undefined}>
+        {titleize(fieldKey)}
+      </dt>
+      <dd className={section ? "kv-section-body" : undefined}>
         <FindingValue value={value} fieldKey={fieldKey} depth={depth} />
       </dd>
     </>
@@ -145,7 +180,18 @@ function FindingRow({
 }
 
 function FriendlyFindings({ findings }: { findings: Record<string, unknown> }) {
-  const entries = Object.entries(findings);
+  // Drop hoisted duplicate text (e.g. autowebcompat-repro copies a
+  // reproduction's steps/summary onto `result`); the in-context copy is kept.
+  const deduped = dropHoistedDuplicates(findings);
+  let entries = Object.entries(deduped);
+  // When the agent emits a full `result` narrative (e.g. frontend-triage), it
+  // already leads with the summary, so the separate top-level `summary` field
+  // just repeats it — drop it. (Still visible via the JSON toggle.)
+  const hasNarrativeResult =
+    typeof deduped.result === "string" && deduped.result.trim().length > 0;
+  if (hasNarrativeResult) {
+    entries = entries.filter(([k]) => k !== "summary");
+  }
   if (entries.length === 0) {
     return <p className="muted">No findings.</p>;
   }

--- a/services/hackbot-ui/components/FindingsView.tsx
+++ b/services/hackbot-ui/components/FindingsView.tsx
@@ -62,7 +62,7 @@ function StringChips({ items }: { items: string[] }) {
 // better as a card headed by the label than as a nested #1/#2 pair. Returns the
 // unpacked pair when `value` matches that shape, otherwise null.
 function asLabeledTuple(
-  value: unknown,
+  value: unknown
 ): { label: string; body: Record<string, unknown> } | null {
   if (
     Array.isArray(value) &&
@@ -121,8 +121,13 @@ function FindingValue({
           const tuple = asLabeledTuple(item);
           return (
             <div className="finding-card" key={i}>
-              <div className="finding-index">{tuple ? tuple.label : `#${i + 1}`}</div>
-              <FindingValue value={tuple ? tuple.body : item} depth={depth + 1} />
+              <div className="finding-index">
+                {tuple ? tuple.label : `#${i + 1}`}
+              </div>
+              <FindingValue
+                value={tuple ? tuple.body : item}
+                depth={depth + 1}
+              />
             </div>
           );
         })}

--- a/services/hackbot-ui/components/Markdown.tsx
+++ b/services/hackbot-ui/components/Markdown.tsx
@@ -3,7 +3,7 @@
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 
-import { formatFence } from "@/lib/findings-format";
+import { formatFence, stripJsonFences } from "@/lib/findings-format";
 
 // Shared markdown renderer for finding text and proposed action previews.
 // Safe by construction: react-markdown does not render raw HTML and does not
@@ -38,11 +38,18 @@ const components: Components = {
   },
 };
 
-export function Markdown({ text }: { text: string }) {
+export function Markdown({
+  text,
+  dropJsonBlocks = false,
+}: {
+  text: string;
+  dropJsonBlocks?: boolean;
+}) {
+  const content = dropJsonBlocks ? stripJsonFences(text) : text;
   return (
     <div className="finding-text markdown-body">
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
-        {text}
+        {content}
       </ReactMarkdown>
     </div>
   );

--- a/services/hackbot-ui/components/RecentRuns.tsx
+++ b/services/hackbot-ui/components/RecentRuns.tsx
@@ -134,9 +134,9 @@ export function RecentRuns() {
                 ? prev.map((x) =>
                     x.run_id === r.run_id
                       ? { ...x, status: doc.status, error: doc.error }
-                      : x,
+                      : x
                   )
-                : prev,
+                : prev
             );
           }
         } catch {
@@ -156,7 +156,7 @@ export function RecentRuns() {
       const qs = params.toString();
       router.push(qs ? `${pathname}?${qs}` : pathname);
     },
-    [router, pathname, searchParams],
+    [router, pathname, searchParams]
   );
 
   const loadMore = useCallback(async () => {

--- a/services/hackbot-ui/components/RecentRuns.tsx
+++ b/services/hackbot-ui/components/RecentRuns.tsx
@@ -1,125 +1,298 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Fragment, useCallback, useEffect, useState } from "react";
 
-import { isTerminal } from "@/lib/types";
-import { loadRuns, type TrackedRun, updateRunStatus } from "@/lib/store";
+import { AGENT_NAMES } from "@/lib/agents";
+import { isTerminal, type RunDoc, type RunStatus } from "@/lib/types";
 import { StatusBadge } from "./StatusBadge";
 
-// Polls the status of any non-terminal tracked runs so the dashboard stays live.
+// Poll the status of any non-terminal, currently-loaded runs so the dashboard
+// stays live without a full reload.
 const POLL_MS = 5000;
+const PAGE_SIZE = 50;
+const COLS = 5;
 
+const STATUS_OPTIONS: RunStatus[] = [
+  "pending",
+  "running",
+  "succeeded",
+  "failed",
+  "timed_out",
+];
+
+// The subset of a run the table renders. Derived from RunDoc.
+interface RunRow {
+  run_id: string;
+  agent: string;
+  status: RunStatus;
+  label: string;
+  created_at: string;
+  error: string | null;
+}
+
+// Human-readable summary of a run's inputs, mirroring the label TriggerForm
+// saves at trigger time (see components/TriggerForm.tsx) so every run reads
+// well straight from the API.
 function labelFromInputs(inputs: Record<string, unknown>): string {
   if (typeof inputs.bug_id === "number") return `bug ${inputs.bug_id}`;
+  if (typeof inputs.git_commit === "string" && inputs.git_commit.trim()) {
+    return `commit ${inputs.git_commit.trim().slice(0, 12)}`;
+  }
+  if (typeof inputs.feature_name === "string" && inputs.feature_name.trim()) {
+    return inputs.feature_name.trim();
+  }
   return "inline report";
 }
 
-async function fetchRuns(): Promise<TrackedRun[]> {
-  const res = await fetch("/api/runs?limit=50");
-  if (!res.ok) return [];
-  const docs = (await res.json()) as Array<{
-    run_id: string;
-    agent: string;
-    status: TrackedRun["status"];
-    inputs: Record<string, unknown>;
-    created_at: string;
-  }>;
-  return docs.map((d) => ({
+function toRow(d: RunDoc): RunRow {
+  return {
     run_id: d.run_id,
     agent: d.agent,
     status: d.status,
     label: labelFromInputs(d.inputs),
     created_at: d.created_at,
-  }));
+    error: d.error,
+  };
 }
 
-function mergeRuns(
-  apiRuns: TrackedRun[],
-  localRuns: TrackedRun[]
-): TrackedRun[] {
-  const seen = new Set(apiRuns.map((r) => r.run_id));
-  const extras = localRuns.filter((r) => !seen.has(r.run_id));
-  return [...extras, ...apiRuns];
+function hasErrorDetail(r: RunRow): boolean {
+  return (r.status === "failed" || r.status === "timed_out") && !!r.error;
+}
+
+async function fetchPage(params: {
+  agent?: string;
+  status?: string;
+  offset: number;
+}): Promise<RunRow[] | null> {
+  const qs = new URLSearchParams({
+    limit: String(PAGE_SIZE),
+    offset: String(params.offset),
+  });
+  if (params.agent) qs.set("agent", params.agent);
+  if (params.status) qs.set("status", params.status);
+  const res = await fetch(`/api/runs?${qs.toString()}`);
+  if (!res.ok) return null;
+  const docs = (await res.json()) as RunDoc[];
+  return docs.map(toRow);
 }
 
 export function RecentRuns() {
-  const [runs, setRuns] = useState<TrackedRun[] | null>(null);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const agentFilter = searchParams.get("agent") ?? "";
+  const statusFilter = searchParams.get("status") ?? "";
 
+  const [runs, setRuns] = useState<RunRow[] | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  // (Re)load the first page whenever the filters change.
   useEffect(() => {
-    fetchRuns().then((apiRuns) => {
-      setRuns(mergeRuns(apiRuns, loadRuns()));
+    let cancelled = false;
+    setRuns(null);
+    setFailed(false);
+    fetchPage({
+      agent: agentFilter || undefined,
+      status: statusFilter || undefined,
+      offset: 0,
+    }).then((page) => {
+      if (cancelled) return;
+      if (page === null) {
+        setFailed(true);
+        setRuns([]);
+        setHasMore(false);
+        return;
+      }
+      setRuns(page);
+      setHasMore(page.length === PAGE_SIZE);
     });
-  }, []);
+    return () => {
+      cancelled = true;
+    };
+  }, [agentFilter, statusFilter]);
 
+  // Live-status polling for the loaded, non-terminal runs — updated in place so
+  // pagination/scroll position is preserved.
   useEffect(() => {
     if (!runs) return;
     const active = runs.filter((r) => !isTerminal(r.status));
     if (active.length === 0) return;
 
     const timer = setInterval(async () => {
-      let changed = false;
       for (const r of active) {
         try {
           const res = await fetch(`/api/runs/${r.run_id}`);
           if (!res.ok) continue;
-          const doc = await res.json();
-          if (doc.status && doc.status !== r.status) {
-            updateRunStatus(r.run_id, doc.status);
-            changed = true;
+          const doc = (await res.json()) as RunDoc;
+          if (doc.status !== r.status) {
+            setRuns((prev) =>
+              prev
+                ? prev.map((x) =>
+                    x.run_id === r.run_id
+                      ? { ...x, status: doc.status, error: doc.error }
+                      : x,
+                  )
+                : prev,
+            );
           }
         } catch {
-          // transient; try again next tick
+          // transient; retry next tick
         }
-      }
-      if (changed) {
-        fetchRuns().then((apiRuns) => {
-          setRuns(mergeRuns(apiRuns, loadRuns()));
-        });
       }
     }, POLL_MS);
 
     return () => clearInterval(timer);
   }, [runs]);
 
-  if (runs === null) {
-    return <p className="muted">Loading…</p>;
-  }
+  const setFilter = useCallback(
+    (key: "agent" | "status", value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value) params.set(key, value);
+      else params.delete(key);
+      const qs = params.toString();
+      router.push(qs ? `${pathname}?${qs}` : pathname);
+    },
+    [router, pathname, searchParams],
+  );
 
-  if (runs.length === 0) {
-    return (
-      <p className="muted">
-        No runs yet. Use the form above to trigger an agent.
-      </p>
-    );
-  }
+  const loadMore = useCallback(async () => {
+    if (!runs || loadingMore) return;
+    setLoadingMore(true);
+    const page = await fetchPage({
+      agent: agentFilter || undefined,
+      status: statusFilter || undefined,
+      offset: runs.length,
+    });
+    if (page) {
+      setRuns((prev) => {
+        const base = prev ?? [];
+        const seen = new Set(base.map((r) => r.run_id));
+        return [...base, ...page.filter((r) => !seen.has(r.run_id))];
+      });
+      setHasMore(page.length === PAGE_SIZE);
+    }
+    setLoadingMore(false);
+  }, [runs, loadingMore, agentFilter, statusFilter]);
+
+  const hasFilters = Boolean(agentFilter || statusFilter);
 
   return (
-    <table className="runs">
-      <thead>
-        <tr>
-          <th>Run</th>
-          <th>Agent</th>
-          <th>Input</th>
-          <th>Status</th>
-          <th>Started</th>
-        </tr>
-      </thead>
-      <tbody>
-        {runs.map((r) => (
-          <tr key={r.run_id}>
-            <td className="mono">
-              <Link href={`/runs/${r.run_id}`}>{r.run_id.slice(0, 8)}</Link>
-            </td>
-            <td>{r.agent}</td>
-            <td>{r.label}</td>
-            <td>
-              <StatusBadge status={r.status} />
-            </td>
-            <td className="muted">{new Date(r.created_at).toLocaleString()}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
+    <>
+      <div className="panel-head">
+        <h2>Recent runs</h2>
+        <div className="runs-filters">
+          <select
+            aria-label="Filter by agent"
+            value={agentFilter}
+            onChange={(e) => setFilter("agent", e.target.value)}
+          >
+            <option value="">All agents</option>
+            {AGENT_NAMES.map((a) => (
+              <option key={a} value={a}>
+                {a}
+              </option>
+            ))}
+          </select>
+          <select
+            aria-label="Filter by status"
+            value={statusFilter}
+            onChange={(e) => setFilter("status", e.target.value)}
+          >
+            <option value="">All statuses</option>
+            {STATUS_OPTIONS.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            className="secondary"
+            onClick={() => router.push(pathname)}
+            disabled={!hasFilters}
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+
+      {runs === null ? (
+        <p className="muted">Loading…</p>
+      ) : failed ? (
+        <p className="muted">Could not load runs. Try again shortly.</p>
+      ) : runs.length === 0 ? (
+        <p className="muted">
+          {hasFilters
+            ? "No runs match these filters."
+            : "No runs yet. Use the form above to trigger an agent."}
+        </p>
+      ) : (
+        <>
+          <div className="table-scroll">
+            <table className="runs">
+              <thead>
+                <tr>
+                  <th>Run</th>
+                  <th>Agent</th>
+                  <th>Input</th>
+                  <th>Status</th>
+                  <th>Started</th>
+                </tr>
+              </thead>
+              <tbody>
+                {runs.map((r) => {
+                  const showError = hasErrorDetail(r);
+                  return (
+                    <Fragment key={r.run_id}>
+                      <tr className={showError ? "has-error" : undefined}>
+                        <td className="mono">
+                          <Link href={`/runs/${r.run_id}`}>
+                            {r.run_id.slice(0, 8)}
+                          </Link>
+                        </td>
+                        <td>{r.agent}</td>
+                        <td>{r.label}</td>
+                        <td>
+                          <StatusBadge status={r.status} />
+                        </td>
+                        <td className="muted">
+                          {new Date(r.created_at).toLocaleString()}
+                        </td>
+                      </tr>
+                      {showError && (
+                        <tr className="run-error-row">
+                          <td colSpan={COLS}>
+                            <div className="run-error-text">
+                              <span className="run-error-tag">Error</span>
+                              {r.error}
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          {hasMore && (
+            <div className="runs-loadmore">
+              <button
+                type="button"
+                className="secondary"
+                onClick={loadMore}
+                disabled={loadingMore}
+              >
+                {loadingMore ? "Loading…" : `Load ${PAGE_SIZE} more`}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </>
   );
 }

--- a/services/hackbot-ui/components/TriggerForm.tsx
+++ b/services/hackbot-ui/components/TriggerForm.tsx
@@ -3,18 +3,9 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 
+import { AGENTS, type AgentValue } from "@/lib/agents";
 import { saveRun } from "@/lib/store";
 import type { RunRef } from "@/lib/types";
-
-const AGENTS = [
-  { value: "bug-fix", label: "bug-fix" },
-  { value: "autowebcompat-repro", label: "autowebcompat-repro" },
-  { value: "build-repair", label: "build-repair" },
-  { value: "frontend-triage", label: "frontend-triage" },
-  { value: "test-plan-generator", label: "test-plan-generator" },
-] as const;
-
-type AgentValue = (typeof AGENTS)[number]["value"];
 
 function parseAgent(value: string | null): AgentValue {
   return AGENTS.some((a) => a.value === value)

--- a/services/hackbot-ui/lib/agents.ts
+++ b/services/hackbot-ui/lib/agents.ts
@@ -1,0 +1,14 @@
+// Single source of truth for the selectable agents, shared by the trigger form
+// (components/TriggerForm.tsx) and the recent-runs filter (components/RecentRuns.tsx)
+// so the two dropdowns can never drift apart.
+export const AGENTS = [
+  { value: "bug-fix", label: "bug-fix" },
+  { value: "autowebcompat-repro", label: "autowebcompat-repro" },
+  { value: "build-repair", label: "build-repair" },
+  { value: "frontend-triage", label: "frontend-triage" },
+  { value: "test-plan-generator", label: "test-plan-generator" },
+] as const;
+
+export type AgentValue = (typeof AGENTS)[number]["value"];
+
+export const AGENT_NAMES: readonly string[] = AGENTS.map((a) => a.value);

--- a/services/hackbot-ui/lib/findings-format.tsx
+++ b/services/hackbot-ui/lib/findings-format.tsx
@@ -36,6 +36,78 @@ export function isScalar(v: unknown): v is string | number | boolean {
   );
 }
 
+// Only strings this long are considered for de-duplication — short scalars
+// (channel names, "blocked", booleans) legitimately repeat and must stay.
+const DEDUP_MIN_LEN = 40;
+
+// Some agents hoist a nested block up to a parent (e.g. autowebcompat-repro
+// copies the primary reproduction's `steps`/`summary` onto the top-level
+// `result`), so the same large text appears both at the top and inside the
+// reproduction. Keep the copy that lives with its context (the most deeply
+// nested occurrence) and drop the shallower hoisted copies — the data stays
+// intact and together, just not repeated. Occurrences that tie at the deepest
+// level (e.g. per-channel copies) are all kept.
+export function dropHoistedDuplicates(
+  findings: Record<string, unknown>,
+): Record<string, unknown> {
+  const maxDepth = new Map<string, number>();
+  const scan = (value: unknown, depth: number): void => {
+    if (typeof value === "string") {
+      if (value.trim().length >= DEDUP_MIN_LEN) {
+        maxDepth.set(value, Math.max(maxDepth.get(value) ?? -1, depth));
+      }
+    } else if (Array.isArray(value)) {
+      value.forEach((v) => scan(v, depth + 1));
+    } else if (isPlainObject(value)) {
+      Object.values(value).forEach((v) => scan(v, depth + 1));
+    }
+  };
+  scan(findings, 0);
+
+  const walk = (value: unknown, depth: number): unknown => {
+    if (Array.isArray(value)) return value.map((v) => walk(v, depth + 1));
+    if (isPlainObject(value)) {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value)) {
+        if (typeof v === "string" && v.trim().length >= DEDUP_MIN_LEN) {
+          const deepest = maxDepth.get(v);
+          // A deeper copy exists elsewhere → this is a hoisted duplicate; skip.
+          if (deepest !== undefined && depth + 1 < deepest) continue;
+        }
+        out[k] = walk(v, depth + 1);
+      }
+      return out;
+    }
+    return value;
+  };
+  return walk(findings, 0) as Record<string, unknown>;
+}
+
+// Remove fenced code blocks that are just a JSON dump (```json ... ``` or a
+// fence whose body parses as JSON). Some agents append the machine-readable
+// findings as a JSON block inside a prose field (e.g. frontend-triage's
+// `result`); in the human-readable view that only duplicates the structured
+// fields shown separately. The raw dump remains available via the JSON toggle.
+export function stripJsonFences(text: string): string {
+  return text
+    .replace(/```(\w*)[ \t]*\n([\s\S]*?)```/g, (whole, lang: string, body: string) => {
+      const isJsonLang = (lang || "").toLowerCase() === "json";
+      const trimmed = body.trim();
+      const looksJson = trimmed.startsWith("{") || trimmed.startsWith("[");
+      if (isJsonLang || looksJson) {
+        try {
+          JSON.parse(trimmed);
+          return "";
+        } catch {
+          if (isJsonLang) return "";
+        }
+      }
+      return whole;
+    })
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 // Pretty-print a fenced code block body when it is (or claims to be) JSON;
 // otherwise return it verbatim (trimmed).
 export function formatFence(lang: string, body: string): string {

--- a/services/hackbot-ui/lib/hackbot.ts
+++ b/services/hackbot-ui/lib/hackbot.ts
@@ -87,8 +87,20 @@ export function getRun(runId: string): Promise<RunDoc> {
   return request<RunDoc>(`/runs/${encodeURIComponent(runId)}`);
 }
 
-export function listRuns(limit = 50): Promise<RunDoc[]> {
-  return request<RunDoc[]>(`/runs?limit=${limit}`);
+export interface ListRunsParams {
+  limit?: number;
+  offset?: number;
+  agent?: string;
+  status?: string;
+}
+
+export function listRuns(params: ListRunsParams = {}): Promise<RunDoc[]> {
+  const qs = new URLSearchParams();
+  qs.set("limit", String(params.limit ?? 50));
+  if (params.offset) qs.set("offset", String(params.offset));
+  if (params.agent) qs.set("agent", params.agent);
+  if (params.status) qs.set("status", params.status);
+  return request<RunDoc[]>(`/runs?${qs.toString()}`);
 }
 
 export function listRunActions(runId: string): Promise<RunAction[]> {


### PR DESCRIPTION
Load (50 rows at a time) and table filtering added to the Recent Runs table (see image).
Deduplication and cleanup of layout on the runs page.


<img width="1051" height="738" alt="Screenshot 2026-07-22 at 11 16 41 AM" src="https://github.com/user-attachments/assets/01598e58-bc33-4e2e-9cf5-8cba8bec8734" />
