### PR TITLE
Fix triggerSchema

### DIFF
--- a/infra/taskcluster-hook-data-pipeline.json
+++ b/infra/taskcluster-hook-data-pipeline.json
@@ -57,7 +57,7 @@
     "workerType": "batch"
   },
   "triggerSchema": {
-    "additionalProperties": false,
+    "additionalProperties": true,
     "type": "object"
   }
 }


### PR DESCRIPTION
There is currently a bug in the Taskcluster Hooks service whereby the trigger schema is not used when the trigger is fired by a pulse message.

This is being fixed in https://github.com/taskcluster/taskcluster/pull/8915. When that bug is fixed, this hook would no longer fire, because the trigger schema here said to filter the pulse messages, only allowing the hook to fire if the json payload of the pulse message is an empty json object (i.e. `{}`). This would not match any pulse events, and so the hook would never fire in response to a pulse message.

I've fixed this by allowing any json object. Note, you could provide a more specific trigger schema here if required, but this should at least ensure tasks are created in response to pulse events.