### PR TITLE
hackbot: record and filter runs by author

### DIFF
--- a/services/hackbot-api/alembic/versions/d2b7a4c1e8f0_runs_author.py
+++ b/services/hackbot-api/alembic/versions/d2b7a4c1e8f0_runs_author.py
@@ -1,0 +1,30 @@
+"""Record the author (triggering user) on runs.
+
+Revision ID: d2b7a4c1e8f0
+Revises: c1a2f3e4b5d6
+Create Date: 2026-07-27 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d2b7a4c1e8f0"
+down_revision: Union[str, Sequence[str], None] = "c1a2f3e4b5d6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("runs", sa.Column("author", sa.String(), nullable=True))
+    op.create_index(op.f("ix_runs_author"), "runs", ["author"], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_runs_author"), table_name="runs")
+    op.drop_column("runs", "author")

--- a/services/hackbot-api/alembic/versions/f3c8a1d5b2e7_runs_requested_by.py
+++ b/services/hackbot-api/alembic/versions/f3c8a1d5b2e7_runs_requested_by.py
@@ -1,6 +1,6 @@
-"""Record the author (triggering user) on runs.
+"""Record who requested each run.
 
-Revision ID: d2b7a4c1e8f0
+Revision ID: f3c8a1d5b2e7
 Revises: c1a2f3e4b5d6
 Create Date: 2026-07-27 00:00:00.000000
 
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "d2b7a4c1e8f0"
+revision: str = "f3c8a1d5b2e7"
 down_revision: Union[str, Sequence[str], None] = "c1a2f3e4b5d6"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
@@ -20,11 +20,13 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Upgrade schema."""
-    op.add_column("runs", sa.Column("author", sa.String(), nullable=True))
-    op.create_index(op.f("ix_runs_author"), "runs", ["author"], unique=False)
+    op.add_column("runs", sa.Column("requested_by", sa.String(), nullable=True))
+    op.create_index(
+        op.f("ix_runs_requested_by"), "runs", ["requested_by"], unique=False
+    )
 
 
 def downgrade() -> None:
     """Downgrade schema."""
-    op.drop_index(op.f("ix_runs_author"), table_name="runs")
-    op.drop_column("runs", "author")
+    op.drop_index(op.f("ix_runs_requested_by"), table_name="runs")
+    op.drop_column("runs", "requested_by")

--- a/services/hackbot-api/app/database/models.py
+++ b/services/hackbot-api/app/database/models.py
@@ -20,6 +20,10 @@ class Run(Base):
     agent: Mapped[str] = mapped_column(String, nullable=False, index=True)
     status: Mapped[str] = mapped_column(String, nullable=False, index=True)
     inputs: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    # Email of the person who triggered the run from the UI. Null for runs
+    # triggered by automation (e.g. Phabricator webhooks) and for legacy runs
+    # created before authorship was recorded. Indexed for "my runs" filtering.
+    author: Mapped[str | None] = mapped_column(String, nullable=True, index=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),

--- a/services/hackbot-api/app/database/models.py
+++ b/services/hackbot-api/app/database/models.py
@@ -20,10 +20,7 @@ class Run(Base):
     agent: Mapped[str] = mapped_column(String, nullable=False, index=True)
     status: Mapped[str] = mapped_column(String, nullable=False, index=True)
     inputs: Mapped[dict] = mapped_column(JSONB, nullable=False)
-    # Email of the person who triggered the run from the UI. Null for runs
-    # triggered by automation (e.g. Phabricator webhooks) and for legacy runs
-    # created before authorship was recorded. Indexed for "my runs" filtering.
-    author: Mapped[str | None] = mapped_column(String, nullable=True, index=True)
+    requested_by: Mapped[str | None] = mapped_column(String, nullable=True, index=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),

--- a/services/hackbot-api/app/routers/runs.py
+++ b/services/hackbot-api/app/routers/runs.py
@@ -2,8 +2,10 @@ import json
 import logging
 import uuid
 from datetime import datetime, timezone
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from pydantic import BeforeValidator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -29,17 +31,14 @@ log = logging.getLogger(__name__)
 router = APIRouter(dependencies=[Depends(require_api_key)])
 
 
-def _normalize_author(author: str | None) -> str | None:
-    """Canonicalize an author email for storage and comparison.
-
-    Authors are stored lowercased and stripped, so the same normalization has to
-    run on both the write and the filter path. Blank values (a missing header or
-    an empty query param) collapse to ``None`` rather than an empty-string author.
-    """
-    if author is None:
+def _normalize_identity(email: str | None) -> str | None:
+    if not email:
         return None
-    normalized = author.strip().lower()
-    return normalized or None
+
+    return email.strip().lower() or None
+
+
+UserEmail = Annotated[str | None, BeforeValidator(_normalize_identity)]
 
 
 def _lookup_agent(name: str) -> AgentSpec:
@@ -68,9 +67,13 @@ async def list_agents() -> list[AgentDescriptor]:
 async def create_run(
     agent_name: str,
     payload: dict,
-    # Set by the UI proxy to the authenticated user's email. Automated callers
-    # (e.g. the Phabricator webhook) omit it, leaving the run unattributed.
-    author: str | None = Header(default=None, alias="X-Hackbot-Author"),
+    on_behalf_of: Annotated[
+        UserEmail,
+        Header(
+            alias="X-On-Behalf-Of",
+            description="Email of the user this run is requested for.",
+        ),
+    ] = None,
     db: AsyncSession = Depends(get_db),
 ) -> RunRef:
     agent = _lookup_agent(agent_name)
@@ -89,7 +92,7 @@ async def create_run(
         agent=agent.name,
         status=RunStatus.pending.value,
         inputs=inputs.model_dump(mode="json"),
-        author=_normalize_author(author),
+        requested_by=on_behalf_of,
         results_prefix=results_prefix,
         artifacts=[],
     )
@@ -130,10 +133,10 @@ async def list_runs(
     agent: str | None = Query(default=None),
     # Aliased so the query param is `status` without shadowing fastapi.status.
     status_filter: RunStatus | None = Query(default=None, alias="status"),
-    # Filter to runs triggered by this user (email). Used by the UI's "my runs"
-    # default. Matched case-insensitively against the stored (lowercased) author;
-    # a blank value means "no filter".
-    author: str | None = Query(default=None),
+    requested_by: Annotated[
+        UserEmail,
+        Query(description="Only return runs requested by this user."),
+    ] = None,
     db: AsyncSession = Depends(get_db),
 ) -> list[RunDoc]:
     stmt = select(Run)
@@ -141,12 +144,11 @@ async def list_runs(
         stmt = stmt.where(Run.agent == agent)
     if status_filter is not None:
         stmt = stmt.where(Run.status == status_filter.value)
-    normalized_author = _normalize_author(author)
-    if normalized_author is not None:
-        stmt = stmt.where(Run.author == normalized_author)
+    if requested_by is not None:
+        stmt = stmt.where(Run.requested_by == requested_by)
     # created_at is the sort key; run_id is a deterministic tiebreaker so offset
-    # paging is stable when timestamps collide. (agent/status/created_at are all
-    # indexed, so filtering + ordering stay index-backed.)
+    # paging is stable when timestamps collide. (agent/status/requested_by and
+    # created_at are all indexed, so filtering + ordering stay index-backed.)
     stmt = (
         stmt.order_by(Run.created_at.desc(), Run.run_id.desc())
         .offset(offset)

--- a/services/hackbot-api/app/routers/runs.py
+++ b/services/hackbot-api/app/routers/runs.py
@@ -29,6 +29,19 @@ log = logging.getLogger(__name__)
 router = APIRouter(dependencies=[Depends(require_api_key)])
 
 
+def _normalize_author(author: str | None) -> str | None:
+    """Canonicalize an author email for storage and comparison.
+
+    Authors are stored lowercased and stripped, so the same normalization has to
+    run on both the write and the filter path. Blank values (a missing header or
+    an empty query param) collapse to ``None`` rather than an empty-string author.
+    """
+    if author is None:
+        return None
+    normalized = author.strip().lower()
+    return normalized or None
+
+
 def _lookup_agent(name: str) -> AgentSpec:
     agent = AGENT_REGISTRY.get(name)
     if agent is None:
@@ -76,7 +89,7 @@ async def create_run(
         agent=agent.name,
         status=RunStatus.pending.value,
         inputs=inputs.model_dump(mode="json"),
-        author=author.lower() if author else None,
+        author=_normalize_author(author),
         results_prefix=results_prefix,
         artifacts=[],
     )
@@ -118,7 +131,8 @@ async def list_runs(
     # Aliased so the query param is `status` without shadowing fastapi.status.
     status_filter: RunStatus | None = Query(default=None, alias="status"),
     # Filter to runs triggered by this user (email). Used by the UI's "my runs"
-    # default. Matched case-insensitively against the stored (lowercased) author.
+    # default. Matched case-insensitively against the stored (lowercased) author;
+    # a blank value means "no filter".
     author: str | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
 ) -> list[RunDoc]:
@@ -127,8 +141,9 @@ async def list_runs(
         stmt = stmt.where(Run.agent == agent)
     if status_filter is not None:
         stmt = stmt.where(Run.status == status_filter.value)
-    if author is not None:
-        stmt = stmt.where(Run.author == author.lower())
+    normalized_author = _normalize_author(author)
+    if normalized_author is not None:
+        stmt = stmt.where(Run.author == normalized_author)
     # created_at is the sort key; run_id is a deterministic tiebreaker so offset
     # paging is stable when timestamps collide. (agent/status/created_at are all
     # indexed, so filtering + ordering stay index-backed.)

--- a/services/hackbot-api/app/routers/runs.py
+++ b/services/hackbot-api/app/routers/runs.py
@@ -3,7 +3,7 @@ import logging
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -55,6 +55,9 @@ async def list_agents() -> list[AgentDescriptor]:
 async def create_run(
     agent_name: str,
     payload: dict,
+    # Set by the UI proxy to the authenticated user's email. Automated callers
+    # (e.g. the Phabricator webhook) omit it, leaving the run unattributed.
+    author: str | None = Header(default=None, alias="X-Hackbot-Author"),
     db: AsyncSession = Depends(get_db),
 ) -> RunRef:
     agent = _lookup_agent(agent_name)
@@ -73,6 +76,7 @@ async def create_run(
         agent=agent.name,
         status=RunStatus.pending.value,
         inputs=inputs.model_dump(mode="json"),
+        author=author.lower() if author else None,
         results_prefix=results_prefix,
         artifacts=[],
     )
@@ -113,6 +117,9 @@ async def list_runs(
     agent: str | None = Query(default=None),
     # Aliased so the query param is `status` without shadowing fastapi.status.
     status_filter: RunStatus | None = Query(default=None, alias="status"),
+    # Filter to runs triggered by this user (email). Used by the UI's "my runs"
+    # default. Matched case-insensitively against the stored (lowercased) author.
+    author: str | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
 ) -> list[RunDoc]:
     stmt = select(Run)
@@ -120,6 +127,8 @@ async def list_runs(
         stmt = stmt.where(Run.agent == agent)
     if status_filter is not None:
         stmt = stmt.where(Run.status == status_filter.value)
+    if author is not None:
+        stmt = stmt.where(Run.author == author.lower())
     # created_at is the sort key; run_id is a deterministic tiebreaker so offset
     # paging is stable when timestamps collide. (agent/status/created_at are all
     # indexed, so filtering + ordering stay index-backed.)

--- a/services/hackbot-api/app/schemas.py
+++ b/services/hackbot-api/app/schemas.py
@@ -63,7 +63,7 @@ class RunDoc(BaseModel):
     agent: str
     status: RunStatus
     inputs: dict[str, Any]
-    author: str | None = None
+    requested_by: str | None = None
     created_at: datetime
     updated_at: datetime
     execution_name: str | None = None

--- a/services/hackbot-api/app/schemas.py
+++ b/services/hackbot-api/app/schemas.py
@@ -63,6 +63,7 @@ class RunDoc(BaseModel):
     agent: str
     status: RunStatus
     inputs: dict[str, Any]
+    author: str | None = None
     created_at: datetime
     updated_at: datetime
     execution_name: str | None = None

--- a/services/hackbot-api/tests/test_create_run_api.py
+++ b/services/hackbot-api/tests/test_create_run_api.py
@@ -1,0 +1,69 @@
+"""Tests for POST /agents/{agent_name}/runs, focused on author attribution.
+
+Follows this suite's fake-based style: the handler is called directly with a fake
+session that captures the Run it adds, and the GCS/Cloud Run collaborators are
+monkeypatched, so no GCP or Postgres is needed.
+"""
+
+import pytest
+from app import gcs, jobs
+from app.routers import runs as runs_router
+
+
+class _CapturingDB:
+    """Captures the ORM object passed to add(); commit/flush are no-ops."""
+
+    def __init__(self):
+        self.added = None
+
+    def add(self, obj):
+        self.added = obj
+
+    async def flush(self):
+        pass
+
+    async def commit(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _stub_gcp(monkeypatch):
+    async def fake_policy(run_id):
+        return {"url": "https://upload.example/", "fields": {"key": "v"}}
+
+    async def fake_trigger(job_name, env):
+        return "projects/p/locations/l/jobs/j/executions/e"
+
+    monkeypatch.setattr(gcs, "run_prefix", lambda run_id: f"results/{run_id}/")
+    monkeypatch.setattr(gcs, "generate_results_policy", fake_policy)
+    monkeypatch.setattr(jobs, "trigger_execution", fake_trigger)
+
+
+async def _create(author, db=None):
+    db = db or _CapturingDB()
+    await runs_router.create_run(
+        agent_name="bug-fix",
+        payload={"bug_id": 1889001},
+        author=author,
+        db=db,
+    )
+    return db.added
+
+
+async def test_create_run_records_author_from_header():
+    run = await _create("someone@mozilla.com")
+    assert run.author == "someone@mozilla.com"
+
+
+async def test_create_run_normalizes_author_case_and_whitespace():
+    # Stored lowercased/stripped so the list_runs filter can match exactly.
+    run = await _create("  Someone@Mozilla.COM \n")
+    assert run.author == "someone@mozilla.com"
+
+
+@pytest.mark.parametrize("header", [None, "", "   "])
+async def test_create_run_leaves_run_unattributed_without_author(header):
+    # Automation (e.g. the Phabricator webhook) omits the header entirely; a
+    # blank one must not land as an empty-string author either.
+    run = await _create(header)
+    assert run.author is None

--- a/services/hackbot-api/tests/test_create_run_api.py
+++ b/services/hackbot-api/tests/test_create_run_api.py
@@ -1,29 +1,14 @@
-"""Tests for POST /agents/{agent_name}/runs, focused on author attribution.
+"""Tests for POST /agents/{agent_name}/runs, focused on requester attribution.
 
-Follows this suite's fake-based style: the handler is called directly with a fake
-session that captures the Run it adds, and the GCS/Cloud Run collaborators are
-monkeypatched, so no GCP or Postgres is needed.
+These go through a TestClient rather than calling the handler directly: the
+`X-On-Behalf-Of` normalization lives in the parameter's annotation (see
+`UserEmail` in app/routers/runs.py), so it only runs as part of FastAPI's request
+handling. The GCS/Cloud Run collaborators are monkeypatched and the DB session is
+the shared `FakeSession`, so no GCP or Postgres is needed.
 """
 
 import pytest
 from app import gcs, jobs
-from app.routers import runs as runs_router
-
-
-class _CapturingDB:
-    """Captures the ORM object passed to add(); commit/flush are no-ops."""
-
-    def __init__(self):
-        self.added = None
-
-    def add(self, obj):
-        self.added = obj
-
-    async def flush(self):
-        pass
-
-    async def commit(self):
-        pass
 
 
 @pytest.fixture(autouse=True)
@@ -39,31 +24,28 @@ def _stub_gcp(monkeypatch):
     monkeypatch.setattr(jobs, "trigger_execution", fake_trigger)
 
 
-async def _create(author, db=None):
-    db = db or _CapturingDB()
-    await runs_router.create_run(
-        agent_name="bug-fix",
-        payload={"bug_id": 1889001},
-        author=author,
-        db=db,
+def _create(client, headers=None):
+    resp = client.post(
+        "/agents/bug-fix/runs", json={"bug_id": 1889001}, headers=headers or {}
     )
-    return db.added
+    assert resp.status_code == 201, resp.text
+    return resp
 
 
-async def test_create_run_records_author_from_header():
-    run = await _create("someone@mozilla.com")
-    assert run.author == "someone@mozilla.com"
+def test_create_run_records_requested_by_from_header(client, db):
+    _create(client, {"X-On-Behalf-Of": "someone@mozilla.com"})
+    assert db.added.requested_by == "someone@mozilla.com"
 
 
-async def test_create_run_normalizes_author_case_and_whitespace():
+def test_create_run_normalizes_requested_by_case_and_whitespace(client, db):
     # Stored lowercased/stripped so the list_runs filter can match exactly.
-    run = await _create("  Someone@Mozilla.COM \n")
-    assert run.author == "someone@mozilla.com"
+    _create(client, {"X-On-Behalf-Of": "  Someone@Mozilla.COM  "})
+    assert db.added.requested_by == "someone@mozilla.com"
 
 
-@pytest.mark.parametrize("header", [None, "", "   "])
-async def test_create_run_leaves_run_unattributed_without_author(header):
+@pytest.mark.parametrize("headers", [{}, {"X-On-Behalf-Of": "   "}])
+def test_create_run_leaves_run_unattributed_without_header(client, db, headers):
     # Automation (e.g. the Phabricator webhook) omits the header entirely; a
-    # blank one must not land as an empty-string author either.
-    run = await _create(header)
-    assert run.author is None
+    # blank one must not land as an empty-string requester either.
+    _create(client, headers)
+    assert db.added.requested_by is None

--- a/services/hackbot-api/tests/test_list_runs_api.py
+++ b/services/hackbot-api/tests/test_list_runs_api.py
@@ -41,7 +41,7 @@ def _fake_run(**overrides):
         agent="frontend-triage",
         status="succeeded",
         inputs={"bug_id": 123},
-        author=None,
+        requested_by=None,
         created_at=datetime(2026, 7, 21, 12, 0, tzinfo=timezone.utc),
         updated_at=datetime(2026, 7, 21, 12, 5, tzinfo=timezone.utc),
         execution_name=None,
@@ -61,7 +61,7 @@ def _sql(stmt) -> str:
 async def test_list_runs_default_orders_and_pages():
     db = _CapturingDB([_fake_run()])
     out = await runs_router.list_runs(
-        limit=50, offset=0, agent=None, status_filter=None, author=None, db=db
+        limit=50, offset=0, agent=None, status_filter=None, requested_by=None, db=db
     )
     sql = _sql(db.stmt)
     assert "FROM runs" in sql
@@ -80,7 +80,7 @@ async def test_list_runs_filters_by_agent_and_status():
         offset=20,
         agent="bug-fix",
         status_filter=RunStatus.failed,
-        author=None,
+        requested_by=None,
         db=db,
     )
     sql = _sql(db.stmt)
@@ -96,7 +96,7 @@ async def test_list_runs_filters_by_agent_only():
         offset=0,
         agent="frontend-triage",
         status_filter=None,
-        author=None,
+        requested_by=None,
         db=db,
     )
     sql = _sql(db.stmt)
@@ -104,29 +104,48 @@ async def test_list_runs_filters_by_agent_only():
     assert "runs.status =" not in sql
 
 
-async def test_list_runs_filters_by_author():
+async def test_list_runs_filters_by_requested_by():
     db = _CapturingDB([])
     await runs_router.list_runs(
         limit=50,
         offset=0,
         agent=None,
         status_filter=None,
-        author="Someone@Mozilla.com",
+        requested_by="someone@mozilla.com",
         db=db,
     )
     sql = _sql(db.stmt)
-    assert "runs.author =" in sql
-    # Stored authors are lowercased, so the filter must lowercase too.
+    assert "runs.requested_by =" in sql
     params = db.stmt.compile(dialect=postgresql.dialect()).params
     assert "someone@mozilla.com" in params.values()
 
 
-@pytest.mark.parametrize("author", ["", "   "])
-async def test_list_runs_ignores_blank_author(author):
-    # A blank author param means "no filter", not "runs with an empty author".
+async def test_list_runs_without_requested_by_is_unfiltered():
     db = _CapturingDB([])
     await runs_router.list_runs(
-        limit=50, offset=0, agent=None, status_filter=None, author=author, db=db
+        limit=50, offset=0, agent=None, status_filter=None, requested_by=None, db=db
     )
-    # "runs.author" also appears in the SELECT list, so assert on the clause.
+    # "runs.requested_by" also appears in the SELECT list, so assert on the clause.
+    assert "WHERE" not in _sql(db.stmt)
+
+
+# The `requested_by` query param is normalized by its annotation (see `UserEmail`
+# in app/routers/runs.py), which only runs inside FastAPI's request handling --
+# hence the TestClient here rather than a direct handler call.
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [("Someone@Mozilla.com", "someone@mozilla.com"), ("  a@b.c ", "a@b.c")],
+)
+def test_list_runs_normalizes_requested_by_query_param(client, db, raw, expected):
+    assert client.get("/runs", params={"requested_by": raw}).status_code == 200
+    params = db.stmt.compile(dialect=postgresql.dialect()).params
+    assert expected in params.values()
+
+
+@pytest.mark.parametrize("raw", ["", "   "])
+def test_list_runs_ignores_blank_requested_by(client, db, raw):
+    # A blank param means "no filter", not "runs with an empty requester".
+    assert client.get("/runs", params={"requested_by": raw}).status_code == 200
     assert "WHERE" not in _sql(db.stmt)

--- a/services/hackbot-api/tests/test_list_runs_api.py
+++ b/services/hackbot-api/tests/test_list_runs_api.py
@@ -40,6 +40,7 @@ def _fake_run(**overrides):
         agent="frontend-triage",
         status="succeeded",
         inputs={"bug_id": 123},
+        author=None,
         created_at=datetime(2026, 7, 21, 12, 0, tzinfo=timezone.utc),
         updated_at=datetime(2026, 7, 21, 12, 5, tzinfo=timezone.utc),
         execution_name=None,
@@ -59,7 +60,7 @@ def _sql(stmt) -> str:
 async def test_list_runs_default_orders_and_pages():
     db = _CapturingDB([_fake_run()])
     out = await runs_router.list_runs(
-        limit=50, offset=0, agent=None, status_filter=None, db=db
+        limit=50, offset=0, agent=None, status_filter=None, author=None, db=db
     )
     sql = _sql(db.stmt)
     assert "FROM runs" in sql
@@ -74,7 +75,12 @@ async def test_list_runs_default_orders_and_pages():
 async def test_list_runs_filters_by_agent_and_status():
     db = _CapturingDB([])
     await runs_router.list_runs(
-        limit=10, offset=20, agent="bug-fix", status_filter=RunStatus.failed, db=db
+        limit=10,
+        offset=20,
+        agent="bug-fix",
+        status_filter=RunStatus.failed,
+        author=None,
+        db=db,
     )
     sql = _sql(db.stmt)
     assert "runs.agent =" in sql
@@ -85,8 +91,30 @@ async def test_list_runs_filters_by_agent_and_status():
 async def test_list_runs_filters_by_agent_only():
     db = _CapturingDB([])
     await runs_router.list_runs(
-        limit=50, offset=0, agent="frontend-triage", status_filter=None, db=db
+        limit=50,
+        offset=0,
+        agent="frontend-triage",
+        status_filter=None,
+        author=None,
+        db=db,
     )
     sql = _sql(db.stmt)
     assert "runs.agent =" in sql
     assert "runs.status =" not in sql
+
+
+async def test_list_runs_filters_by_author():
+    db = _CapturingDB([])
+    await runs_router.list_runs(
+        limit=50,
+        offset=0,
+        agent=None,
+        status_filter=None,
+        author="Someone@Mozilla.com",
+        db=db,
+    )
+    sql = _sql(db.stmt)
+    assert "runs.author =" in sql
+    # Stored authors are lowercased, so the filter must lowercase too.
+    params = db.stmt.compile(dialect=postgresql.dialect()).params
+    assert "someone@mozilla.com" in params.values()

--- a/services/hackbot-api/tests/test_list_runs_api.py
+++ b/services/hackbot-api/tests/test_list_runs_api.py
@@ -9,6 +9,7 @@ import uuid
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
+import pytest
 from app.routers import runs as runs_router
 from app.schemas import RunStatus
 from sqlalchemy.dialects import postgresql
@@ -118,3 +119,14 @@ async def test_list_runs_filters_by_author():
     # Stored authors are lowercased, so the filter must lowercase too.
     params = db.stmt.compile(dialect=postgresql.dialect()).params
     assert "someone@mozilla.com" in params.values()
+
+
+@pytest.mark.parametrize("author", ["", "   "])
+async def test_list_runs_ignores_blank_author(author):
+    # A blank author param means "no filter", not "runs with an empty author".
+    db = _CapturingDB([])
+    await runs_router.list_runs(
+        limit=50, offset=0, agent=None, status_filter=None, author=author, db=db
+    )
+    # "runs.author" also appears in the SELECT list, so assert on the clause.
+    assert "WHERE" not in _sql(db.stmt)

--- a/services/hackbot-ui/app/api/runs/route.ts
+++ b/services/hackbot-ui/app/api/runs/route.ts
@@ -5,9 +5,9 @@ import { getAuthedEmail } from "@/lib/session";
 
 export const dynamic = "force-dynamic";
 
-// GET /api/runs?limit=50&offset=0&agent=<name>&status=<status>
+// GET /api/runs?limit=50&offset=0&agent=<name>&status=<status>&author=<email>
 // Returns a page of runs from hackbot-api (newest first), optionally filtered
-// by agent and/or status.
+// by agent, status and/or the email of the user who triggered them.
 export async function GET(req: NextRequest) {
   if (!(await getAuthedEmail())) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/services/hackbot-ui/app/api/runs/route.ts
+++ b/services/hackbot-ui/app/api/runs/route.ts
@@ -20,7 +20,8 @@ export async function GET(req: NextRequest) {
     const offset = Number.isFinite(rawOffset) && rawOffset > 0 ? rawOffset : 0;
     const agent = searchParams.get("agent") || undefined;
     const status = searchParams.get("status") || undefined;
-    const runs = await listRuns({ limit, offset, agent, status });
+    const author = searchParams.get("author") || undefined;
+    const runs = await listRuns({ limit, offset, agent, status, author });
     return NextResponse.json(runs);
   } catch (err) {
     const status = err instanceof HackbotError ? err.status : 500;
@@ -31,7 +32,8 @@ export async function GET(req: NextRequest) {
 // POST /api/runs  { agent: string, inputs: object }
 // Triggers a new agent run via hackbot-api.
 export async function POST(req: NextRequest) {
-  if (!(await getAuthedEmail())) {
+  const email = await getAuthedEmail();
+  if (!email) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
@@ -55,7 +57,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const run = await createRun(agent, inputs ?? {});
+    const run = await createRun(agent, inputs ?? {}, email);
     return NextResponse.json(run, { status: 201 });
   } catch (err) {
     const status = err instanceof HackbotError ? err.status : 500;

--- a/services/hackbot-ui/app/api/runs/route.ts
+++ b/services/hackbot-ui/app/api/runs/route.ts
@@ -5,9 +5,9 @@ import { getAuthedEmail } from "@/lib/session";
 
 export const dynamic = "force-dynamic";
 
-// GET /api/runs?limit=50&offset=0&agent=<name>&status=<status>&author=<email>
+// GET /api/runs?limit=50&offset=0&agent=<name>&status=<status>&requested_by=<email>
 // Returns a page of runs from hackbot-api (newest first), optionally filtered
-// by agent, status and/or the email of the user who triggered them.
+// by agent, status and/or the email of the user they're attributed to.
 export async function GET(req: NextRequest) {
   if (!(await getAuthedEmail())) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -20,8 +20,8 @@ export async function GET(req: NextRequest) {
     const offset = Number.isFinite(rawOffset) && rawOffset > 0 ? rawOffset : 0;
     const agent = searchParams.get("agent") || undefined;
     const status = searchParams.get("status") || undefined;
-    const author = searchParams.get("author") || undefined;
-    const runs = await listRuns({ limit, offset, agent, status, author });
+    const requestedBy = searchParams.get("requested_by") || undefined;
+    const runs = await listRuns({ limit, offset, agent, status, requestedBy });
     return NextResponse.json(runs);
   } catch (err) {
     const status = err instanceof HackbotError ? err.status : 500;
@@ -30,7 +30,8 @@ export async function GET(req: NextRequest) {
 }
 
 // POST /api/runs  { agent: string, inputs: object }
-// Triggers a new agent run via hackbot-api.
+// Triggers a new agent run via hackbot-api, attributed to the signed-in user
+// (the session email, never a client-supplied one).
 export async function POST(req: NextRequest) {
   const email = await getAuthedEmail();
   if (!email) {

--- a/services/hackbot-ui/components/RecentRuns.tsx
+++ b/services/hackbot-ui/components/RecentRuns.tsx
@@ -29,7 +29,7 @@ interface RunRow {
   agent: string;
   status: RunStatus;
   label: string;
-  author: string | null;
+  requestedBy: string | null;
   created_at: string;
   error: string | null;
 }
@@ -54,7 +54,7 @@ function toRow(d: RunDoc): RunRow {
     agent: d.agent,
     status: d.status,
     label: labelFromInputs(d.inputs),
-    author: d.author,
+    requestedBy: d.requested_by,
     created_at: d.created_at,
     error: d.error,
   };
@@ -64,18 +64,18 @@ function hasErrorDetail(r: RunRow): boolean {
   return (r.status === "failed" || r.status === "timed_out") && !!r.error;
 }
 
-// Compact author cell: the email's local part (full email on hover). Runs with
-// no author come from automation (e.g. Phabricator webhooks).
-function AuthorCell({ author }: { author: string | null }) {
-  if (!author) return <span className="muted">automation</span>;
-  const localPart = author.split("@")[0];
-  return <span title={author}>{localPart}</span>;
+// Compact requester cell: the email's local part (full email on hover). Runs
+// with no requester come from automation (e.g. Phabricator webhooks).
+function RequesterCell({ requestedBy }: { requestedBy: string | null }) {
+  if (!requestedBy) return <span className="muted">automation</span>;
+  const localPart = requestedBy.split("@")[0];
+  return <span title={requestedBy}>{localPart}</span>;
 }
 
 async function fetchPage(params: {
   agent?: string;
   status?: string;
-  author?: string;
+  requestedBy?: string;
   offset: number;
 }): Promise<RunRow[] | null> {
   const qs = new URLSearchParams({
@@ -84,7 +84,7 @@ async function fetchPage(params: {
   });
   if (params.agent) qs.set("agent", params.agent);
   if (params.status) qs.set("status", params.status);
-  if (params.author) qs.set("author", params.author);
+  if (params.requestedBy) qs.set("requested_by", params.requestedBy);
   const res = await fetch(`/api/runs?${qs.toString()}`);
   if (!res.ok) return null;
   const docs = (await res.json()) as RunDoc[];
@@ -102,7 +102,7 @@ export function RecentRuns() {
   const statusFilter = searchParams.get("status") ?? "";
   // Default to "my runs"; `?scope=all` shows everyone's.
   const showAll = searchParams.get("scope") === "all";
-  const authorFilter = showAll ? undefined : (myEmail ?? undefined);
+  const requesterFilter = showAll ? undefined : myEmail ?? undefined;
   // In "my runs" mode we need the signed-in email before we can filter, so hold
   // off fetching until the session resolves. Once resolved without an email
   // (shouldn't happen for an authed user), fall through to an unfiltered list.
@@ -122,7 +122,7 @@ export function RecentRuns() {
     fetchPage({
       agent: agentFilter || undefined,
       status: statusFilter || undefined,
-      author: authorFilter,
+      requestedBy: requesterFilter,
       offset: 0,
     }).then((page) => {
       if (cancelled) return;
@@ -138,7 +138,7 @@ export function RecentRuns() {
     return () => {
       cancelled = true;
     };
-  }, [agentFilter, statusFilter, authorFilter, sessionReady]);
+  }, [agentFilter, statusFilter, requesterFilter, sessionReady]);
 
   // Live-status polling for the loaded, non-terminal runs — updated in place so
   // pagination/scroll position is preserved.
@@ -194,7 +194,7 @@ export function RecentRuns() {
     const page = await fetchPage({
       agent: agentFilter || undefined,
       status: statusFilter || undefined,
-      author: authorFilter,
+      requestedBy: requesterFilter,
       offset: runs.length,
     });
     // `null` means the request failed; an empty page is a valid last page.
@@ -207,7 +207,7 @@ export function RecentRuns() {
       setHasMore(page.length === PAGE_SIZE);
     }
     setLoadingMore(false);
-  }, [runs, loadingMore, agentFilter, statusFilter, authorFilter]);
+  }, [runs, loadingMore, agentFilter, statusFilter, requesterFilter]);
 
   const hasFilters = Boolean(agentFilter || statusFilter || showAll);
 
@@ -217,7 +217,7 @@ export function RecentRuns() {
         <h2>Recent runs</h2>
         <div className="runs-filters">
           <select
-            aria-label="Filter by author"
+            aria-label="Filter by requester"
             value={showAll ? "all" : "mine"}
             onChange={(e) => setFilter("scope", e.target.value)}
           >
@@ -280,7 +280,7 @@ export function RecentRuns() {
                   <th>Run</th>
                   <th>Agent</th>
                   <th>Input</th>
-                  <th>Author</th>
+                  <th>Requested by</th>
                   <th>Status</th>
                   <th>Started</th>
                 </tr>
@@ -299,7 +299,7 @@ export function RecentRuns() {
                         <td>{r.agent}</td>
                         <td>{r.label}</td>
                         <td>
-                          <AuthorCell author={r.author} />
+                          <RequesterCell requestedBy={r.requestedBy} />
                         </td>
                         <td>
                           <StatusBadge status={r.status} />

--- a/services/hackbot-ui/components/RecentRuns.tsx
+++ b/services/hackbot-ui/components/RecentRuns.tsx
@@ -102,7 +102,7 @@ export function RecentRuns() {
   const statusFilter = searchParams.get("status") ?? "";
   // Default to "my runs"; `?scope=all` shows everyone's.
   const showAll = searchParams.get("scope") === "all";
-  const authorFilter = showAll ? undefined : myEmail ?? undefined;
+  const authorFilter = showAll ? undefined : (myEmail ?? undefined);
   // In "my runs" mode we need the signed-in email before we can filter, so hold
   // off fetching until the session resolves. Once resolved without an email
   // (shouldn't happen for an authed user), fall through to an unfiltered list.
@@ -197,7 +197,8 @@ export function RecentRuns() {
       author: authorFilter,
       offset: runs.length,
     });
-    if (page) {
+    // `null` means the request failed; an empty page is a valid last page.
+    if (page !== null) {
       setRuns((prev) => {
         const base = prev ?? [];
         const seen = new Set(base.map((r) => r.run_id));

--- a/services/hackbot-ui/components/RecentRuns.tsx
+++ b/services/hackbot-ui/components/RecentRuns.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Fragment, useCallback, useEffect, useState } from "react";
 
 import { AGENT_NAMES } from "@/lib/agents";
+import { useSession } from "@/lib/auth-client";
 import { isTerminal, type RunDoc, type RunStatus } from "@/lib/types";
 import { StatusBadge } from "./StatusBadge";
 
@@ -12,7 +13,7 @@ import { StatusBadge } from "./StatusBadge";
 // stays live without a full reload.
 const POLL_MS = 5000;
 const PAGE_SIZE = 50;
-const COLS = 5;
+const COLS = 6;
 
 const STATUS_OPTIONS: RunStatus[] = [
   "pending",
@@ -28,6 +29,7 @@ interface RunRow {
   agent: string;
   status: RunStatus;
   label: string;
+  author: string | null;
   created_at: string;
   error: string | null;
 }
@@ -52,6 +54,7 @@ function toRow(d: RunDoc): RunRow {
     agent: d.agent,
     status: d.status,
     label: labelFromInputs(d.inputs),
+    author: d.author,
     created_at: d.created_at,
     error: d.error,
   };
@@ -61,9 +64,18 @@ function hasErrorDetail(r: RunRow): boolean {
   return (r.status === "failed" || r.status === "timed_out") && !!r.error;
 }
 
+// Compact author cell: the email's local part (full email on hover). Runs with
+// no author come from automation (e.g. Phabricator webhooks).
+function AuthorCell({ author }: { author: string | null }) {
+  if (!author) return <span className="muted">automation</span>;
+  const localPart = author.split("@")[0];
+  return <span title={author}>{localPart}</span>;
+}
+
 async function fetchPage(params: {
   agent?: string;
   status?: string;
+  author?: string;
   offset: number;
 }): Promise<RunRow[] | null> {
   const qs = new URLSearchParams({
@@ -72,6 +84,7 @@ async function fetchPage(params: {
   });
   if (params.agent) qs.set("agent", params.agent);
   if (params.status) qs.set("status", params.status);
+  if (params.author) qs.set("author", params.author);
   const res = await fetch(`/api/runs?${qs.toString()}`);
   if (!res.ok) return null;
   const docs = (await res.json()) as RunDoc[];
@@ -82,22 +95,34 @@ export function RecentRuns() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const { data: session, isPending: sessionPending } = useSession();
+  const myEmail = session?.user?.email ?? null;
+
   const agentFilter = searchParams.get("agent") ?? "";
   const statusFilter = searchParams.get("status") ?? "";
+  // Default to "my runs"; `?scope=all` shows everyone's.
+  const showAll = searchParams.get("scope") === "all";
+  const authorFilter = showAll ? undefined : myEmail ?? undefined;
+  // In "my runs" mode we need the signed-in email before we can filter, so hold
+  // off fetching until the session resolves. Once resolved without an email
+  // (shouldn't happen for an authed user), fall through to an unfiltered list.
+  const sessionReady = showAll || myEmail !== null || !sessionPending;
 
   const [runs, setRuns] = useState<RunRow[] | null>(null);
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [failed, setFailed] = useState(false);
 
-  // (Re)load the first page whenever the filters change.
+  // (Re)load the first page whenever the filters (or resolved identity) change.
   useEffect(() => {
+    if (!sessionReady) return;
     let cancelled = false;
     setRuns(null);
     setFailed(false);
     fetchPage({
       agent: agentFilter || undefined,
       status: statusFilter || undefined,
+      author: authorFilter,
       offset: 0,
     }).then((page) => {
       if (cancelled) return;
@@ -113,7 +138,7 @@ export function RecentRuns() {
     return () => {
       cancelled = true;
     };
-  }, [agentFilter, statusFilter]);
+  }, [agentFilter, statusFilter, authorFilter, sessionReady]);
 
   // Live-status polling for the loaded, non-terminal runs — updated in place so
   // pagination/scroll position is preserved.
@@ -149,10 +174,14 @@ export function RecentRuns() {
   }, [runs]);
 
   const setFilter = useCallback(
-    (key: "agent" | "status", value: string) => {
+    (key: "agent" | "status" | "scope", value: string) => {
       const params = new URLSearchParams(searchParams.toString());
-      if (value) params.set(key, value);
-      else params.delete(key);
+      // "mine" is the default scope, so drop the param rather than storing it.
+      if (value && !(key === "scope" && value === "mine")) {
+        params.set(key, value);
+      } else {
+        params.delete(key);
+      }
       const qs = params.toString();
       router.push(qs ? `${pathname}?${qs}` : pathname);
     },
@@ -165,6 +194,7 @@ export function RecentRuns() {
     const page = await fetchPage({
       agent: agentFilter || undefined,
       status: statusFilter || undefined,
+      author: authorFilter,
       offset: runs.length,
     });
     if (page) {
@@ -176,15 +206,23 @@ export function RecentRuns() {
       setHasMore(page.length === PAGE_SIZE);
     }
     setLoadingMore(false);
-  }, [runs, loadingMore, agentFilter, statusFilter]);
+  }, [runs, loadingMore, agentFilter, statusFilter, authorFilter]);
 
-  const hasFilters = Boolean(agentFilter || statusFilter);
+  const hasFilters = Boolean(agentFilter || statusFilter || showAll);
 
   return (
     <>
       <div className="panel-head">
         <h2>Recent runs</h2>
         <div className="runs-filters">
+          <select
+            aria-label="Filter by author"
+            value={showAll ? "all" : "mine"}
+            onChange={(e) => setFilter("scope", e.target.value)}
+          >
+            <option value="mine">My runs</option>
+            <option value="all">All runs</option>
+          </select>
           <select
             aria-label="Filter by agent"
             value={agentFilter}
@@ -226,9 +264,11 @@ export function RecentRuns() {
         <p className="muted">Could not load runs. Try again shortly.</p>
       ) : runs.length === 0 ? (
         <p className="muted">
-          {hasFilters
+          {agentFilter || statusFilter
             ? "No runs match these filters."
-            : "No runs yet. Use the form above to trigger an agent."}
+            : showAll
+              ? "No runs yet. Use the form above to trigger an agent."
+              : "You haven't triggered any runs yet. Use the form above, or switch to “All runs” to see everyone's."}
         </p>
       ) : (
         <>
@@ -239,6 +279,7 @@ export function RecentRuns() {
                   <th>Run</th>
                   <th>Agent</th>
                   <th>Input</th>
+                  <th>Author</th>
                   <th>Status</th>
                   <th>Started</th>
                 </tr>
@@ -256,6 +297,9 @@ export function RecentRuns() {
                         </td>
                         <td>{r.agent}</td>
                         <td>{r.label}</td>
+                        <td>
+                          <AuthorCell author={r.author} />
+                        </td>
                         <td>
                           <StatusBadge status={r.status} />
                         </td>

--- a/services/hackbot-ui/lib/hackbot.ts
+++ b/services/hackbot-ui/lib/hackbot.ts
@@ -73,12 +73,16 @@ export function listAgents(): Promise<AgentDescriptor[]> {
 export function createRun(
   agentName: string,
   inputs: Record<string, unknown>,
+  author?: string | null,
 ): Promise<RunRef> {
   return request<RunRef>(
     `/agents/${encodeURIComponent(agentName)}/runs`,
     {
       method: "POST",
       body: JSON.stringify(inputs),
+      // Attribute the run to the authenticated user; the API records it so the
+      // dashboard can filter to "my runs".
+      headers: author ? { "X-Hackbot-Author": author } : undefined,
     },
   );
 }
@@ -92,6 +96,7 @@ export interface ListRunsParams {
   offset?: number;
   agent?: string;
   status?: string;
+  author?: string;
 }
 
 export function listRuns(params: ListRunsParams = {}): Promise<RunDoc[]> {
@@ -100,6 +105,7 @@ export function listRuns(params: ListRunsParams = {}): Promise<RunDoc[]> {
   if (params.offset) qs.set("offset", String(params.offset));
   if (params.agent) qs.set("agent", params.agent);
   if (params.status) qs.set("status", params.status);
+  if (params.author) qs.set("author", params.author);
   return request<RunDoc[]>(`/runs?${qs.toString()}`);
 }
 

--- a/services/hackbot-ui/lib/hackbot.ts
+++ b/services/hackbot-ui/lib/hackbot.ts
@@ -9,7 +9,7 @@ import type { AgentDescriptor, RunAction, RunDoc, RunRef } from "./types";
 export class HackbotError extends Error {
   constructor(
     message: string,
-    readonly status: number,
+    readonly status: number
   ) {
     super(message);
     this.name = "HackbotError";
@@ -28,10 +28,7 @@ function config(): { baseUrl: string; apiKey: string } {
   return { baseUrl: baseUrl.replace(/\/$/, ""), apiKey };
 }
 
-async function request<T>(
-  path: string,
-  init: RequestInit = {},
-): Promise<T> {
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
   const { baseUrl, apiKey } = config();
   const res = await fetch(`${baseUrl}${path}`, {
     ...init,
@@ -73,18 +70,13 @@ export function listAgents(): Promise<AgentDescriptor[]> {
 export function createRun(
   agentName: string,
   inputs: Record<string, unknown>,
-  author?: string | null,
+  requestedBy?: string | null
 ): Promise<RunRef> {
-  return request<RunRef>(
-    `/agents/${encodeURIComponent(agentName)}/runs`,
-    {
-      method: "POST",
-      body: JSON.stringify(inputs),
-      // Attribute the run to the authenticated user; the API records it so the
-      // dashboard can filter to "my runs".
-      headers: author ? { "X-Hackbot-Author": author } : undefined,
-    },
-  );
+  return request<RunRef>(`/agents/${encodeURIComponent(agentName)}/runs`, {
+    method: "POST",
+    body: JSON.stringify(inputs),
+    headers: requestedBy ? { "X-On-Behalf-Of": requestedBy } : undefined,
+  });
 }
 
 export function getRun(runId: string): Promise<RunDoc> {
@@ -96,7 +88,7 @@ export interface ListRunsParams {
   offset?: number;
   agent?: string;
   status?: string;
-  author?: string;
+  requestedBy?: string;
 }
 
 export function listRuns(params: ListRunsParams = {}): Promise<RunDoc[]> {
@@ -105,7 +97,7 @@ export function listRuns(params: ListRunsParams = {}): Promise<RunDoc[]> {
   if (params.offset) qs.set("offset", String(params.offset));
   if (params.agent) qs.set("agent", params.agent);
   if (params.status) qs.set("status", params.status);
-  if (params.author) qs.set("author", params.author);
+  if (params.requestedBy) qs.set("requested_by", params.requestedBy);
   return request<RunDoc[]>(`/runs?${qs.toString()}`);
 }
 
@@ -117,7 +109,7 @@ export function listRunActions(runId: string): Promise<RunAction[]> {
 export function applyRunActions(runId: string): Promise<RunAction[]> {
   return request<RunAction[]>(
     `/runs/${encodeURIComponent(runId)}/actions/apply`,
-    { method: "POST" },
+    { method: "POST" }
   );
 }
 
@@ -126,13 +118,10 @@ export function applyRunActions(runId: string): Promise<RunAction[]> {
 // the upstream `{artifact_path:path}` route still sees the directory structure.
 export function getArtifactDownloadUrl(
   runId: string,
-  artifactName: string,
+  artifactName: string
 ): Promise<{ url: string }> {
-  const encodedPath = artifactName
-    .split("/")
-    .map(encodeURIComponent)
-    .join("/");
+  const encodedPath = artifactName.split("/").map(encodeURIComponent).join("/");
   return request<{ url: string }>(
-    `/runs/${encodeURIComponent(runId)}/artifacts/${encodedPath}`,
+    `/runs/${encodeURIComponent(runId)}/artifacts/${encodedPath}`
   );
 }

--- a/services/hackbot-ui/lib/types.ts
+++ b/services/hackbot-ui/lib/types.ts
@@ -62,6 +62,8 @@ export interface RunDoc {
   agent: string;
   status: RunStatus;
   inputs: Record<string, unknown>;
+  // Email of the user who triggered the run, or null for automation/legacy runs.
+  author: string | null;
   created_at: string;
   updated_at: string;
   execution_name: string | null;

--- a/services/hackbot-ui/lib/types.ts
+++ b/services/hackbot-ui/lib/types.ts
@@ -62,8 +62,7 @@ export interface RunDoc {
   agent: string;
   status: RunStatus;
   inputs: Record<string, unknown>;
-  // Email of the user who triggered the run, or null for automation/legacy runs.
-  author: string | null;
+  requested_by: string | null;
   created_at: string;
   updated_at: string;
   execution_name: string | null;


### PR DESCRIPTION
Runs now record the email of the user who triggered them from the UI, so the dashboard can default to "my runs" and show who launched each run.

- hackbot-api: add nullable, indexed `author` column (migration d2b7a4c1e8f0); `create_run` reads it from the `X-Hackbot-Author` header (automation such as the Phabricator webhook omits it); `list_runs` gains an `author` filter matched case-insensitively; `RunDoc` exposes it.
- hackbot-ui: the /api/runs proxy attributes POSTs to the authenticated session email and forwards the `author` filter on GET; Recent runs defaults to "My runs", adds a My runs / All runs selector, and shows an Author column.