### PR TITLE
Restrict Hackbot triggers to authorized user with  editbugs permissions

### DIFF
--- a/bugbug/tools/code_review/agent.py
+++ b/bugbug/tools/code_review/agent.py
@@ -268,7 +268,6 @@ class CodeReviewTool(GenerativeModelTool):
         Returns at most one comment. Empty when no split is warranted.
         """
         prompt = PATCH_SCOPE_PROMPT.format(
-            current_date=current_date_for_prompt(),
             target_software=self.target_software,
             patch=format_patch_set(patch.patch_set),
             patch_summary=patch_summary,

--- a/bugbug/tools/code_review/agent.py
+++ b/bugbug/tools/code_review/agent.py
@@ -7,7 +7,7 @@
 
 import json
 import os
-from datetime import datetime
+from datetime import UTC, datetime
 from logging import getLogger
 from typing import Optional
 
@@ -59,6 +59,10 @@ from bugbug.tools.core.llms import DEFAULT_ANTHROPIC_MODEL, get_tokenizer
 from bugbug.tools.core.platforms.base import Patch
 
 logger = getLogger(__name__)
+
+
+def current_date_for_prompt() -> str:
+    return datetime.now(UTC).date().isoformat()
 
 
 class CodeReviewTool(GenerativeModelTool):
@@ -209,6 +213,7 @@ class CodeReviewTool(GenerativeModelTool):
         created_before = patch.date_created if self.is_experiment_env else None
 
         return FIRST_MESSAGE_TEMPLATE.format(
+            current_date=current_date_for_prompt(),
             patch=format_patch_set(patch.patch_set),
             patch_summarization=patch_summary,
             external_context=external_context,
@@ -263,6 +268,7 @@ class CodeReviewTool(GenerativeModelTool):
         Returns at most one comment. Empty when no split is warranted.
         """
         prompt = PATCH_SCOPE_PROMPT.format(
+            current_date=current_date_for_prompt(),
             target_software=self.target_software,
             patch=format_patch_set(patch.patch_set),
             patch_summary=patch_summary,

--- a/bugbug/tools/code_review/prompts.py
+++ b/bugbug/tools/code_review/prompts.py
@@ -60,8 +60,6 @@ Do not write comments that:
 
 PATCH_SCOPE_PROMPT = """You are an expert {target_software} engineer assessing whether a pull request is too large or unfocused to be reviewed well.
 
-Current date: {current_date}
-
 Large changes are harder to review and empirically carry higher defect and regression risk: reviewer defect-detection drops sharply once a change grows past a few hundred changed lines, and at Mozilla the patches that introduce regressions tend to be the larger ones.
 
 Decide whether to suggest the author split this patch into smaller, independently reviewable pieces. Either of these is a reason to suggest a split:

--- a/bugbug/tools/code_review/prompts.py
+++ b/bugbug/tools/code_review/prompts.py
@@ -60,6 +60,8 @@ Do not write comments that:
 
 PATCH_SCOPE_PROMPT = """You are an expert {target_software} engineer assessing whether a pull request is too large or unfocused to be reviewed well.
 
+Current date: {current_date}
+
 Large changes are harder to review and empirically carry higher defect and regression risk: reviewer defect-detection drops sharply once a change grows past a few hundred changed lines, and at Mozilla the patches that introduce regressions tend to be the larger ones.
 
 Decide whether to suggest the author split this patch into smaller, independently reviewable pieces. Either of these is a reason to suggest a split:
@@ -89,7 +91,9 @@ Here is the patch you need to assess:
 """
 
 
-FIRST_MESSAGE_TEMPLATE = """Here is a summary of the patch:
+FIRST_MESSAGE_TEMPLATE = """Current date: {current_date}
+
+Here is a summary of the patch:
 
 <patch_summary>
 {patch_summarization}

--- a/libs/phabricator-client/phabricator_client/client.py
+++ b/libs/phabricator-client/phabricator_client/client.py
@@ -115,6 +115,19 @@ class PhabricatorClient:
             if user.get("phid")
         }
 
+    async def get_project_members(self, project_phid: str) -> frozenset[str]:
+        """Return the user PHIDs belonging to a Phabricator project."""
+        result = await self.conduit_request(
+            "project.search",
+            constraints={"phids": [project_phid]},
+            attachments={"members": True},
+        )
+        data = result.get("data") or []
+        if not data:
+            return frozenset()
+        members = data[0].get("attachments", {}).get("members", {}).get("members", [])
+        return frozenset(member["phid"] for member in members if member.get("phid"))
+
     async def query_latest_diff(self, revision_id: int) -> PhabricatorDiff | None:
         """The most recent diff for a revision, or ``None`` if it has none.
 

--- a/libs/phabricator-client/tests/test_client.py
+++ b/libs/phabricator-client/tests/test_client.py
@@ -172,6 +172,38 @@ async def test_search_users_skips_call_when_nothing_to_resolve(monkeypatch):
     assert captured == {}  # no request was made
 
 
+async def test_get_project_members(monkeypatch):
+    captured = _capture_post(
+        monkeypatch,
+        {
+            "result": {
+                "data": [
+                    {
+                        "attachments": {
+                            "members": {
+                                "members": [
+                                    {"phid": "PHID-USER-1"},
+                                    {"phid": "PHID-USER-2"},
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+    )
+    assert await _client().get_project_members("PHID-PROJ-1") == frozenset(
+        {"PHID-USER-1", "PHID-USER-2"}
+    )
+    assert captured["params"]["constraints"] == {"phids": ["PHID-PROJ-1"]}
+    assert captured["params"]["attachments"] == {"members": True}
+
+
+async def test_get_project_members_missing_project(monkeypatch):
+    _capture_post(monkeypatch, {"result": {"data": []}})
+    assert await _client().get_project_members("PHID-PROJ-1") == frozenset()
+
+
 async def test_query_latest_diff_picks_highest_id(monkeypatch):
     _capture_post(
         monkeypatch,

--- a/services/hackbot-api/app/phabricator_webhook.py
+++ b/services/hackbot-api/app/phabricator_webhook.py
@@ -9,6 +9,7 @@ Bugzilla bug id. The route in ``app/routers/webhooks.py`` orchestrates these.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -20,6 +21,13 @@ log = logging.getLogger(__name__)
 
 # Transaction types that carry a comment we can scan for the mention.
 _COMMENT_TYPES = frozenset({"comment", "inline"})
+EDITBUGS_GROUP_PHID = "PHID-PROJ-njo5uuqyyq3oijbkhy55"
+
+
+@dataclass(frozen=True)
+class HackbotMention:
+    raw: str
+    author_phid: str
 
 
 def triggering_transaction_phids(payload: dict) -> list[str]:
@@ -37,8 +45,8 @@ def find_hackbot_mentions(
     *,
     bot_phid: str,
     token: str,
-) -> list[str]:
-    """Return the text of every triggering comment that mentions ``token``.
+) -> list[HackbotMention]:
+    """Return every triggering comment that mentions ``token``.
 
     Only considers transactions named in this delivery, of a comment type, not
     authored by the bot itself (loop prevention). A single review can leave
@@ -46,7 +54,7 @@ def find_hackbot_mentions(
     returned, in transaction order. At most one per transaction: a transaction's
     ``comments`` list is that comment's version history, not distinct comments.
     """
-    matches: list[str] = []
+    matches: list[HackbotMention] = []
     for transaction in transactions:
         if transaction.get("phid") not in triggering_phids:
             continue
@@ -57,7 +65,12 @@ def find_hackbot_mentions(
         for comment in transaction.get("comments") or []:
             raw = (comment.get("content") or {}).get("raw") or ""
             if token in raw:
-                matches.append(raw)
+                matches.append(
+                    HackbotMention(
+                        raw=raw,
+                        author_phid=transaction.get("authorPHID", ""),
+                    )
+                )
                 break
     return matches
 
@@ -111,19 +124,34 @@ async def detect_mention_and_revision(
     revision can't be resolved, or it has no Bugzilla bug id (bug-fix needs one).
     """
     transactions = await client.search_transactions(object_phid)
-    comments = find_hackbot_mentions(
+    mentions = find_hackbot_mentions(
         transactions,
         set(triggering_phids),
         bot_phid=webhook.bot_phid,
         token=webhook.mention_token,
     )
-    if not comments:
+    if not mentions:
         log.warning(
             "No %s mention found in triggering transactions %s on %s",
             webhook.mention_token,
             triggering_phids,
             object_phid,
         )
+        return None
+
+    authorized_members = await client.get_project_members(EDITBUGS_GROUP_PHID)
+    comments: list[str] = []
+    for mention in mentions:
+        if mention.author_phid in authorized_members:
+            comments.append(mention.raw)
+        else:
+            log.warning(
+                "Ignoring %s mention from non-editbugs user %s on %s",
+                webhook.mention_token,
+                mention.author_phid or "<missing PHID>",
+                object_phid,
+            )
+    if not comments:
         return None
     comment = _join_comments(comments)
 

--- a/services/hackbot-api/tests/test_webhooks.py
+++ b/services/hackbot-api/tests/test_webhooks.py
@@ -15,7 +15,10 @@ from app.auth import verify_phabricator_signature
 from app.config import settings
 from app.main import app
 from app.phabricator_webhook import (
+    EDITBUGS_GROUP_PHID,
+    HackbotMention,
     _join_comments,
+    detect_mention_and_revision,
     find_hackbot_mentions,
     resolve_revision,
     triggering_transaction_phids,
@@ -70,7 +73,7 @@ def test_find_mention_matches():
     txns = [_comment_txn("PHID-XACT-1", "PHID-USER-a", "hey @hackbot please fix")]
     assert find_hackbot_mentions(
         txns, {"PHID-XACT-1"}, bot_phid="PHID-USER-bot", token="@hackbot"
-    ) == ["hey @hackbot please fix"]
+    ) == [HackbotMention("hey @hackbot please fix", "PHID-USER-a")]
 
 
 def test_find_mention_no_token():
@@ -120,7 +123,7 @@ def test_find_mention_matches_inline_comment():
     ]
     assert find_hackbot_mentions(
         txns, {"PHID-XACT-1"}, bot_phid="PHID-USER-bot", token="@hackbot"
-    ) == ["@hackbot here"]
+    ) == [HackbotMention("@hackbot here", "PHID-USER-a")]
 
 
 def test_find_mention_collects_all_inline_matches():
@@ -136,7 +139,10 @@ def test_find_mention_collects_all_inline_matches():
         {"PHID-XACT-1", "PHID-XACT-2", "PHID-XACT-3"},
         bot_phid="PHID-USER-bot",
         token="@hackbot",
-    ) == ["@hackbot fix this", "@hackbot and this too"]
+    ) == [
+        HackbotMention("@hackbot fix this", "PHID-USER-a"),
+        HackbotMention("@hackbot and this too", "PHID-USER-a"),
+    ]
 
 
 def test_find_mention_one_per_transaction_ignores_comment_versions():
@@ -153,7 +159,7 @@ def test_find_mention_one_per_transaction_ignores_comment_versions():
     }
     assert find_hackbot_mentions(
         [txn], {"PHID-XACT-1"}, bot_phid="PHID-USER-bot", token="@hackbot"
-    ) == ["@hackbot v1"]
+    ) == [HackbotMention("@hackbot v1", "PHID-USER-a")]
 
 
 def test_join_comments_single_passthrough():
@@ -170,11 +176,16 @@ def test_join_comments_numbers_multiple():
 
 
 class _FakeClient:
-    def __init__(self, revision):
+    def __init__(self, revision, members=()):
         self._revision = revision
+        self._members = frozenset(members)
 
     async def search_revision(self, phid):
         return self._revision
+
+    async def get_project_members(self, project_phid):
+        assert project_phid == EDITBUGS_GROUP_PHID
+        return self._members
 
 
 async def test_resolve_revision_with_bug():
@@ -190,6 +201,52 @@ async def test_resolve_revision_no_bug():
 async def test_resolve_revision_not_found():
     client = _FakeClient(None)
     assert await resolve_revision(client, "PHID-DREV-x") == (None, None)
+
+
+async def test_detect_mention_requires_editbugs_membership(monkeypatch):
+    client = _FakeClient(
+        {"id": 42, "fields": {"bugzilla.bug-id": "12345"}},
+        members={"PHID-USER-authorized"},
+    )
+    transactions = [
+        _comment_txn("PHID-XACT-1", "PHID-USER-unauthorized", "@hackbot ignore"),
+    ]
+    monkeypatch.setattr(
+        client,
+        "search_transactions",
+        AsyncMock(return_value=transactions),
+    )
+
+    result = await detect_mention_and_revision(
+        client,
+        settings.webhook,
+        "PHID-DREV-x",
+        ["PHID-XACT-1"],
+    )
+    assert result is None
+
+
+async def test_detect_mention_accepts_editbugs_member(monkeypatch):
+    client = _FakeClient(
+        {"id": 42, "fields": {"bugzilla.bug-id": "12345"}},
+        members={"PHID-USER-authorized"},
+    )
+    transactions = [
+        _comment_txn("PHID-XACT-1", "PHID-USER-authorized", "@hackbot please fix"),
+    ]
+    monkeypatch.setattr(
+        client,
+        "search_transactions",
+        AsyncMock(return_value=transactions),
+    )
+
+    result = await detect_mention_and_revision(
+        client,
+        settings.webhook,
+        "PHID-DREV-x",
+        ["PHID-XACT-1"],
+    )
+    assert result == ("@hackbot please fix", 42, 12345)
 
 
 # --- payload parsing ---

--- a/tests/test_code_review.py
+++ b/tests/test_code_review.py
@@ -1284,6 +1284,26 @@ def _make_scope_tool(scope_response):
     return tool
 
 
+def test_generate_initial_prompt_includes_current_date():
+    pytest.importorskip("langchain")
+    from bugbug.tools.code_review.agent import CodeReviewTool
+
+    tool = CodeReviewTool.__new__(CodeReviewTool)
+    tool.is_experiment_env = False
+    tool._get_comment_examples = MagicMock(return_value="")
+    tool._get_generated_examples = MagicMock(return_value="")
+
+    review_patch = make_patch("--- a/f.txt\n+++ b/f.txt\n@@ -0,0 +1 @@\n+a\n")
+
+    with patch(
+        "bugbug.tools.code_review.agent.current_date_for_prompt",
+        return_value="2026-07-30",
+    ):
+        prompt = tool.generate_initial_prompt(review_patch, "summary")
+
+    assert "Current date: 2026-07-30" in prompt
+
+
 def test_assess_patch_scope_returns_at_most_one_comment():
     # The model returns two comments; the pass must keep only the first.
     comments = [
@@ -1303,6 +1323,20 @@ def test_assess_patch_scope_returns_at_most_one_comment():
 
     assert len(result) == 1
     assert result[0].comment == "Split this patch 0"
+
+
+def test_assess_patch_scope_prompt_includes_current_date():
+    tool = _make_scope_tool(PatchScopeResponse(comments=[]))
+
+    review_patch = make_patch("--- a/f.txt\n+++ b/f.txt\n@@ -0,0 +1,2 @@\n+a\n+b\n")
+    with patch(
+        "bugbug.tools.code_review.agent.current_date_for_prompt",
+        return_value="2026-07-30",
+    ):
+        asyncio.run(tool.assess_patch_scope(review_patch, "summary"))
+
+    prompt = tool.scope_agent.ainvoke.call_args.args[0]["messages"][0].content
+    assert "Current date: 2026-07-30" in prompt
 
 
 def test_assess_patch_scope_returns_empty_when_no_split_warranted():

--- a/tests/test_code_review.py
+++ b/tests/test_code_review.py
@@ -1284,26 +1284,6 @@ def _make_scope_tool(scope_response):
     return tool
 
 
-def test_generate_initial_prompt_includes_current_date():
-    pytest.importorskip("langchain")
-    from bugbug.tools.code_review.agent import CodeReviewTool
-
-    tool = CodeReviewTool.__new__(CodeReviewTool)
-    tool.is_experiment_env = False
-    tool._get_comment_examples = MagicMock(return_value="")
-    tool._get_generated_examples = MagicMock(return_value="")
-
-    review_patch = make_patch("--- a/f.txt\n+++ b/f.txt\n@@ -0,0 +1 @@\n+a\n")
-
-    with patch(
-        "bugbug.tools.code_review.agent.current_date_for_prompt",
-        return_value="2026-07-30",
-    ):
-        prompt = tool.generate_initial_prompt(review_patch, "summary")
-
-    assert "Current date: 2026-07-30" in prompt
-
-
 def test_assess_patch_scope_returns_at_most_one_comment():
     # The model returns two comments; the pass must keep only the first.
     comments = [
@@ -1323,20 +1303,6 @@ def test_assess_patch_scope_returns_at_most_one_comment():
 
     assert len(result) == 1
     assert result[0].comment == "Split this patch 0"
-
-
-def test_assess_patch_scope_prompt_includes_current_date():
-    tool = _make_scope_tool(PatchScopeResponse(comments=[]))
-
-    review_patch = make_patch("--- a/f.txt\n+++ b/f.txt\n@@ -0,0 +1,2 @@\n+a\n+b\n")
-    with patch(
-        "bugbug.tools.code_review.agent.current_date_for_prompt",
-        return_value="2026-07-30",
-    ):
-        asyncio.run(tool.assess_patch_scope(review_patch, "summary"))
-
-    prompt = tool.scope_agent.ainvoke.call_args.args[0]["messages"][0].content
-    assert "Current date: 2026-07-30" in prompt
 
 
 def test_assess_patch_scope_returns_empty_when_no_split_warranted():


### PR DESCRIPTION

## Changes

- Check the author of each `@hackbot` comment.
- Process comments only from users authorized to edit revisions.
- Ignore comments from unauthorized users before creating a Hackbot run.
- Add test coverage for authorized, unauthorized

#6423