### PR TITLE
Make code review agent aware of the current date

### DIFF
--- a/bugbug/tools/code_review/agent.py
+++ b/bugbug/tools/code_review/agent.py
@@ -268,7 +268,6 @@ class CodeReviewTool(GenerativeModelTool):
         Returns at most one comment. Empty when no split is warranted.
         """
         prompt = PATCH_SCOPE_PROMPT.format(
-            current_date=current_date_for_prompt(),
             target_software=self.target_software,
             patch=format_patch_set(patch.patch_set),
             patch_summary=patch_summary,

--- a/bugbug/tools/code_review/agent.py
+++ b/bugbug/tools/code_review/agent.py
@@ -7,7 +7,7 @@
 
 import json
 import os
-from datetime import datetime
+from datetime import UTC, datetime
 from logging import getLogger
 from typing import Optional
 
@@ -59,6 +59,10 @@ from bugbug.tools.core.llms import DEFAULT_ANTHROPIC_MODEL, get_tokenizer
 from bugbug.tools.core.platforms.base import Patch
 
 logger = getLogger(__name__)
+
+
+def current_date_for_prompt() -> str:
+    return datetime.now(UTC).date().isoformat()
 
 
 class CodeReviewTool(GenerativeModelTool):
@@ -209,6 +213,7 @@ class CodeReviewTool(GenerativeModelTool):
         created_before = patch.date_created if self.is_experiment_env else None
 
         return FIRST_MESSAGE_TEMPLATE.format(
+            current_date=current_date_for_prompt(),
             patch=format_patch_set(patch.patch_set),
             patch_summarization=patch_summary,
             external_context=external_context,
@@ -263,6 +268,7 @@ class CodeReviewTool(GenerativeModelTool):
         Returns at most one comment. Empty when no split is warranted.
         """
         prompt = PATCH_SCOPE_PROMPT.format(
+            current_date=current_date_for_prompt(),
             target_software=self.target_software,
             patch=format_patch_set(patch.patch_set),
             patch_summary=patch_summary,

--- a/bugbug/tools/code_review/prompts.py
+++ b/bugbug/tools/code_review/prompts.py
@@ -60,8 +60,6 @@ Do not write comments that:
 
 PATCH_SCOPE_PROMPT = """You are an expert {target_software} engineer assessing whether a pull request is too large or unfocused to be reviewed well.
 
-Current date: {current_date}
-
 Large changes are harder to review and empirically carry higher defect and regression risk: reviewer defect-detection drops sharply once a change grows past a few hundred changed lines, and at Mozilla the patches that introduce regressions tend to be the larger ones.
 
 Decide whether to suggest the author split this patch into smaller, independently reviewable pieces. Either of these is a reason to suggest a split:

--- a/bugbug/tools/code_review/prompts.py
+++ b/bugbug/tools/code_review/prompts.py
@@ -60,6 +60,8 @@ Do not write comments that:
 
 PATCH_SCOPE_PROMPT = """You are an expert {target_software} engineer assessing whether a pull request is too large or unfocused to be reviewed well.
 
+Current date: {current_date}
+
 Large changes are harder to review and empirically carry higher defect and regression risk: reviewer defect-detection drops sharply once a change grows past a few hundred changed lines, and at Mozilla the patches that introduce regressions tend to be the larger ones.
 
 Decide whether to suggest the author split this patch into smaller, independently reviewable pieces. Either of these is a reason to suggest a split:
@@ -89,7 +91,9 @@ Here is the patch you need to assess:
 """
 
 
-FIRST_MESSAGE_TEMPLATE = """Here is a summary of the patch:
+FIRST_MESSAGE_TEMPLATE = """Current date: {current_date}
+
+Here is a summary of the patch:
 
 <patch_summary>
 {patch_summarization}

--- a/tests/test_code_review.py
+++ b/tests/test_code_review.py
@@ -1284,6 +1284,26 @@ def _make_scope_tool(scope_response):
     return tool
 
 
+def test_generate_initial_prompt_includes_current_date():
+    pytest.importorskip("langchain")
+    from bugbug.tools.code_review.agent import CodeReviewTool
+
+    tool = CodeReviewTool.__new__(CodeReviewTool)
+    tool.is_experiment_env = False
+    tool._get_comment_examples = MagicMock(return_value="")
+    tool._get_generated_examples = MagicMock(return_value="")
+
+    review_patch = make_patch("--- a/f.txt\n+++ b/f.txt\n@@ -0,0 +1 @@\n+a\n")
+
+    with patch(
+        "bugbug.tools.code_review.agent.current_date_for_prompt",
+        return_value="2026-07-30",
+    ):
+        prompt = tool.generate_initial_prompt(review_patch, "summary")
+
+    assert "Current date: 2026-07-30" in prompt
+
+
 def test_assess_patch_scope_returns_at_most_one_comment():
     # The model returns two comments; the pass must keep only the first.
     comments = [
@@ -1303,6 +1323,20 @@ def test_assess_patch_scope_returns_at_most_one_comment():
 
     assert len(result) == 1
     assert result[0].comment == "Split this patch 0"
+
+
+def test_assess_patch_scope_prompt_includes_current_date():
+    tool = _make_scope_tool(PatchScopeResponse(comments=[]))
+
+    review_patch = make_patch("--- a/f.txt\n+++ b/f.txt\n@@ -0,0 +1,2 @@\n+a\n+b\n")
+    with patch(
+        "bugbug.tools.code_review.agent.current_date_for_prompt",
+        return_value="2026-07-30",
+    ):
+        asyncio.run(tool.assess_patch_scope(review_patch, "summary"))
+
+    prompt = tool.scope_agent.ainvoke.call_args.args[0]["messages"][0].content
+    assert "Current date: 2026-07-30" in prompt
 
 
 def test_assess_patch_scope_returns_empty_when_no_split_warranted():

--- a/tests/test_code_review.py
+++ b/tests/test_code_review.py
@@ -1284,26 +1284,6 @@ def _make_scope_tool(scope_response):
     return tool
 
 
-def test_generate_initial_prompt_includes_current_date():
-    pytest.importorskip("langchain")
-    from bugbug.tools.code_review.agent import CodeReviewTool
-
-    tool = CodeReviewTool.__new__(CodeReviewTool)
-    tool.is_experiment_env = False
-    tool._get_comment_examples = MagicMock(return_value="")
-    tool._get_generated_examples = MagicMock(return_value="")
-
-    review_patch = make_patch("--- a/f.txt\n+++ b/f.txt\n@@ -0,0 +1 @@\n+a\n")
-
-    with patch(
-        "bugbug.tools.code_review.agent.current_date_for_prompt",
-        return_value="2026-07-30",
-    ):
-        prompt = tool.generate_initial_prompt(review_patch, "summary")
-
-    assert "Current date: 2026-07-30" in prompt
-
-
 def test_assess_patch_scope_returns_at_most_one_comment():
     # The model returns two comments; the pass must keep only the first.
     comments = [
@@ -1323,20 +1303,6 @@ def test_assess_patch_scope_returns_at_most_one_comment():
 
     assert len(result) == 1
     assert result[0].comment == "Split this patch 0"
-
-
-def test_assess_patch_scope_prompt_includes_current_date():
-    tool = _make_scope_tool(PatchScopeResponse(comments=[]))
-
-    review_patch = make_patch("--- a/f.txt\n+++ b/f.txt\n@@ -0,0 +1,2 @@\n+a\n+b\n")
-    with patch(
-        "bugbug.tools.code_review.agent.current_date_for_prompt",
-        return_value="2026-07-30",
-    ):
-        asyncio.run(tool.assess_patch_scope(review_patch, "summary"))
-
-    prompt = tool.scope_agent.ainvoke.call_args.args[0]["messages"][0].content
-    assert "Current date: 2026-07-30" in prompt
 
 
 def test_assess_patch_scope_returns_empty_when_no_split_warranted():


### PR DESCRIPTION
Resolves  #6376

This PR makes the code review agent include the current UTC date in its prompt on every review call.

The change applies to both review flows:
the main code review prompt
the patch-scope review prompt