### PR TITLE
Configure Sentry DSN for hackbot-api

### DIFF
--- a/services/hackbot-api/app/config.py
+++ b/services/hackbot-api/app/config.py
@@ -33,7 +33,9 @@ class Settings(BaseSettings):
     # Server
     port: int = 8080
     environment: str = "development"
-    sentry_dsn: str | None = None
+    sentry_dsn: str | None = (
+        "https://0627922a12291ec4313be63aea828247@o1069899.ingest.us.sentry.io/4511785557295104"
+    )
 
     model_config = {
         "env_file": ".env",


### PR DESCRIPTION
## Summary
Sets the Sentry DSN for the hackbot-api service so error reporting is actually enabled.

The Sentry SDK was already wired up in `app/main.py` (behind an `if settings.sentry_dsn:` guard) and `sentry-sdk` is already a dependency, but `sentry_dsn` defaulted to `None`, so `sentry_sdk.init()` was never called. This sets the DSN as the config default, matching the `reviewhelper-api` convention (a Sentry DSN is a public client key, not a secret). It remains overridable via the `SENTRY_DSN` environment variable.

## Changes
- `services/hackbot-api/app/config.py`: default `sentry_dsn` to the project DSN instead of `None`.