### PR TITLE
Preserve Phabricator diff author on patch updates

### DIFF
--- a/libs/hackbot-runtime/hackbot_runtime/actions/handlers/phabricator_handler.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/handlers/phabricator_handler.py
@@ -127,24 +127,23 @@ async def _diff_commits(diff_id: Any) -> list[dict]:
     return commits if isinstance(commits, list) else []
 
 
-def _preserve_local_commit_authors(
-    local_commits: dict, previous_commits: list[dict]
-) -> None:
-    """Copy the previous diff's commit author identity onto new commit metadata."""
+def _local_commit_author_fields(previous_commits: list[dict]) -> dict[str, str]:
+    """Return the previous diff's commit author identity."""
     if not previous_commits:
-        return
+        return {}
 
     previous_author = previous_commits[-1].get("author") or {}
-    author_fields = {}
-    if previous_author.get("name"):
-        author_fields["author"] = previous_author["name"]
-    if previous_author.get("email"):
-        author_fields["authorEmail"] = previous_author["email"]
-    if not author_fields:
-        return
+    if not previous_author.get("name") or not previous_author.get("email"):
+        log.warning(
+            "Could not preserve local commit author: previous diff author metadata "
+            "is incomplete"
+        )
+        return {}
 
-    for commit_info in local_commits.values():
-        commit_info.update(author_fields)
+    return {
+        "author": previous_author["name"],
+        "authorEmail": previous_author["email"],
+    }
 
 
 def _arc_commit_message(title: str, summary: str | None, bug_id: Any, url: str) -> str:
@@ -309,17 +308,11 @@ class UpdatePatchHandler:
         try:
             fields = await _revision_fields(revision_id)
             previous_diff_id = fields.get("diffID")
-            try:
-                _preserve_local_commit_authors(
-                    submission["local_commits"],
-                    await _diff_commits(previous_diff_id),
-                )
-            except Exception:
-                log.warning(
-                    "Could not preserve local commit author from previous diff %s",
-                    previous_diff_id,
-                    exc_info=True,
-                )
+            author_fields = _local_commit_author_fields(
+                await _diff_commits(previous_diff_id)
+            )
+            for commit_info in submission["local_commits"].values():
+                commit_info.update(author_fields)
 
             diff_result = await _conduit_request(
                 "differential.creatediff",

--- a/libs/hackbot-runtime/hackbot_runtime/actions/handlers/phabricator_handler.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/handlers/phabricator_handler.py
@@ -108,6 +108,45 @@ async def _revision_fields(revision_id: int) -> dict:
     return data[0].get("fields", {}) if data else {}
 
 
+async def _diff_commits(diff_id: Any) -> list[dict]:
+    """Return a diff's existing local commits from ``differential.diff.search``."""
+    if not diff_id:
+        return []
+
+    result = await _conduit_request(
+        "differential.diff.search",
+        constraints={"ids": [int(diff_id)]},
+        attachments={"commits": True},
+        limit=1,
+    )
+    data = result.get("data") or []
+    if not data:
+        return []
+
+    commits = data[0].get("attachments", {}).get("commits", {}).get("commits", [])
+    return commits if isinstance(commits, list) else []
+
+
+def _preserve_local_commit_authors(
+    local_commits: dict, previous_commits: list[dict]
+) -> None:
+    """Copy the previous diff's commit author identity onto new commit metadata."""
+    if not previous_commits:
+        return
+
+    previous_author = previous_commits[-1].get("author") or {}
+    author_fields = {}
+    if previous_author.get("name"):
+        author_fields["author"] = previous_author["name"]
+    if previous_author.get("email"):
+        author_fields["authorEmail"] = previous_author["email"]
+    if not author_fields:
+        return
+
+    for commit_info in local_commits.values():
+        commit_info.update(author_fields)
+
+
 def _arc_commit_message(title: str, summary: str | None, bug_id: Any, url: str) -> str:
     """Build moz-phab's arc commit message, with the Differential Revision URL.
 
@@ -247,7 +286,10 @@ class UpdatePatchHandler:
     Only the diff changes: title, summary, bug id, and review status are left
     exactly as they are, so an update never overwrites something a reviewer or
     the patch author has since edited. The revision's fields are read only to
-    rebuild the ``local:commits`` message, which has to match the revision.
+    rebuild the ``local:commits`` message, which has to match the revision. The
+    previous diff's commit author is preserved so updating a patch does not
+    silently replace the author's identity with Hackbot's synthetic commit
+    identity.
     """
 
     async def apply(self, params: dict[str, Any], ctx: ApplyContext) -> ActionResult:
@@ -265,6 +307,20 @@ class UpdatePatchHandler:
             )
 
         try:
+            fields = await _revision_fields(revision_id)
+            previous_diff_id = fields.get("diffID")
+            try:
+                _preserve_local_commit_authors(
+                    submission["local_commits"],
+                    await _diff_commits(previous_diff_id),
+                )
+            except Exception:
+                log.warning(
+                    "Could not preserve local commit author from previous diff %s",
+                    previous_diff_id,
+                    exc_info=True,
+                )
+
             diff_result = await _conduit_request(
                 "differential.creatediff",
                 repositoryPHID=await _repository_phid(),
@@ -276,7 +332,6 @@ class UpdatePatchHandler:
                 transactions=[{"type": "update", "value": diff_result["phid"]}],
             )
 
-            fields = await _revision_fields(revision_id)
             await _set_local_commits(
                 diff_result["diffid"],
                 submission["local_commits"],

--- a/libs/hackbot-runtime/tests/test_phabricator_handler.py
+++ b/libs/hackbot-runtime/tests/test_phabricator_handler.py
@@ -266,6 +266,76 @@ async def test_update_patch_local_commits_use_the_revisions_own_fields(monkeypat
     )
 
 
+async def test_update_patch_preserves_previous_diff_commit_author(monkeypatch):
+    fake, calls = _fake_conduit(
+        {
+            "differential.creatediff": {"phid": "PHID-DIFF-NEW", "diffid": 8},
+            "differential.revision.edit": {"object": {"id": 42}},
+            "differential.revision.search": {
+                "data": [
+                    {
+                        "fields": {
+                            "title": "WIP: Existing title",
+                            "summary": "old sum",
+                            "bugzilla.bug-id": "9",
+                            "diffID": 7,
+                        }
+                    }
+                ]
+            },
+            "differential.diff.search": {
+                "data": [
+                    {
+                        "id": 1335196,
+                        "type": "DIFF",
+                        "phid": "PHID-DIFF-j6xoinvjxogsqyfmelha",
+                        "attachments": {
+                            "commits": {
+                                "commits": [
+                                    {
+                                        "identifier": "d0b3319556e92ee5f25590c40562f4ce4d7909f2",
+                                        "author": {
+                                            "name": "Patch Author",
+                                            "email": "author@mozilla.example",
+                                            "raw": "Patch Author <author@mozilla.example>",
+                                            "epoch": 1,
+                                        },
+                                    }
+                                ]
+                            }
+                        },
+                    }
+                ]
+            },
+            "differential.setdiffproperty": {},
+        }
+    )
+    monkeypatch.setattr(phabricator_handler, "_conduit_request", fake)
+    monkeypatch.setattr(
+        phabricator_handler, "_repository_phid", AsyncMock(return_value="PHID-REPO-1")
+    )
+
+    result = await phabricator_handler.UpdatePatchHandler().apply(
+        {"revision_id": 42},
+        _ctx(
+            local_commits={
+                "new-node": {
+                    "author": "Hackbot Agent",
+                    "authorEmail": "hackbot@mozilla.tld",
+                    "commit": "new-node",
+                }
+            }
+        ),
+    )
+    assert result.status == "applied"
+
+    prop_call = next(c for c in calls if c[0] == "differential.setdiffproperty")
+    stored = json.loads(prop_call[1]["data"])["new-node"]
+    assert stored["author"] == "Patch Author"
+    assert stored["authorEmail"] == "author@mozilla.example"
+    assert stored["commit"] == "new-node"
+
+
 @pytest.mark.parametrize(
     ("handler", "params"),
     [


### PR DESCRIPTION

## Summary

Preserve the original patch author when Hackbot updates an existing Phabricator revision.

Before this change, updating a patch could replace the reconstructed commit author with Hackbot's synthetic author. Now, updates keep the author name and email from the previous diff instead.

## Tests

Added a test that covers updating an existing Phabricator revision and verifies the new diff keeps the previous author metadata.



Resolves #6411
