### PR TITLE
hackbot: run per-action-type hooks before recording an action

### DIFF
--- a/libs/hackbot-runtime/hackbot_runtime/actions/__init__.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/__init__.py
@@ -8,12 +8,13 @@ claude-sdk adapter is ``hackbot_runtime.actions.claude_sdk.actions_server_for``.
 """
 
 from hackbot_runtime.actions import bugzilla, phabricator, testrail
-from hackbot_runtime.actions.recorder import ActionsRecorder
+from hackbot_runtime.actions.recorder import ActionHook, ActionsRecorder
 
 ACTIONS_SERVER_NAME = "actions"
 
 __all__ = [
     "ACTIONS_SERVER_NAME",
+    "ActionHook",
     "ActionsRecorder",
     "bugzilla",
     "phabricator",

--- a/libs/hackbot-runtime/hackbot_runtime/actions/recorder.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/recorder.py
@@ -1,7 +1,16 @@
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 
 from hackbot_runtime.artifacts import publish_file
 from hackbot_runtime.uploader import SignedPolicyUploader
+
+# Callback run on an action of one type before it is recorded. It receives the
+# action dict (``type``/``params``/``reasoning``, plus ``ref`` when given) and
+# may mutate it in place; the return value is ignored. Raising aborts the
+# recording (nothing is appended and no attachment is published), so a hook
+# doubles as a validation gate: raise ``ToolError`` to report the reason back to
+# the agent.
+ActionHook = Callable[[dict], None]
 
 
 class ActionsRecorder:
@@ -14,16 +23,35 @@ class ActionsRecorder:
     Framework-agnostic: knows nothing about MCP, LangChain, or any specific
     action domain. Per-framework adapters wrap this and translate their
     native tool calls into ``record(...)`` calls.
+
+    ``hooks`` maps an action type to the :data:`ActionHook` callbacks to run,
+    in order, before that action is appended. They live here rather than in the
+    action declarations so the runtime can attach behaviour that cuts across
+    domains (enrichment, validation) without every ``@tool`` handler knowing
+    about it.
     """
 
     def __init__(
         self,
         uploader: SignedPolicyUploader | None = None,
         artifacts_dir: Path | None = None,
+        hooks: Mapping[str, Sequence[ActionHook]] = {},
     ) -> None:
         self._actions: list[dict] = []
         self._uploader = uploader
         self._artifacts_dir = artifacts_dir
+        self._hooks = {
+            action_type: list(action_hooks)
+            for action_type, action_hooks in hooks.items()
+        }
+
+    def add_hook(self, action_type: str, hook: ActionHook) -> None:
+        """Append ``hook`` to the hooks run for ``action_type``.
+
+        For wiring a hook after construction; it runs after any hook already
+        registered for that type.
+        """
+        self._hooks.setdefault(action_type, []).append(hook)
 
     def record(
         self,
@@ -52,6 +80,13 @@ class ActionsRecorder:
         ``phabricator.submit_patch`` action recorded with ``ref="patch"``).
         Resolved by the apply step, since the result doesn't exist yet at
         record time.
+
+        Any hooks registered for ``action_type`` run on the action, in
+        registration order, and may still change it (see :data:`ActionHook`). A
+        hook that raises propagates to the caller and the action is not
+        recorded. Hooks run before ``attachments`` are published, so an aborted
+        recording leaves nothing behind: the action the hooks see carries no
+        ``attachments`` key yet.
         """
         idx = len(self._actions)
         action: dict = {
@@ -61,6 +96,9 @@ class ActionsRecorder:
         }
         if ref is not None:
             action["ref"] = ref
+
+        for hook in self._hooks.get(action_type, ()):
+            hook(action)
 
         if attachments:
             recorded_attachments: list[dict] = []

--- a/libs/hackbot-runtime/tests/test_recorder.py
+++ b/libs/hackbot-runtime/tests/test_recorder.py
@@ -1,7 +1,8 @@
-"""Tests for ActionsRecorder: attachment upload vs local-copy behavior."""
+"""Tests for ActionsRecorder: attachment upload vs local-copy behavior, hooks."""
 
 from pathlib import Path
 
+import pytest
 from hackbot_runtime.actions import ActionsRecorder
 
 
@@ -88,3 +89,131 @@ def test_ref_omitted_when_not_given():
     rec = ActionsRecorder()
     rec.record("bugzilla.update_bug", {"bug_id": 1})
     assert "ref" not in rec.actions[0]
+
+
+def test_hooks_run_in_order_and_mutations_are_recorded():
+    calls: list[str] = []
+
+    def first(action):
+        calls.append("first")
+        action["params"]["priority"] = "P1"
+
+    def second(action):
+        calls.append("second")
+        # Sees the previous hook's mutation, and the built action.
+        action["params"]["seen"] = action["params"]["priority"]
+
+    rec = ActionsRecorder(hooks={"bugzilla.update_bug": [first, second]})
+    returned = rec.record("bugzilla.update_bug", {"bug_id": 1}, reasoning="rule X")
+
+    assert calls == ["first", "second"]
+    assert returned["params"] == {"bug_id": 1, "priority": "P1", "seen": "P1"}
+    assert rec.actions[0] == returned
+
+
+def test_hooks_only_run_for_their_action_type():
+    seen: list[str] = []
+    rec = ActionsRecorder(
+        hooks={"phabricator.submit_patch": [lambda action: seen.append(action["type"])]}
+    )
+
+    rec.record("bugzilla.add_comment", {"bug_id": 1})
+    assert seen == []
+
+    rec.record("phabricator.submit_patch", {"bug_id": 1})
+    assert seen == ["phabricator.submit_patch"]
+
+
+def test_hook_sees_ref_but_runs_before_attachments_are_published(tmp_path):
+    src = tmp_path / "fix.patch"
+    src.write_text("diff")
+    captured: list[dict] = []
+
+    def capture(action):
+        captured.append(dict(action))
+
+    rec = ActionsRecorder(
+        artifacts_dir=tmp_path / "a",
+        hooks={"bugzilla.add_attachment": [capture]},
+    )
+    recorded = rec.record(
+        "bugzilla.add_attachment",
+        {"bug_id": 1},
+        ref="patch",
+        attachments={"file": src},
+    )
+
+    assert captured[0]["ref"] == "patch"
+    # Publishing happens only once the hooks have accepted the action.
+    assert "attachments" not in captured[0]
+    assert recorded["attachments"] == [
+        {"name": "file", "uploaded_key": "attachments/0/file"}
+    ]
+
+
+def test_raising_hook_aborts_the_recording():
+    def reject(action):
+        raise ValueError("no")
+
+    def never(action):  # pragma: no cover - must not run
+        raise AssertionError("later hook ran after an earlier one raised")
+
+    rec = ActionsRecorder(hooks={"bugzilla.update_bug": [reject, never]})
+
+    with pytest.raises(ValueError, match="no"):
+        rec.record("bugzilla.update_bug", {"bug_id": 1})
+
+    assert rec.actions == []
+
+
+def test_raising_hook_publishes_no_attachment(tmp_path):
+    src = tmp_path / "fix.patch"
+    src.write_text("diff")
+    uploader = _StubUploader()
+    artifacts = tmp_path / "artifacts"
+
+    def reject(action):
+        raise ValueError("no")
+
+    rec = ActionsRecorder(
+        uploader=uploader,
+        artifacts_dir=artifacts,
+        hooks={"bugzilla.add_attachment": [reject]},
+    )
+
+    with pytest.raises(ValueError, match="no"):
+        rec.record("bugzilla.add_attachment", {"bug_id": 1}, attachments={"file": src})
+
+    # Nothing uploaded or copied: an aborted recording leaves no orphaned file
+    # at a key the next recorded action would reuse.
+    assert uploader.uploaded == []
+    assert not artifacts.exists()
+
+    # The next successful record still owns attachments/0, with no leftover
+    # from the rejected action sitting at that key.
+    rec.record("bugzilla.update_bug", {"bug_id": 1})
+    assert [a["type"] for a in rec.actions] == ["bugzilla.update_bug"]
+
+
+def test_add_hook_appends_after_constructor_hooks():
+    calls: list[str] = []
+    rec = ActionsRecorder(
+        hooks={"bugzilla.update_bug": [lambda action: calls.append("ctor")]}
+    )
+    rec.add_hook("bugzilla.update_bug", lambda action: calls.append("added"))
+    rec.add_hook("bugzilla.add_comment", lambda action: calls.append("other-type"))
+
+    rec.record("bugzilla.update_bug", {"bug_id": 1})
+
+    assert calls == ["ctor", "added"]
+
+
+def test_constructor_hooks_are_copied():
+    hooks: dict[str, list] = {"bugzilla.update_bug": []}
+    rec = ActionsRecorder(hooks=hooks)
+    hooks["bugzilla.update_bug"].append(
+        lambda action: pytest.fail("mutating the caller's mapping must not register")
+    )
+
+    rec.record("bugzilla.update_bug", {"bug_id": 1})
+    assert len(rec.actions) == 1


### PR DESCRIPTION
Resolves #6424

ActionsRecorder now takes a mapping of action type to hooks (plus add_hook for wiring one after construction). Each hook receives the fully built action dict just before it is appended and may mutate it in place; raising aborts the recording, so a hook also serves as a validation gate.

Hooks live on the recorder so the runtime can attach behaviour that cuts across action domains without every handler knowing about it.