### PR TITLE
Taskcluster v102 no longer supports normal priority - change to lowest

### DIFF
--- a/infra/taskcluster-hook-check-models-start.json
+++ b/infra/taskcluster-hook-check-models-start.json
@@ -38,7 +38,7 @@
       "image": "mozilla/bugbug-spawn-pipeline",
       "maxRunTime": 7200
     },
-    "priority": "normal",
+    "priority": "lowest",
     "provisionerId": "proj-bugbug",
     "retries": 5,
     "routes": ["notify.email.bugbug-team@mozilla.com.on-failed"],

--- a/infra/taskcluster-hook-classify-patch.json
+++ b/infra/taskcluster-hook-classify-patch.json
@@ -58,7 +58,7 @@
       "image": "mozilla/bugbug-commit-retrieval",
       "maxRunTime": 7200
     },
-    "priority": "normal",
+    "priority": "lowest",
     "provisionerId": "proj-bugbug",
     "retries": 5,
     "routes": [

--- a/infra/taskcluster-hook-data-pipeline.json
+++ b/infra/taskcluster-hook-data-pipeline.json
@@ -44,7 +44,7 @@
       "image": "mozilla/bugbug-spawn-pipeline",
       "maxRunTime": 7200
     },
-    "priority": "normal",
+    "priority": "lowest",
     "provisionerId": "proj-bugbug",
     "retries": 5,
     "routes": [

--- a/infra/taskcluster-hook-landings-risk-report.json
+++ b/infra/taskcluster-hook-landings-risk-report.json
@@ -38,7 +38,7 @@
       "image": "mozilla/bugbug-spawn-pipeline",
       "maxRunTime": 7200
     },
-    "priority": "normal",
+    "priority": "lowest",
     "provisionerId": "proj-bugbug",
     "retries": 5,
     "routes": ["notify.email.bugbug-team@mozilla.com.on-failed"],


### PR DESCRIPTION
Prior to Taskcluster v102.0.1, task priority `normal` was internally [mapped](https://github.com/taskcluster/taskcluster/blob/05bfba092ae07bff31b232a1c502ee23ba08a46a/services/queue/src/api.js#L687) to `lowest`.

This sets it explicitly, since `normal` priority was removed in https://github.com/taskcluster/taskcluster/pull/8865 which was released in [Taskcluster v102.0.1](https://github.com/taskcluster/taskcluster/releases/tag/v102.0.1).