### PR TITLE
Auto-apply high-confidence frontend-triage results

### DIFF
--- a/agents/frontend-triage/README.md
+++ b/agents/frontend-triage/README.md
@@ -76,8 +76,11 @@ Each run writes to `~/hackbot/artifacts/<run_id>/`:
 
 - **`summary.json`** — `findings` holds the structured plan (`root_cause`,
   `proposed_fix`, `target_files`, `confidence`) plus the executor handoff fields
-  `actionable`, `regressor_node` and `relevant_tests`. `actions` holds the
-  **recorded** Bugzilla comment — written here for review, not posted.
+  `actionable`, `regressor_node` and `relevant_tests`, plus `auto_apply` — the
+  run's own verdict on whether it may be posted without review. `actions` holds
+  the **recorded** Bugzilla comment (and, at high confidence, possibly a field
+  change). Recording is not posting, but see below: an `auto_apply` run's actions
+  do reach the bug unattended.
 - **`logs/agent.log`** — the streamed reasoning and every tool call, and the only
   record of which model actually ran.
 - **No `changes/` directory.** Its absence confirms the run stayed read-only.
@@ -99,11 +102,33 @@ Two caveats before acting on a plan:
 `bugzilla.add_comment` and `bugzilla.update_bug`, but those come from an
 in-process actions server that appends to `summary.json` and makes no network
 calls. The only Bugzilla access the agent has is through the broker sidecar,
-which exposes five read tools and holds the API key. Applying a recorded action
-is a separate, human step from the Hackbot UI — unlike `bug-fix`, this agent
-does not set `auto_apply_actions`.
+which exposes five read tools and holds the API key.
 
-Two hooks shape the comment as it is recorded:
+**Afterwards, though, a confident run posts itself.** When the run reports
+`confidence: high` and does not report `actionable: false`, it sets
+`findings.auto_apply`, and hackbot-api applies the recorded actions to the real
+bug with nobody in between. `may_apply_unattended()` in `agent.py` is that
+decision in full. Medium and low are held for a person to apply from the Hackbot
+UI, as before.
+
+Judgement and reach are bounded separately, because an action's params are model
+output no matter how sure the agent is — and the agent spends the run reading bug
+comments nobody controls. Two hooks in `hooks.py` refuse an action outright as it
+is recorded, and they are the only thing bounding what an unattended run writes:
+hackbot-api applies whatever it finds in `summary.json`, dispatching it against a
+handler registry far wider than the tools this agent was given.
+
+- `add_comment_hook` — one comment, public, on the bug being triaged.
+- `update_bug_hook` — one field change, add-only, on the bug being triaged, and
+  only `keywords`/`severity` with values from `TRIAGE_SEVERITIES` /
+  `TRIAGE_KEYWORDS` in `config.py`. Widen those sets alongside the rule that needs
+  the new value.
+
+A refusal reaches the agent as a tool error it can correct in the same run, and the
+action never lands in `summary.json`. The action _type_ needs no check:
+`ENABLED_ACTION_TYPES` decides which tools the actions server exposes at all.
+
+Two further hooks shape the comment text as it is recorded:
 
 - `permalink_hook` expands `{{searchfox.permalink}}/<path>#<line>` into
   `https://searchfox.org/firefox-main/rev/<sha>/…`, so every source reference

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
@@ -49,6 +49,7 @@ from .config import (
     MOZILLA_VCS_TOOLS,
     SEARCHFOX_TOOLS,
 )
+from .hooks import add_comment_hook, update_bug_hook
 
 HERE = Path(__file__).resolve().parent
 
@@ -98,6 +99,10 @@ class FrontendTriageResult(HackbotAgentResult):
     )
     # Triage judgments (best-effort, parsed from the agent's final message).
     severity_assessment: SeverityAssessment | None = None
+    # This run's verdict on whether its recorded actions may reach the bug without a
+    # human, computed by `may_apply_unattended`. hackbot-api reads it and still has
+    # the final say.
+    auto_apply: bool = False
     # The agent's full final message, always present as a fallback.
     result: str | None = None
 
@@ -168,6 +173,42 @@ def make_investigator() -> AgentDefinition:
     )
 
 
+CONFIDENCE_LEVELS = ("high", "medium", "low")
+
+
+def parse_confidence(value: object) -> str | None:
+    """One of :data:`CONFIDENCE_LEVELS`, or None if ``value`` isn't one.
+
+    The value comes out of the agent's free-form JSON block and decides whether the
+    run's actions are posted, so casing and stray whitespace are tolerated rather
+    than letting `"High"` read as "not high". Anything else returns None, so callers
+    fail closed rather than inventing a level.
+    """
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized if normalized in CONFIDENCE_LEVELS else None
+
+
+def may_apply_unattended(plan: dict) -> bool:
+    """Whether this run's recorded actions may reach the bug without a human.
+
+    Recorded as ``findings.auto_apply``. This lives in the agent rather than in
+    hackbot-api because it turns on the agent's self-reported rating, which arrives
+    in the final message *after* every action is already recorded.
+
+    Two conditions, both failing closed on a plan that didn't parse:
+
+    - ``confidence: high`` — the run localized the cause in specific code.
+    - ``actionable`` is not false. ``rules/scoping.md`` pairs an out-of-scope report
+      with ``confidence: low``, but nothing makes the agent pair them, so a
+      ``high`` + ``actionable: false`` run would otherwise post an out-of-scope note
+      on the strength of the confidence alone. The test is ``is not False`` so that
+      a missing ``actionable`` doesn't read as out of scope.
+    """
+    return plan.get("confidence") == "high" and plan.get("actionable") is not False
+
+
 def parse_plan(text: str | None) -> dict:
     """Extract the structured plan from the agent's final message, if present.
 
@@ -207,7 +248,7 @@ def parse_plan(text: str | None) -> dict:
         "root_cause": data.get("root_cause"),
         "proposed_fix": data.get("proposed_fix"),
         "target_files": _as_list(data.get("target_files")),
-        "confidence": data.get("confidence"),
+        "confidence": parse_confidence(data.get("confidence")),
         "actionable": actionable,
         "regressor_node": data.get("regressor_node"),
         "relevant_tests": _as_list(data.get("relevant_tests")),
@@ -267,6 +308,17 @@ async def run_frontend_triage(
             "[frontend_triage] no searchfox revision; linking tip-of-tree",
             file=sys.stderr,
         )
+    # Bound what the agent may record, at the moment it records it. These are the
+    # only check on what an unattended run writes to a bug — see hooks.py. Registered
+    # ahead of the hooks below so a refusal happens before the comment body is
+    # rewritten.
+    actions_recorder.add_hook(
+        "bugzilla.add_comment", add_comment_hook(actions_recorder, bug)
+    )
+    actions_recorder.add_hook(
+        "bugzilla.update_bug", update_bug_hook(actions_recorder, bug)
+    )
+
     actions_recorder.add_hook(
         "bugzilla.add_comment",
         permalink_hook(permalink_prefix(searchfox_rev), source_repo.resolve()),
@@ -344,5 +396,6 @@ async def run_frontend_triage(
         result=result_msg.result,
         num_turns=result_msg.num_turns,
         total_cost_usd=result_msg.total_cost_usd,
+        auto_apply=may_apply_unattended(plan),
         **plan,
     )

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/config.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/config.py
@@ -33,7 +33,41 @@ MOZILLA_VCS_TOOLS = [
 # and plans only: it records a comment with its findings/plan and, at high
 # confidence, may propose field updates (e.g. keyword/severity). It never
 # creates bugs or attaches files.
+#
+# `bugzilla.update_bug` needs `editbugs` on the apply account. The apply step coalesces
+# a same-bug field change with the nearest comment into one PUT, so losing that
+# privilege would take the analysis comment down with the rejected field change.
 ENABLED_ACTION_TYPES = [
     "bugzilla.add_comment",
     "bugzilla.update_bug",
 ]
+
+# What a `bugzilla.update_bug` from this agent may touch. Enforced at record time
+# by `hooks.update_bug_hook`, so an out-of-bounds change is refused while the agent
+# can still correct it, rather than recorded and held for a human later.
+
+TRIAGE_FIELDS = frozenset({"keywords", "severity"})
+
+# Bugzilla's `bug_severity` legal values are `--`, `blocker`, `S1`, `critical`,
+# `S2`, `major`, `normal`, `S3`, `minor`, `S4`, `trivial`, `N/A`, `enhancement`
+# (https://bugzilla.mozilla.org/rest/field/bug/bug_severity). Narrowed to the four
+# `rules/severity-assessment.md` actually defines: the word forms are legacy, kept
+# for old bugs, and `--`/`N/A` mean unset or not-applicable, which is a metadata
+# regression rather than a triage judgment.
+TRIAGE_SEVERITIES = frozenset({"S1", "S2", "S3", "S4"})
+
+# Bugzilla defines ~340 keywords (https://bugzilla.mozilla.org/rest/field/bug/keywords,
+# or https://bugzilla.mozilla.org/describekeywords.cgi for the annotated list), several
+# of which drive automation. These six are the ones a frontend triage pass can add
+# without side effects. No ruleset in `rules/` directs a keyword addition today, so
+# widen this set alongside the rule that needs it rather than ahead of one.
+TRIAGE_KEYWORDS = frozenset(
+    {
+        "access",
+        "dataloss",
+        "good-first-bug",
+        "papercut",
+        "perf",
+        "regression",
+    }
+)

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/hooks.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/hooks.py
@@ -1,0 +1,134 @@
+"""Record-time limits on what this agent may write to a bug.
+
+Once a run marks itself high-confidence its actions are applied to Bugzilla with no
+human in between, and an action's params are model output. These hooks bound that:
+one public comment and one add-only ``keywords``/``severity`` change, both on the
+bug being triaged.
+
+They run at record time rather than at apply time for two reasons. The refusal
+reaches the agent as a tool error it can correct in the same run, and the
+out-of-bounds action never reaches ``summary.json``. ``ActionsRecorder`` runs hooks
+before appending, so raising here aborts the recording (see
+:data:`hackbot_runtime.actions.ActionHook`).
+
+The action **type** needs no check. ``ENABLED_ACTION_TYPES`` filters the tools the
+actions server exposes, so this agent has no way to record a
+``bugzilla.create_bug`` or a Phabricator action in the first place.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_tools.registry import ToolError
+from hackbot_runtime.actions import ActionHook, ActionsRecorder
+
+from .config import TRIAGE_FIELDS, TRIAGE_KEYWORDS, TRIAGE_SEVERITIES
+
+
+def _check_only_one(recorder: ActionsRecorder, action_type: str) -> None:
+    # The rules ask for a single comment and at most one field change, but nothing
+    # else caps the count, and the agent reads every comment on the bug as untrusted
+    # input. A run told to write "a single brief comment" could record fifty.
+    if any(action["type"] == action_type for action in recorder.actions):
+        raise ToolError(
+            f"you have already recorded a {action_type}; record one per run, "
+            "revising it rather than adding another"
+        )
+
+
+def _check_target_bug(params: dict, bug_id: int) -> None:
+    if params.get("bug_id") != bug_id:
+        raise ToolError(
+            f"you are triaging bug {bug_id}; record actions against that bug, "
+            f"not bug {params.get('bug_id')!r}"
+        )
+
+
+def _check_severity(value: Any) -> None:
+    # Single-valued, so a scalar is the only way to set it — there is no additive
+    # form to insist on the way there is for keywords. `isinstance` before the
+    # membership test, because a list or dict is unhashable and `in` would raise
+    # rather than reject.
+    if not isinstance(value, str) or value not in TRIAGE_SEVERITIES:
+        raise ToolError(
+            f"severity {value!r} is not one you may set; "
+            f"use one of {', '.join(sorted(TRIAGE_SEVERITIES))}"
+        )
+
+
+def _check_keywords(value: Any) -> None:
+    # A bare list *replaces* every keyword already on the bug; `{"add": [...]}` is
+    # the only form that adds one.
+    if not isinstance(value, dict) or set(value) != {"add"}:
+        raise ToolError(
+            'keywords must be added, not set: pass {"add": ["…"]} rather than '
+            f"{value!r}, which would replace the keywords already on the bug"
+        )
+    additions = value["add"]
+    if not isinstance(additions, list) or not additions:
+        raise ToolError("keywords' add must be a non-empty list")
+    # `isinstance` first: an unhashable entry would make `in` raise rather than reject.
+    unknown = [
+        k for k in additions if not isinstance(k, str) or k not in TRIAGE_KEYWORDS
+    ]
+    if unknown:
+        raise ToolError(
+            f"keyword(s) {', '.join(repr(k) for k in unknown)} are not ones you may "
+            f"add; use one of {', '.join(sorted(TRIAGE_KEYWORDS))}"
+        )
+
+
+def update_bug_hook(recorder: ActionsRecorder, bug_id: int) -> ActionHook:
+    """Refuse a ``bugzilla.update_bug`` outside what this agent is trusted with.
+
+    Mirrors what ``rules/frontend-triage.md`` and ``rules/severity-assessment.md``
+    sanction: one add-only change to fields in :data:`~.config.TRIAGE_FIELDS`, with
+    values from Bugzilla's own vocabulary, on ``bug_id`` — the bug the run was asked
+    about.
+    """
+
+    def hook(action: dict) -> None:
+        params = action.get("params") or {}
+        _check_only_one(recorder, "bugzilla.update_bug")
+        _check_target_bug(params, bug_id)
+
+        changes = params.get("changes")
+        if not isinstance(changes, dict) or not changes:
+            raise ToolError("changes must be a non-empty mapping of field to value")
+
+        disallowed = sorted(set(changes) - TRIAGE_FIELDS)
+        if disallowed:
+            raise ToolError(
+                f"you may not change {', '.join(disallowed)}; this agent changes only "
+                f"{', '.join(sorted(TRIAGE_FIELDS))}"
+            )
+
+        for field, value in changes.items():
+            if field == "severity":
+                _check_severity(value)
+            else:
+                _check_keywords(value)
+
+    return hook
+
+
+def add_comment_hook(recorder: ActionsRecorder, bug_id: int) -> ActionHook:
+    """Refuse a ``bugzilla.add_comment`` this agent may not post.
+
+    One public comment, on the bug being triaged. A private comment is invisible to
+    the reporter and to everyone else on the bug, so nobody would see what an
+    unattended run concluded — and the developers on the bug are the audience for it.
+    """
+
+    def hook(action: dict) -> None:
+        params = action.get("params") or {}
+        _check_only_one(recorder, "bugzilla.add_comment")
+        _check_target_bug(params, bug_id)
+
+        if params.get("is_private"):
+            raise ToolError(
+                "record the comment publicly: everyone on the bug needs to read it"
+            )
+
+    return hook

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/prompts/system.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/prompts/system.md
@@ -80,7 +80,9 @@ When you spawn an investigator via the Task tool, write a complete, self-contain
 
 # Recording actions
 
-The `actions` MCP tools (`bugzilla_add_comment`, `bugzilla_update_bug`) do **not** mutate Bugzilla directly. They record an intended action into the run's `summary.json` for a human reviewer (or a downstream apply step) to enact. Treat each recorded action as a final, irrevocable proposal.
+The `actions` MCP tools (`bugzilla_add_comment`, `bugzilla_update_bug`) do **not** mutate Bugzilla directly. They record an intended action into the run's `summary.json` for a downstream apply step. Treat each recorded action as a final, irrevocable proposal.
+
+**Recording is not posting, but it is not always reviewed either.** When you report `confidence: high`, this run's recorded actions are applied to the real bug automatically, with no human in between. At `medium` or `low` they are held for a person to apply by hand. So reserve `high` for when you have actually localized the cause in specific code — not for a plausible-sounding hypothesis — and write every action as if it will be read on the bug unreviewed, because at `high` it will be.
 
 Before calling any action tool, state in your response:
 
@@ -89,9 +91,16 @@ Before calling any action tool, state in your response:
 
 Record exactly one `bugzilla_add_comment` with your fix plan (which should also state the severity conclusion). Only record a `bugzilla_update_bug` when confidence is **high** and a specific triage rule directs it — e.g. a `severity` (per the `severity-assessment` rules) or an obvious keyword. You may combine several such fields into one `bugzilla_update_bug`, each justified in the `reasoning`. At medium/low confidence, state the assessment in the comment and structured output but do **not** record a field change. Never record `status: RESOLVED`.
 
+Both action tools are deliberately narrow, and a call outside what they accept is refused with the reason (fix it and retry — a refused call records nothing, so it costs you nothing but the turn):
+
+- At most one comment and one field change per run, both on the bug you were asked to triage.
+- `bugzilla_update_bug` may change only `keywords` and `severity`.
+- `keywords` must be `{{"add": ["…"]}}`. A bare list **replaces** every keyword already on the bug.
+- `severity` must be one of `S1`, `S2`, `S3`, `S4` — the levels `severity-assessment` defines.
+
 The `reasoning` parameter on every action tool is required and stored alongside the recorded action. Fill it properly.
 
-Always be **brief** and to the point. Developers have limited time. Do **not** record private comments — all developers on the bug need to see them.
+Always be **brief** and to the point. Developers have limited time. Do **not** record private comments — all developers on the bug need to see them, and a private one is refused.
 
 # Final message: structured plan
 

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/rules/frontend-triage.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/rules/frontend-triage.md
@@ -39,11 +39,16 @@ not restate the whole bug. Do not claim the fix is verified — you did not run 
 
 ## Confidence and field changes
 
+Your `confidence` decides whether your actions reach the bug unreviewed — see
+**Recording actions** in the system prompt before you pick a level.
+
 - **High** (you found the specific code and the cause is clear): record the
   plan comment. If a rule or convention clearly applies, you may also record a
   `bugzilla_update_bug` for an obviously-correct field — e.g. adding a relevant
   keyword, or a `severity` (per `severity-assessment`). Do not change
-  `status`/`resolution`.
+  `status`/`resolution`. Record a keyword addition as
+  `{"keywords": {"add": ["…"]}}` — a bare list replaces every keyword already on
+  the bug.
 - **Medium** (plausible area, cause not pinned down): record the comment with
   your best hypothesis and the open questions that would confirm it.
 - **Low** (could not localize): record a comment stating what you checked and

--- a/agents/frontend-triage/pyproject.toml
+++ b/agents/frontend-triage/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
     "uvicorn>=0.27.0",
 ]
 
+[project.optional-dependencies]
+dev = ["pytest>=8.0.0", "pytest-asyncio>=0.23.0"]
+
 [tool.uv.sources]
 hackbot-runtime = { workspace = true }
 agent-tools = { workspace = true }
@@ -23,3 +26,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["hackbot_agents"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/agents/frontend-triage/tests/test_hooks.py
+++ b/agents/frontend-triage/tests/test_hooks.py
@@ -1,0 +1,200 @@
+"""Tests for the record-time limits on what this agent may write to a bug.
+
+The hooks run inside the agent as the action is recorded, so a rejection reaches the
+model as a tool error and the action never lands in summary.json — see
+hackbot_agents/frontend_triage/hooks.py.
+"""
+
+import pytest
+from agent_tools.registry import ToolError
+from hackbot_agents.frontend_triage.hooks import add_comment_hook, update_bug_hook
+from hackbot_runtime.actions import ActionsRecorder
+
+BUG = 2014702
+
+
+def _recorder():
+    rec = ActionsRecorder()
+    rec.add_hook("bugzilla.update_bug", update_bug_hook(rec, BUG))
+    rec.add_hook("bugzilla.add_comment", add_comment_hook(rec, BUG))
+    return rec
+
+
+def _update(rec, changes, bug_id=BUG):
+    return rec.record(
+        "bugzilla.update_bug",
+        {"bug_id": bug_id, "changes": changes},
+        reasoning="rule X",
+    )
+
+
+def _comment(rec, bug_id=BUG, **params):
+    return rec.record(
+        "bugzilla.add_comment",
+        {"bug_id": bug_id, "text": "hi", **params},
+        reasoning="rule X",
+    )
+
+
+def _rejects(changes, bug_id=BUG):
+    """Assert the change is refused and nothing is left behind."""
+    rec = _recorder()
+    with pytest.raises(ToolError):
+        _update(rec, changes, bug_id=bug_id)
+    assert rec.actions == []
+
+
+def test_adding_an_allowed_keyword_is_recorded():
+    rec = _recorder()
+    _update(rec, {"keywords": {"add": ["perf"]}})
+    assert rec.actions[0]["params"]["changes"] == {"keywords": {"add": ["perf"]}}
+
+
+def test_setting_a_current_severity_is_recorded():
+    rec = _recorder()
+    _update(rec, {"severity": "S2"})
+    assert rec.actions[0]["params"]["changes"] == {"severity": "S2"}
+
+
+def test_an_unknown_severity_is_refused():
+    # Anything `rules/severity-assessment.md` doesn't define, including the legacy
+    # words Bugzilla still accepts for old bugs and the unset `--`/`N/A`.
+    for value in (
+        "S5",
+        "critical",
+        "normal",
+        "enhancement",
+        "--",
+        "N/A",
+        "",
+        "s2",
+        "S2 ",
+    ):
+        _rejects({"severity": value})
+
+
+def test_a_severity_that_is_not_a_string_is_refused():
+    for value in (None, True, 2, ["S2"], {"set": "S2"}):
+        _rejects({"severity": value})
+
+
+def test_an_unknown_keyword_is_refused():
+    # `keywords` being an allowed field does not open up all ~340 keywords Bugzilla
+    # defines, several of which drive automation.
+    for keyword in ("checkin-needed", "sec-high", "leave-open", "meta", ""):
+        _rejects({"keywords": {"add": [keyword]}})
+
+
+def test_one_bad_keyword_in_a_batch_is_enough():
+    _rejects({"keywords": {"add": ["perf", "leave-open"]}})
+
+
+def test_a_keyword_that_is_not_a_string_is_refused():
+    # Unhashable entries included: a bare `in` against a frozenset would raise
+    # TypeError here rather than returning a refusal the agent can read.
+    for keyword in (None, 7, True, ["perf"], {"name": "perf"}):
+        _rejects({"keywords": {"add": [keyword]}})
+
+
+def test_a_destructive_keyword_edit_is_refused():
+    # A bare list replaces every keyword already on the bug, and the recording tool
+    # advertises add/remove/set to the model, so name-only checking is not enough.
+    for value in (
+        ["perf"],
+        "perf",
+        {"set": ["perf"]},
+        {"set": []},
+        {"remove": ["regression"]},
+        {"add": ["perf"], "remove": ["regression"]},
+        {"add": "perf"},
+        {"add": []},
+        {},
+    ):
+        _rejects({"keywords": value})
+
+
+def test_a_field_outside_the_allowlist_is_refused():
+    # `bugzilla.update_bug` accepts any field the REST endpoint does, so the
+    # allowlist is what keeps triage from resolving or reassigning the bug.
+    for changes in (
+        {"status": "RESOLVED"},
+        {"resolution": "DUPLICATE"},
+        {"assigned_to": "someone@mozilla.com"},
+        {"component": "General"},
+        {"comment": "hi"},  # a third route to posting a comment
+        {"keywords": {"add": ["perf"]}, "status": "RESOLVED"},  # one bad key is enough
+    ):
+        _rejects(changes)
+
+
+def test_changes_must_be_a_non_empty_mapping():
+    for changes in ([], "", 0, {}, None, "keywords=perf"):
+        _rejects(changes)
+
+
+def test_a_change_against_another_bug_is_refused():
+    # The bug being triaged can name any other bug in its comments, and the agent
+    # reads all of them.
+    for bug_id in (999, "2014702", None, f"{BUG} "):
+        _rejects({"severity": "S2"}, bug_id=bug_id)
+
+
+def test_a_private_comment_is_refused():
+    rec = _recorder()
+    with pytest.raises(ToolError):
+        _comment(rec, is_private=True)
+    assert rec.actions == []
+
+
+def test_a_public_comment_is_recorded():
+    rec = _recorder()
+    _comment(rec, is_private=False)
+    assert rec.actions[0]["type"] == "bugzilla.add_comment"
+
+
+def test_a_comment_against_another_bug_is_refused():
+    for bug_id in (999, "2014702", None, f"{BUG} "):
+        rec = _recorder()
+        with pytest.raises(ToolError):
+            _comment(rec, bug_id=bug_id)
+        assert rec.actions == []
+
+
+def test_only_one_comment_may_be_recorded():
+    # A model told to write "a single brief comment" can still record fifty; the
+    # prompt is not what caps this.
+    rec = _recorder()
+    _comment(rec)
+    with pytest.raises(ToolError):
+        _comment(rec)
+    assert len(rec.actions) == 1
+
+
+def test_only_one_field_change_may_be_recorded():
+    rec = _recorder()
+    _update(rec, {"severity": "S2"})
+    with pytest.raises(ToolError):
+        _update(rec, {"severity": "S3"})
+    assert len(rec.actions) == 1
+
+
+def test_a_comment_and_a_field_change_coexist():
+    # One plan comment plus one field change is the pair the rules sanction, and the
+    # apply step coalesces it into a single Bugzilla PUT.
+    rec = _recorder()
+    _comment(rec)
+    _update(rec, {"keywords": {"add": ["perf"]}})
+    assert [a["type"] for a in rec.actions] == [
+        "bugzilla.add_comment",
+        "bugzilla.update_bug",
+    ]
+
+
+def test_a_refused_action_does_not_use_up_the_allowance():
+    # The count is taken from what was actually recorded, so a rejected attempt
+    # leaves the agent free to retry with a corrected call.
+    rec = _recorder()
+    with pytest.raises(ToolError):
+        _update(rec, {"severity": "critical"})
+    _update(rec, {"severity": "S2"})
+    assert len(rec.actions) == 1

--- a/agents/frontend-triage/tests/test_plan.py
+++ b/agents/frontend-triage/tests/test_plan.py
@@ -1,0 +1,90 @@
+"""Tests for the structured plan the agent parses out of its own final message.
+
+`may_apply_unattended` decides whether a run's recorded actions reach a real bug
+with nobody in between, so it is covered as closely as the hooks are.
+"""
+
+from pathlib import Path
+
+from hackbot_agents.frontend_triage.agent import (
+    load_system_prompt,
+    may_apply_unattended,
+    parse_confidence,
+    parse_plan,
+)
+
+
+def _block(body: str) -> str:
+    return f"Here is the plan.\n\n```json\n{body}\n```"
+
+
+def test_the_system_prompt_renders():
+    # system.md goes through str.format, so a literal brace in it must be doubled or
+    # startup raises KeyError and the run never begins. The prompt now has to show
+    # JSON payloads like {"add": [...]}, which is where that would happen.
+    prompt = load_system_prompt(Path("rules"), "")
+    assert '{"add": ["…"]}' in prompt
+    assert "{rules_dir}" not in prompt
+
+
+def test_confidence_is_normalized():
+    # The value comes out of the agent's free-form JSON block and decides whether the
+    # actions are posted, so "High" must not read as "not high".
+    for raw in ("high", "High", "HIGH", "  high ", "\nHigh\t"):
+        assert parse_confidence(raw) == "high"
+    assert parse_confidence("Medium") == "medium"
+    assert parse_confidence("LOW") == "low"
+
+
+def test_an_unusable_confidence_is_none():
+    for raw in ("very-high", "", "  ", "h", None, 42, True, ["high"], {"high": 1}):
+        assert parse_confidence(raw) is None
+
+
+def test_parse_plan_normalizes_confidence():
+    plan = parse_plan(_block('{"summary": "s", "confidence": "High"}'))
+    assert plan["confidence"] == "high"
+
+
+def test_parse_plan_drops_an_unusable_confidence():
+    plan = parse_plan(_block('{"summary": "s", "confidence": "quite sure"}'))
+    assert plan["confidence"] is None
+
+
+def test_only_a_high_confidence_plan_applies_unattended():
+    assert may_apply_unattended({"confidence": "high"})
+    assert not may_apply_unattended({"confidence": "medium"})
+    assert not may_apply_unattended({"confidence": "low"})
+
+
+def test_an_out_of_scope_run_does_not_apply_unattended():
+    # `rules/scoping.md` pairs out-of-scope with `actionable: false` *and*
+    # `confidence: low`, but nothing makes the agent pair them, so a high +
+    # actionable:false run would post an out-of-scope note on the strength of the
+    # confidence alone.
+    assert not may_apply_unattended({"confidence": "high", "actionable": False})
+    # A run that doesn't report `actionable` at all is not held back by it.
+    assert may_apply_unattended({"confidence": "high", "actionable": True})
+    assert may_apply_unattended({"confidence": "high", "actionable": None})
+
+
+def test_a_plan_that_did_not_parse_does_not_apply_unattended():
+    # Fails closed: a plan with no `confidence` is not a `high`.
+    for text in (
+        None,
+        "",
+        "no json here",
+        "```json\nnot json\n```",
+        "```json\n[]\n```",
+    ):
+        assert not may_apply_unattended(parse_plan(text)), text
+    assert not may_apply_unattended({})
+
+
+def test_an_unusable_confidence_does_not_apply_unattended():
+    # Normalization in `parse_plan` is what makes the `==` comparison safe. Without
+    # it "High" falls through to False and a well-formed high-confidence run is held.
+    plan = parse_plan(_block('{"confidence": "High", "actionable": true}'))
+    assert may_apply_unattended(plan)
+    plan = parse_plan(_block('{"confidence": "highish", "actionable": true}'))
+    assert not may_apply_unattended(plan)

--- a/services/hackbot-api/app/actions_applier.py
+++ b/services/hackbot-api/app/actions_applier.py
@@ -2,12 +2,12 @@
 
 On run completion the recorded actions from `summary["actions"]` are always
 upserted as `run_actions` rows (one per entry) so they're visible and
-manageable in the UI. Whether they're then applied *automatically* depends on
-the agent's `auto_apply_actions` opt-in (see `app/agents.py`); either way they
-can be applied on demand (manual apply-all from the UI). Application runs each
-pending row through the handler registry in `hackbot_runtime.actions.handlers`
-and is idempotent per action — an already-`applied` row is never re-applied, so
-Pub/Sub retries and repeated manual applies are safe.
+manageable in the UI. Whether they're then applied *automatically* is decided by
+`_auto_apply_blocker` (see `app/agents.py`); either way they
+can be applied on demand (manual apply-all from the UI). Application runs each pending
+row through the handler registry in `hackbot_runtime.actions.handlers` and is
+idempotent per action — an already-`applied` row is never re-applied, so Pub/Sub
+retries and repeated manual applies are safe.
 """
 
 from __future__ import annotations
@@ -28,7 +28,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import gcs
-from app.agents import AGENT_REGISTRY
+from app.agents import AGENT_REGISTRY, AgentSpec
 from app.database.models import Run, RunAction
 from app.schemas import RunStatus
 
@@ -84,6 +84,28 @@ def resolve_placeholders(value: Any, results_by_ref: dict[str, dict]) -> Any:
     if isinstance(value, list):
         return [resolve_placeholders(v, results_by_ref) for v in value]
     return value
+
+
+def _auto_apply_blocker(spec: AgentSpec | None, run: Run) -> str | None:
+    """Why `run`'s recorded actions need a human, or None if they may be applied.
+
+    This holds no policy about what an agent may record. That is bounded on the agent
+    side, as it records, where a refusal reaches the agent as a tool error it can
+    correct in the same run — frontend-triage does it with action hooks. Whether a
+    given result is safe to apply is also the agent's call, since only it knows how
+    sure it was; it reports that as `findings.auto_apply`. This function honors both
+    and fails closed.
+    """
+    if spec is None or not spec.auto_apply_actions:
+        return "auto-apply is off for this agent"
+
+    # `is not True`, so a run that reports no verdict — or something that isn't a
+    # boolean — is held rather than read as consent.
+    findings = (run.summary or {}).get("findings") or {}
+    if spec.auto_apply_requires_consent and findings.get("auto_apply") is not True:
+        return "the agent did not mark this result safe to apply unattended"
+
+    return None
 
 
 async def ensure_action_rows(
@@ -224,11 +246,11 @@ async def _apply_pending_rows(
 
 
 async def on_run_completed(db: AsyncSession, run: Run) -> None:
-    """Record a completed run's actions, and auto-apply them if the agent opts in.
+    """Record a completed run's actions, and auto-apply them if the agent qualifies.
 
-    Called from the `apply-run-actions` push route. Actions are always recorded
-    (so the UI can show/manually apply them); they're applied automatically only
-    when the run's agent has `auto_apply_actions=True`.
+    Called from the `apply-run-actions` push route. Actions are always recorded (so the
+    UI can show/manually apply them); they're applied automatically only when
+    `_auto_apply_blocker` finds nothing in the way.
     """
     # Defense-in-depth: only a succeeded run's actions are recorded/applied. A
     # failed/timed-out run may have recorded actions before erroring, but acting
@@ -243,15 +265,18 @@ async def on_run_completed(db: AsyncSession, run: Run) -> None:
     await db.commit()
 
     spec = AGENT_REGISTRY.get(run.agent)
-    if spec and spec.auto_apply_actions:
+    blocker = _auto_apply_blocker(spec, run)
+    if blocker is None:
         await _apply_pending_rows(db, run, rows)
-    else:
-        log.info(
-            "Recorded %d action(s) for run %s; auto-apply off for agent %s",
-            len(rows),
-            run.run_id,
-            run.agent,
-        )
+        return
+
+    log.info(
+        "Recorded %d action(s) for run %s; holding for review: %s (agent %s)",
+        len(rows),
+        run.run_id,
+        blocker,
+        run.agent,
+    )
 
 
 async def apply_all_pending(db: AsyncSession, run: Run) -> None:

--- a/services/hackbot-api/app/agents.py
+++ b/services/hackbot-api/app/agents.py
@@ -27,6 +27,12 @@ class AgentSpec:
     # succeeds. Off by default: actions are still recorded and can always be
     # applied manually from the UI; only opted-in agents auto-apply.
     auto_apply_actions: bool = False
+    # Whether auto-apply additionally needs the run's own say-so: `findings.auto_apply`
+    # must be True, or the actions are recorded and held. Set this for agents that
+    # judge their results one run at a time, since only the agent knows how sure it
+    # was; this is where that verdict is honored. Fails closed, so a run that reports
+    # no verdict never qualifies.
+    auto_apply_requires_consent: bool = False
 
 
 def model_to_env(inputs: BaseModel) -> dict[str, str]:
@@ -80,6 +86,10 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
         description="Triage a Firefox desktop frontend bug (read-only) and produce a root-cause analysis and proposed fix plan.",
         job_name="hackbot-agent-frontend-triage",
         input_schema=FrontendTriageInputs,
+        # Triage results reach a real bug unattended, so only the ones the agent
+        # marked `auto_apply` qualify. Everything else stays for manual apply.
+        auto_apply_actions=True,
+        auto_apply_requires_consent=True,
     ),
     "test-repair": AgentSpec(
         name="test-repair",

--- a/services/hackbot-api/tests/test_actions_applier.py
+++ b/services/hackbot-api/tests/test_actions_applier.py
@@ -1,13 +1,13 @@
 """Tests for the action applier.
 
 Covers the {{actions.<ref>.<field>}} placeholder resolver, the succeeded-run
-gate + per-agent auto-apply opt-in in `on_run_completed`, and the manual
-`apply_all_pending` path — see app/actions_applier.py.
+gate + per-agent auto-apply opt-in and per-run consent in `on_run_completed`, and
+the manual `apply_all_pending` path — see app/actions_applier.py.
 """
 
 import logging
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from types import SimpleNamespace
 
 from app import actions_applier
@@ -16,6 +16,7 @@ from app.actions_applier import (
     on_run_completed,
     resolve_placeholders,
 )
+from app.agents import AGENT_REGISTRY
 from app.schemas import RunStatus
 
 
@@ -75,6 +76,110 @@ class _FakeRun:
     agent: str = "bug-fix"
     run_id: uuid.UUID = field(default_factory=uuid.uuid4)
     summary: dict | None = None
+    inputs: dict = field(default_factory=dict)
+
+
+def _spec(*, auto=True, consent=False):
+    """A real `AgentSpec` built with `replace` off a registry entry.
+
+    Every field then takes its production default, so a field added later can't read
+    as absent. A hand-rolled namespace would instead raise `AttributeError` inside
+    `_auto_apply_blocker`.
+    """
+    return replace(
+        AGENT_REGISTRY["bug-fix"],
+        auto_apply_actions=auto,
+        auto_apply_requires_consent=consent,
+    )
+
+
+def _auto_applies(spec, run):
+    return actions_applier._auto_apply_blocker(spec, run) is None
+
+
+def _run_with_findings(**findings):
+    return _FakeRun(
+        status=RunStatus.succeeded.value,
+        inputs={"bug_id": 2014702},
+        summary={"findings": findings, "actions": []},
+    )
+
+
+def test_auto_apply_off_never_applies():
+    # `auto_apply_actions` is checked first, so what a run reports about itself makes
+    # no difference when the agent hasn't opted in at all.
+    spec = _spec(auto=False, consent=True)
+    assert not _auto_applies(spec, _run_with_findings(auto_apply=True))
+
+
+def test_unknown_agent_never_applies():
+    assert not _auto_applies(None, _run_with_findings(auto_apply=True))
+
+
+def test_an_agent_that_needs_no_consent_applies_unconditionally():
+    # Agents that opt in without asking for a per-run verdict keep applying whatever
+    # findings say. `bug-fix` and `test-repair` predate this change.
+    spec = _spec()
+    assert _auto_applies(spec, _FakeRun(status=RunStatus.succeeded.value))
+    assert _auto_applies(spec, _run_with_findings(auto_apply=False))
+
+
+# --- the run's own verdict ----------------------------------------------- #
+#
+# The agent decides `findings.auto_apply`, because `confidence` lands in its final
+# message after every action is already recorded. What it may record at all is
+# bounded on the agent side too, as it records — see `hooks.py` in frontend-triage.
+# These tests cover only how the service honors the verdict.
+
+
+def test_a_vouched_for_run_applies():
+    spec = _spec(consent=True)
+    assert _auto_applies(spec, _run_with_findings(auto_apply=True))
+
+
+def test_a_run_that_did_not_vouch_for_itself_is_held():
+    # The check is `is not True`, so anything short of a literal boolean true is held.
+    # A run that reports no verdict has not given one.
+    spec = _spec(consent=True)
+    for findings in (
+        {"auto_apply": False},
+        {"auto_apply": None},
+        {"auto_apply": "true"},  # a string is not consent
+        {"auto_apply": 1},
+        {},  # never reported
+    ):
+        assert not _auto_applies(spec, _run_with_findings(**findings)), findings
+
+
+def test_a_run_with_no_findings_at_all_is_held():
+    spec = _spec(consent=True)
+    for summary in (None, {}, {"findings": None}, {"findings": {}}):
+        run = _FakeRun(status=RunStatus.succeeded.value, summary=summary)
+        assert not _auto_applies(spec, run), summary
+
+
+def test_the_real_frontend_triage_spec_asks_for_consent():
+    # Asserts the live registry entry rather than a paraphrase of it. Without
+    # `auto_apply_requires_consent` the agent's verdict is ignored and a medium- or
+    # low-confidence run posts the same as a high one.
+    spec = AGENT_REGISTRY["frontend-triage"]
+    assert spec.auto_apply_actions is True
+    assert spec.auto_apply_requires_consent is True
+
+
+def test_which_agents_auto_apply_without_asking_for_consent():
+    # `bug-fix` and `test-repair` auto-apply whatever they record, and the apply step
+    # dispatches against the runtime's *global* handler registry — creating bugs,
+    # attaching files, submitting Phabricator patches. Both predate this change, and
+    # bounding them is a decision about those agents, so this records the gap rather
+    # than closing it. Failing here means a new agent opted in without bounding what
+    # it records.
+    unbounded = {
+        name
+        for name, spec in AGENT_REGISTRY.items()
+        if spec.auto_apply_actions and not spec.auto_apply_requires_consent
+    }
+    assert unbounded == {"bug-fix", "test-repair"}
 
 
 class _FakeDB:
@@ -90,7 +195,7 @@ class _FakeDB:
         )
 
 
-def _patch_applier(monkeypatch, *, auto: bool | None):
+def _patch_applier(monkeypatch, *, auto: bool | None, consent=False):
     """Stub ensure/apply and the registry; record what got called.
 
     `auto=None` means the agent isn't in the registry at all.
@@ -106,9 +211,7 @@ def _patch_applier(monkeypatch, *, auto: bool | None):
 
     monkeypatch.setattr(actions_applier, "ensure_action_rows", fake_ensure)
     monkeypatch.setattr(actions_applier, "_apply_pending_rows", fake_apply)
-    registry = (
-        {} if auto is None else {"bug-fix": SimpleNamespace(auto_apply_actions=auto)}
-    )
+    registry = {} if auto is None else {"bug-fix": _spec(auto=auto, consent=consent)}
     monkeypatch.setattr(actions_applier, "AGENT_REGISTRY", registry)
     return calls
 
@@ -140,6 +243,27 @@ async def test_succeeded_unknown_agent_does_not_apply(monkeypatch):
     calls = _patch_applier(monkeypatch, auto=None)
     await on_run_completed(_FakeDB(), _FakeRun(status=RunStatus.succeeded.value))
     assert calls == {"ensured": True, "applied": False}
+
+
+async def test_succeeded_vouched_for_run_applies(monkeypatch):
+    calls = _patch_applier(monkeypatch, auto=True, consent=True)
+    await on_run_completed(_FakeDB(), _run_with_findings(auto_apply=True))
+    assert calls == {"ensured": True, "applied": True}
+
+
+async def test_succeeded_unvouched_run_records_but_does_not_apply(monkeypatch):
+    calls = _patch_applier(monkeypatch, auto=True, consent=True)
+    # Recorded for the UI (and manual apply), but nothing reaches Bugzilla.
+    await on_run_completed(_FakeDB(), _run_with_findings(auto_apply=False))
+    assert calls == {"ensured": True, "applied": False}
+
+
+async def test_other_agents_do_not_auto_apply():
+    # Opting an agent in is a deliberate edit, so spell out who is in today:
+    # bug-fix and test-repair auto-apply unconditionally, frontend-triage only when
+    # the run vouched for itself, and everyone else stays human-gated.
+    auto_apply = {n for n, s in AGENT_REGISTRY.items() if s.auto_apply_actions}
+    assert auto_apply == {"bug-fix", "frontend-triage", "test-repair"}
 
 
 async def test_apply_all_pending_always_applies(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -2568,6 +2568,12 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "agent-tools", extras = ["bugzilla", "searchfox", "vcs"], editable = "libs/agent-tools" },
@@ -2575,9 +2581,12 @@ requires-dist = [
     { name = "claude-agent-sdk", specifier = ">=0.1.30" },
     { name = "hackbot-runtime", extras = ["claude-sdk"], editable = "libs/hackbot-runtime" },
     { name = "mcp", specifier = ">=1.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "starlette", specifier = ">=0.36.0" },
     { name = "uvicorn", specifier = ">=0.27.0" },
 ]
+provides-extras = ["dev"]
 
 [[package]]
 name = "hackbot-agent-test-plan-generator"


### PR DESCRIPTION
`frontend-triage` records its root-cause analysis and fix plan as Bugzilla actions, but
nothing applied them, so every triage needed a person to click Apply in the hackbot UI.
This closes that loop for the results the agent is confident about.

## How the decision is made

A run reports `findings.auto_apply` from the two values only it has: `confidence: high`,
and `actionable` not false. Both arrive in the trailing JSON block *after* every action
is already recorded, which is why this can't be a record-time check and isn't
hackbot-api's call to make. `may_apply_unattended()` in `agent.py` is that policy in
full.

It fails closed, since a plan that didn't parse has no `confidence`. And because
`confidence` is read out of the agent's free-form JSON, `parse_confidence` normalizes
case and whitespace, so `"High"` doesn't quietly read as not-high.

Medium and low are unchanged from today: still recorded, still visible in the UI, still
appliable by hand. So are all the other agents — `test_other_agents_do_not_auto_apply`
asserts exactly who auto-applies.

## What the agent may record

Confidence gates how sure the agent is, not how far its actions can go. An action's
params are model output however sure it is, and the run reads bug comments nobody
controls. Two hooks in `hooks.py` refuse, at record time:

- `add_comment_hook` — one comment, public, on the bug being triaged.
- `update_bug_hook` — one field change, add-only, on the bug being triaged, and only
  `keywords`/`severity` with values from `TRIAGE_SEVERITIES`/`TRIAGE_KEYWORDS` in
  `config.py`.

They refuse at record time rather than holding at apply time because `ActionsRecorder`
runs hooks before appending: the reason goes back to the agent as a tool error it can
correct in the same run, and the out-of-bounds action never reaches `summary.json` at
all. The vocabulary lives in the agent's config, next to the rules that would widen it —
`TRIAGE_SEVERITIES` is exactly the `S1`–`S4` that `rules/severity-assessment.md`
defines.

The action *type* needs no check: `ENABLED_ACTION_TYPES` already decides which tools the
actions server exposes, so this agent has no way to record a `bugzilla.create_bug` or a
Phabricator action in the first place.

## The hackbot-api side

`AgentSpec.auto_apply_requires_consent` makes `auto_apply_actions` conditional on
`findings.auto_apply`, and fails closed when a run reports nothing. That's the whole
service-side change; no policy about what an agent may write lives there. That belongs
with the agent, which knows its own rules and can explain a rejection to the model
rather than silently parking a run for a human.

## What the prompt now tells the agent

`confidence` used to be advisory metadata a human read off the run. It now decides
whether a comment reaches a real bug unreviewed, and the agent was being asked to
self-report it without being told what it does, which invites grading on a curve. The
system prompt now says so, and states what the action tools will accept, so the model
learns the shape before a hook has to reject it.

## Tradeoffs worth a reviewer's attention

The hooks are now the only thing bounding what an unattended run writes. The apply step
dispatches whatever it finds in `summary.json` against the runtime's global handler
registry, which is far wider than the tools this agent was given. That's a real change
in where the boundary sits.

`bug-fix` and `test-repair` auto-apply everything they record and are untouched here.
Bounding them is a decision about those agents, so `test_which_agents_auto_apply_without_asking_for_consent`
records the gap rather than closing it, and fails if a new agent opts in without
bounding itself.

## Testing

- `agents/frontend-triage`: **27 passed** — a new suite, since the agent had none. Two
  files: `tests/test_hooks.py` covers what the hooks refuse, `tests/test_plan.py` covers
  `may_apply_unattended` and the confidence normalization that feeds it.
- `libs/hackbot-runtime`: **203 passed**.
- `services/hackbot-api`: **3 failed, 95 passed, 8 errors**. That failure set is
  pre-existing, not introduced here — the parent commit `59137c9b` alone gives **3
  failed, 84 passed, 8 errors**, the same 3 and the same 8, verified by running its suite
  unmodified in a clean worktree. The 3 are `comment.is_markdown` missing from
  expectations in `test_actions_applier.py`; the 8 are `fixture 'client' not found` in
  `test_list_runs_api.py` / `test_create_run_api.py`.

Note that neither `services/hackbot-api` nor the agent suites run in Taskcluster today —
`.taskcluster.yml` covers `tests/`, `http_service/`, `libs/agent-tools` and
`libs/hackbot-runtime` only. CI won't exercise any of the above.

## Deploying

No new configuration. `BUGZILLA_API_KEY` is already set on the service and working
(`hackbot@mozilla.tld` has been applying comments), so nothing new is needed for the
apply path.

`bugzilla.update_bug` needs `editbugs` on the apply account. The apply step coalesces a
same-bug field change with the nearest comment into one PUT, so losing that privilege
would take the analysis comment down with the rejected field change.

## Follow-up

- mozilla/bugbot will start triggering these runs automatically for newly filed
  `Firefox :: New Tab Page` bugs from staff. **This should land first**, so a triggered
  run auto-applies.
- Slack reporting is out of this PR; #6523 has since landed and is the right vehicle.

