### PR TITLE
Restrict Hackbot triggers to authorized user with editbugs permissions

### DIFF
--- a/libs/phabricator-client/phabricator_client/client.py
+++ b/libs/phabricator-client/phabricator_client/client.py
@@ -122,11 +122,8 @@ class PhabricatorClient:
             constraints={"phids": [project_phid]},
             attachments={"members": True},
         )
-        data = result.get("data") or []
-        if not data:
-            return frozenset()
-        members = data[0].get("attachments", {}).get("members", {}).get("members", [])
-        return frozenset(member["phid"] for member in members if member.get("phid"))
+        members = result["data"][0]["attachments"]["members"]["members"]
+        return frozenset(member["phid"] for member in members)
 
     async def query_latest_diff(self, revision_id: int) -> PhabricatorDiff | None:
         """The most recent diff for a revision, or ``None`` if it has none.

--- a/libs/phabricator-client/phabricator_client/client.py
+++ b/libs/phabricator-client/phabricator_client/client.py
@@ -115,6 +115,19 @@ class PhabricatorClient:
             if user.get("phid")
         }
 
+    async def get_project_members(self, project_phid: str) -> frozenset[str]:
+        """Return the user PHIDs belonging to a Phabricator project."""
+        result = await self.conduit_request(
+            "project.search",
+            constraints={"phids": [project_phid]},
+            attachments={"members": True},
+        )
+        data = result.get("data") or []
+        if not data:
+            return frozenset()
+        members = data[0].get("attachments", {}).get("members", {}).get("members", [])
+        return frozenset(member["phid"] for member in members if member.get("phid"))
+
     async def query_latest_diff(self, revision_id: int) -> PhabricatorDiff | None:
         """The most recent diff for a revision, or ``None`` if it has none.
 

--- a/libs/phabricator-client/tests/test_client.py
+++ b/libs/phabricator-client/tests/test_client.py
@@ -172,6 +172,38 @@ async def test_search_users_skips_call_when_nothing_to_resolve(monkeypatch):
     assert captured == {}  # no request was made
 
 
+async def test_get_project_members(monkeypatch):
+    captured = _capture_post(
+        monkeypatch,
+        {
+            "result": {
+                "data": [
+                    {
+                        "attachments": {
+                            "members": {
+                                "members": [
+                                    {"phid": "PHID-USER-1"},
+                                    {"phid": "PHID-USER-2"},
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+    )
+    assert await _client().get_project_members("PHID-PROJ-1") == frozenset(
+        {"PHID-USER-1", "PHID-USER-2"}
+    )
+    assert captured["params"]["constraints"] == {"phids": ["PHID-PROJ-1"]}
+    assert captured["params"]["attachments"] == {"members": True}
+
+
+async def test_get_project_members_missing_project(monkeypatch):
+    _capture_post(monkeypatch, {"result": {"data": []}})
+    assert await _client().get_project_members("PHID-PROJ-1") == frozenset()
+
+
 async def test_query_latest_diff_picks_highest_id(monkeypatch):
     _capture_post(
         monkeypatch,

--- a/libs/phabricator-client/tests/test_client.py
+++ b/libs/phabricator-client/tests/test_client.py
@@ -199,11 +199,6 @@ async def test_get_project_members(monkeypatch):
     assert captured["params"]["attachments"] == {"members": True}
 
 
-async def test_get_project_members_missing_project(monkeypatch):
-    _capture_post(monkeypatch, {"result": {"data": []}})
-    assert await _client().get_project_members("PHID-PROJ-1") == frozenset()
-
-
 async def test_query_latest_diff_picks_highest_id(monkeypatch):
     _capture_post(
         monkeypatch,

--- a/services/hackbot-api/app/config.py
+++ b/services/hackbot-api/app/config.py
@@ -45,7 +45,7 @@ class Settings(BaseSettings):
     # Phabricator Conduit connection config, embedded as a nested model and
     # populated in this single settings parse from PHABRICATOR_URL /
     # PHABRICATOR_API_KEY / PHABRICATOR_TIMEOUT_SECONDS (see env_nested_delimiter
-    # below). Injected directly as PhabricatorClient(settings.phabricator).
+    # below). Constructed once at application startup and injected as a dependency.
     # Required, so a missing/invalid api_key fails at startup.
     phabricator: PhabricatorSettings
 

--- a/services/hackbot-api/app/config.py
+++ b/services/hackbot-api/app/config.py
@@ -42,11 +42,6 @@ class Settings(BaseSettings):
     # API auth
     external_api_key: str = ""
 
-    # Phabricator Conduit connection config, embedded as a nested model and
-    # populated in this single settings parse from PHABRICATOR_URL /
-    # PHABRICATOR_API_KEY / PHABRICATOR_TIMEOUT_SECONDS (see env_nested_delimiter
-    # below). Constructed once at application startup and injected as a dependency.
-    # Required, so a missing/invalid api_key fails at startup.
     phabricator: PhabricatorSettings
 
     # Inbound webhook receiver config, embedded as a nested model and populated

--- a/services/hackbot-api/app/main.py
+++ b/services/hackbot-api/app/main.py
@@ -3,10 +3,15 @@ from contextlib import asynccontextmanager
 
 import sentry_sdk
 from fastapi import FastAPI
+from phabricator_client import PhabricatorClient
 
 from app import __version__
 from app.config import settings
 from app.database.connection import close_db, init_db
+from app.phabricator_authorization import (
+    AUTHORIZED_GROUP_PHID,
+    PhabricatorAuthorizer,
+)
 from app.routers import events_router, runs_router, webhooks_router
 
 if settings.sentry_dsn:
@@ -37,6 +42,11 @@ app = FastAPI(
     description="Agent orchestration platform that runs agents as Cloud Run Jobs",
     version=__version__,
     lifespan=lifespan,
+)
+app.state.phabricator_client = PhabricatorClient(settings.phabricator)
+app.state.phabricator_authorizer = PhabricatorAuthorizer(
+    app.state.phabricator_client,
+    AUTHORIZED_GROUP_PHID,
 )
 
 app.include_router(runs_router)

--- a/services/hackbot-api/app/main.py
+++ b/services/hackbot-api/app/main.py
@@ -3,15 +3,10 @@ from contextlib import asynccontextmanager
 
 import sentry_sdk
 from fastapi import FastAPI
-from phabricator_client import PhabricatorClient
 
 from app import __version__
 from app.config import settings
 from app.database.connection import close_db, init_db
-from app.phabricator_authorization import (
-    AUTHORIZED_GROUP_PHID,
-    PhabricatorAuthorizer,
-)
 from app.routers import events_router, runs_router, webhooks_router
 
 if settings.sentry_dsn:
@@ -42,11 +37,6 @@ app = FastAPI(
     description="Agent orchestration platform that runs agents as Cloud Run Jobs",
     version=__version__,
     lifespan=lifespan,
-)
-app.state.phabricator_client = PhabricatorClient(settings.phabricator)
-app.state.phabricator_authorizer = PhabricatorAuthorizer(
-    app.state.phabricator_client,
-    AUTHORIZED_GROUP_PHID,
 )
 
 app.include_router(runs_router)

--- a/services/hackbot-api/app/phabricator_authorization.py
+++ b/services/hackbot-api/app/phabricator_authorization.py
@@ -1,0 +1,69 @@
+"""Authorization checks for Phabricator webhook authors."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import TYPE_CHECKING
+
+from cachetools import TTLCache
+
+if TYPE_CHECKING:
+    from phabricator_client import PhabricatorClient
+
+
+class PhabricatorAuthorizer:
+    """Cache-backed authorization checks against a Phabricator project."""
+
+    def __init__(
+        self,
+        group_phid: str,
+        *,
+        cache_ttl_seconds: int = 300,
+        missing_member_refresh_cooldown_seconds: int = 30,
+    ) -> None:
+        self._group_phid = group_phid
+        self._members_cache: TTLCache[str, frozenset[str]] = TTLCache(
+            maxsize=1,
+            ttl=cache_ttl_seconds,
+        )
+        self._members_lock = asyncio.Lock()
+        self._last_members_refresh = 0.0
+        self._missing_member_refresh_cooldown_seconds = (
+            missing_member_refresh_cooldown_seconds
+        )
+
+    async def is_authorized(self, client: PhabricatorClient, author_phid: str) -> bool:
+        """Return whether an author belongs to the authorized project.
+
+        Known members use the cached project snapshot. An unknown author causes
+        one refresh so recently added members take effect promptly. Subsequent
+        unknown authors use a short cooldown to avoid a Phabricator request for
+        every unauthorized webhook delivery.
+        """
+        cached_members = self._members_cache.get(self._group_phid)
+        if cached_members is not None and author_phid in cached_members:
+            return True
+
+        async with self._members_lock:
+            cached_members = self._members_cache.get(self._group_phid)
+            if cached_members is not None and author_phid in cached_members:
+                return True
+
+            now = time.monotonic()
+            if (
+                cached_members is not None
+                and now - self._last_members_refresh
+                < self._missing_member_refresh_cooldown_seconds
+            ):
+                return False
+
+            members = await client.get_project_members(self._group_phid)
+            self._members_cache[self._group_phid] = members
+            self._last_members_refresh = time.monotonic()
+            return author_phid in members
+
+
+# Members of this project are authorized to trigger Hackbot.
+AUTHORIZED_GROUP_PHID = "PHID-PROJ-njo5uuqyyq3oijbkhy55"  # bmo-editbugs-team
+phabricator_authorizer = PhabricatorAuthorizer(AUTHORIZED_GROUP_PHID)

--- a/services/hackbot-api/app/phabricator_authorization.py
+++ b/services/hackbot-api/app/phabricator_authorization.py
@@ -12,17 +12,23 @@ if TYPE_CHECKING:
     from phabricator_client import PhabricatorClient
 
 
+# Members of this project are authorized to trigger Hackbot.
+AUTHORIZED_GROUP_PHID = "PHID-PROJ-njo5uuqyyq3oijbkhy55"  # bmo-editbugs-team
+
+
 class PhabricatorAuthorizer:
     """Cache-backed authorization checks against a Phabricator project."""
 
     def __init__(
         self,
-        group_phid: str,
+        client: PhabricatorClient,
+        authorized_group_phid: str,
         *,
         cache_ttl_seconds: int = 300,
         missing_member_refresh_cooldown_seconds: int = 30,
     ) -> None:
-        self._group_phid = group_phid
+        self._client = client
+        self._authorized_group_phid = authorized_group_phid
         self._members_cache: TTLCache[str, frozenset[str]] = TTLCache(
             maxsize=1,
             ttl=cache_ttl_seconds,
@@ -33,7 +39,7 @@ class PhabricatorAuthorizer:
             missing_member_refresh_cooldown_seconds
         )
 
-    async def is_authorized(self, client: PhabricatorClient, author_phid: str) -> bool:
+    async def is_authorized(self, author_phid: str) -> bool:
         """Return whether an author belongs to the authorized project.
 
         Known members use the cached project snapshot. An unknown author causes
@@ -41,12 +47,12 @@ class PhabricatorAuthorizer:
         unknown authors use a short cooldown to avoid a Phabricator request for
         every unauthorized webhook delivery.
         """
-        cached_members = self._members_cache.get(self._group_phid)
+        cached_members = self._members_cache.get(self._authorized_group_phid)
         if cached_members is not None and author_phid in cached_members:
             return True
 
         async with self._members_lock:
-            cached_members = self._members_cache.get(self._group_phid)
+            cached_members = self._members_cache.get(self._authorized_group_phid)
             if cached_members is not None and author_phid in cached_members:
                 return True
 
@@ -58,12 +64,9 @@ class PhabricatorAuthorizer:
             ):
                 return False
 
-            members = await client.get_project_members(self._group_phid)
-            self._members_cache[self._group_phid] = members
+            members = await self._client.get_project_members(
+                self._authorized_group_phid
+            )
+            self._members_cache[self._authorized_group_phid] = members
             self._last_members_refresh = time.monotonic()
             return author_phid in members
-
-
-# Members of this project are authorized to trigger Hackbot.
-AUTHORIZED_GROUP_PHID = "PHID-PROJ-njo5uuqyyq3oijbkhy55"  # bmo-editbugs-team
-phabricator_authorizer = PhabricatorAuthorizer(AUTHORIZED_GROUP_PHID)

--- a/services/hackbot-api/app/phabricator_webhook.py
+++ b/services/hackbot-api/app/phabricator_webhook.py
@@ -8,13 +8,11 @@ Bugzilla bug id. The route in ``app/routers/webhooks.py`` orchestrates these.
 
 from __future__ import annotations
 
-import asyncio
 import logging
-import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from cachetools import TTLCache
+from app.phabricator_authorization import phabricator_authorizer
 
 if TYPE_CHECKING:
     from phabricator_client import PhabricatorClient
@@ -25,16 +23,6 @@ log = logging.getLogger(__name__)
 
 # Transaction types that carry a comment we can scan for the mention.
 _COMMENT_TYPES = frozenset({"comment", "inline"})
-EDITBUGS_GROUP_PHID = "PHID-PROJ-njo5uuqyyq3oijbkhy55"
-_MEMBERSHIP_CACHE_TTL_SECONDS = 60
-_MISSING_MEMBER_REFRESH_COOLDOWN_SECONDS = 30
-
-_editbugs_members_cache: TTLCache[str, frozenset[str]] = TTLCache(
-    maxsize=1,
-    ttl=_MEMBERSHIP_CACHE_TTL_SECONDS,
-)
-_editbugs_members_lock = asyncio.Lock()
-_last_editbugs_members_refresh = 0.0
 
 
 @dataclass(frozen=True)
@@ -102,45 +90,6 @@ def _join_comments(comments: list[str]) -> str:
     return "\n\n".join(f"[comment {i}]\n{c}" for i, c in enumerate(comments, 1))
 
 
-async def get_authorized_members(
-    client: PhabricatorClient, author_phids: set[str]
-) -> frozenset[str]:
-    """Return the members authorized to trigger Hackbot for these authors.
-
-    Known authors use the cached project-members snapshot. If any author is
-    absent, refresh the snapshot once so newly added members take effect without
-    waiting for the TTL. The cooldown prevents repeated unauthorized mentions
-    from issuing a Phabricator request for every delivery.
-    """
-    global _last_editbugs_members_refresh
-
-    if not author_phids:
-        return frozenset()
-
-    cached_members = _editbugs_members_cache.get(EDITBUGS_GROUP_PHID)
-    if cached_members is not None and author_phids.issubset(cached_members):
-        return cached_members
-
-    # A shared async lock, so concurrent webhook requests do not issue duplicate refreshes.
-    async with _editbugs_members_lock:
-        cached_members = _editbugs_members_cache.get(EDITBUGS_GROUP_PHID)
-        if cached_members is not None and author_phids.issubset(cached_members):
-            return cached_members
-
-        now = time.monotonic()
-        if (
-            cached_members is not None
-            and now - _last_editbugs_members_refresh
-            < _MISSING_MEMBER_REFRESH_COOLDOWN_SECONDS
-        ):
-            return cached_members
-
-        members = await client.get_project_members(EDITBUGS_GROUP_PHID)
-        _editbugs_members_cache[EDITBUGS_GROUP_PHID] = members
-        _last_editbugs_members_refresh = time.monotonic()
-        return members
-
-
 async def resolve_revision(
     client: PhabricatorClient, revision_phid: str
 ) -> tuple[int | None, int | None]:
@@ -185,13 +134,12 @@ async def detect_mention_and_revision(
         bot_phid=webhook.bot_phid,
         token=webhook.mention_token,
     )
-    authorized_members = await get_authorized_members(
-        client,
-        {mention.author_phid for mention in mentions},
-    )
     comments: list[str] = []
     for mention in mentions:
-        if mention.author_phid in authorized_members:
+        if await phabricator_authorizer.is_authorized(
+            client,
+            mention.author_phid,
+        ):
             comments.append(mention.raw)
         else:
             log.warning(

--- a/services/hackbot-api/app/phabricator_webhook.py
+++ b/services/hackbot-api/app/phabricator_webhook.py
@@ -60,7 +60,10 @@ def find_hackbot_mentions(
             continue
         if transaction.get("type") not in _COMMENT_TYPES:
             continue
-        if bot_phid and transaction.get("authorPHID") == bot_phid:
+        author_phid = transaction.get("authorPHID")
+        if not author_phid:
+            continue
+        if bot_phid and author_phid == bot_phid:
             continue
         for comment in transaction.get("comments") or []:
             raw = (comment.get("content") or {}).get("raw") or ""
@@ -68,7 +71,7 @@ def find_hackbot_mentions(
                 matches.append(
                     HackbotMention(
                         raw=raw,
-                        author_phid=transaction.get("authorPHID", ""),
+                        author_phid=author_phid,
                     )
                 )
                 break
@@ -130,15 +133,6 @@ async def detect_mention_and_revision(
         bot_phid=webhook.bot_phid,
         token=webhook.mention_token,
     )
-    if not mentions:
-        log.warning(
-            "No %s mention found in triggering transactions %s on %s",
-            webhook.mention_token,
-            triggering_phids,
-            object_phid,
-        )
-        return None
-
     authorized_members = await client.get_project_members(EDITBUGS_GROUP_PHID)
     comments: list[str] = []
     for mention in mentions:
@@ -148,10 +142,16 @@ async def detect_mention_and_revision(
             log.warning(
                 "Ignoring %s mention from non-editbugs user %s on %s",
                 webhook.mention_token,
-                mention.author_phid or "<missing PHID>",
+                mention.author_phid,
                 object_phid,
             )
     if not comments:
+        log.warning(
+            "No actionable %s mention found in triggering transactions %s on %s",
+            webhook.mention_token,
+            triggering_phids,
+            object_phid,
+        )
         return None
     comment = _join_comments(comments)
 

--- a/services/hackbot-api/app/phabricator_webhook.py
+++ b/services/hackbot-api/app/phabricator_webhook.py
@@ -12,12 +12,11 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from app.phabricator_authorization import phabricator_authorizer
-
 if TYPE_CHECKING:
     from phabricator_client import PhabricatorClient
 
     from app.config import WebhookSettings
+    from app.phabricator_authorization import PhabricatorAuthorizer
 
 log = logging.getLogger(__name__)
 
@@ -27,7 +26,7 @@ _COMMENT_TYPES = frozenset({"comment", "inline"})
 
 @dataclass(frozen=True)
 class HackbotMention:
-    raw: str
+    comment: str
     author_phid: str
 
 
@@ -67,11 +66,11 @@ def find_hackbot_mentions(
         if bot_phid and author_phid == bot_phid:
             continue
         for comment in transaction.get("comments") or []:
-            raw = (comment.get("content") or {}).get("raw") or ""
-            if token in raw:
+            comment_text = (comment.get("content") or {}).get("raw") or ""
+            if token in comment_text:
                 matches.append(
                     HackbotMention(
-                        raw=raw,
+                        comment=comment_text,
                         author_phid=author_phid,
                     )
                 )
@@ -116,6 +115,8 @@ async def detect_mention_and_revision(
     webhook: WebhookSettings,
     object_phid: str,
     triggering_phids: list[str],
+    *,
+    authorizer: PhabricatorAuthorizer,
 ) -> tuple[str, int, int] | None:
     """Read Conduit and return ``(comment, revision_id, bug_id)`` or None.
 
@@ -136,11 +137,8 @@ async def detect_mention_and_revision(
     )
     comments: list[str] = []
     for mention in mentions:
-        if await phabricator_authorizer.is_authorized(
-            client,
-            mention.author_phid,
-        ):
-            comments.append(mention.raw)
+        if await authorizer.is_authorized(mention.author_phid):
+            comments.append(mention.comment)
         else:
             log.warning(
                 "Ignoring %s mention from non-editbugs user %s on %s",

--- a/services/hackbot-api/app/phabricator_webhook.py
+++ b/services/hackbot-api/app/phabricator_webhook.py
@@ -8,9 +8,13 @@ Bugzilla bug id. The route in ``app/routers/webhooks.py`` orchestrates these.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+
+from cachetools import TTLCache
 
 if TYPE_CHECKING:
     from phabricator_client import PhabricatorClient
@@ -22,6 +26,15 @@ log = logging.getLogger(__name__)
 # Transaction types that carry a comment we can scan for the mention.
 _COMMENT_TYPES = frozenset({"comment", "inline"})
 EDITBUGS_GROUP_PHID = "PHID-PROJ-njo5uuqyyq3oijbkhy55"
+_MEMBERSHIP_CACHE_TTL_SECONDS = 60
+_MISSING_MEMBER_REFRESH_COOLDOWN_SECONDS = 30
+
+_editbugs_members_cache: TTLCache[str, frozenset[str]] = TTLCache(
+    maxsize=1,
+    ttl=_MEMBERSHIP_CACHE_TTL_SECONDS,
+)
+_editbugs_members_lock = asyncio.Lock()
+_last_editbugs_members_refresh = 0.0
 
 
 @dataclass(frozen=True)
@@ -89,6 +102,45 @@ def _join_comments(comments: list[str]) -> str:
     return "\n\n".join(f"[comment {i}]\n{c}" for i, c in enumerate(comments, 1))
 
 
+async def get_authorized_members(
+    client: PhabricatorClient, author_phids: set[str]
+) -> frozenset[str]:
+    """Return the members authorized to trigger Hackbot for these authors.
+
+    Known authors use the cached project-members snapshot. If any author is
+    absent, refresh the snapshot once so newly added members take effect without
+    waiting for the TTL. The cooldown prevents repeated unauthorized mentions
+    from issuing a Phabricator request for every delivery.
+    """
+    global _last_editbugs_members_refresh
+
+    if not author_phids:
+        return frozenset()
+
+    cached_members = _editbugs_members_cache.get(EDITBUGS_GROUP_PHID)
+    if cached_members is not None and author_phids.issubset(cached_members):
+        return cached_members
+
+    # A shared async lock, so concurrent webhook requests do not issue duplicate refreshes.
+    async with _editbugs_members_lock:
+        cached_members = _editbugs_members_cache.get(EDITBUGS_GROUP_PHID)
+        if cached_members is not None and author_phids.issubset(cached_members):
+            return cached_members
+
+        now = time.monotonic()
+        if (
+            cached_members is not None
+            and now - _last_editbugs_members_refresh
+            < _MISSING_MEMBER_REFRESH_COOLDOWN_SECONDS
+        ):
+            return cached_members
+
+        members = await client.get_project_members(EDITBUGS_GROUP_PHID)
+        _editbugs_members_cache[EDITBUGS_GROUP_PHID] = members
+        _last_editbugs_members_refresh = time.monotonic()
+        return members
+
+
 async def resolve_revision(
     client: PhabricatorClient, revision_phid: str
 ) -> tuple[int | None, int | None]:
@@ -133,7 +185,10 @@ async def detect_mention_and_revision(
         bot_phid=webhook.bot_phid,
         token=webhook.mention_token,
     )
-    authorized_members = await client.get_project_members(EDITBUGS_GROUP_PHID)
+    authorized_members = await get_authorized_members(
+        client,
+        {mention.author_phid for mention in mentions},
+    )
     comments: list[str] = []
     for mention in mentions:
         if mention.author_phid in authorized_members:

--- a/services/hackbot-api/app/phabricator_webhook.py
+++ b/services/hackbot-api/app/phabricator_webhook.py
@@ -9,6 +9,7 @@ Bugzilla bug id. The route in ``app/routers/webhooks.py`` orchestrates these.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -20,6 +21,13 @@ log = logging.getLogger(__name__)
 
 # Transaction types that carry a comment we can scan for the mention.
 _COMMENT_TYPES = frozenset({"comment", "inline"})
+EDITBUGS_GROUP_PHID = "PHID-PROJ-njo5uuqyyq3oijbkhy55"
+
+
+@dataclass(frozen=True)
+class HackbotMention:
+    raw: str
+    author_phid: str
 
 
 def triggering_transaction_phids(payload: dict) -> list[str]:
@@ -37,8 +45,8 @@ def find_hackbot_mentions(
     *,
     bot_phid: str,
     token: str,
-) -> list[str]:
-    """Return the text of every triggering comment that mentions ``token``.
+) -> list[HackbotMention]:
+    """Return every triggering comment that mentions ``token``.
 
     Only considers transactions named in this delivery, of a comment type, not
     authored by the bot itself (loop prevention). A single review can leave
@@ -46,7 +54,7 @@ def find_hackbot_mentions(
     returned, in transaction order. At most one per transaction: a transaction's
     ``comments`` list is that comment's version history, not distinct comments.
     """
-    matches: list[str] = []
+    matches: list[HackbotMention] = []
     for transaction in transactions:
         if transaction.get("phid") not in triggering_phids:
             continue
@@ -57,7 +65,12 @@ def find_hackbot_mentions(
         for comment in transaction.get("comments") or []:
             raw = (comment.get("content") or {}).get("raw") or ""
             if token in raw:
-                matches.append(raw)
+                matches.append(
+                    HackbotMention(
+                        raw=raw,
+                        author_phid=transaction.get("authorPHID", ""),
+                    )
+                )
                 break
     return matches
 
@@ -111,19 +124,34 @@ async def detect_mention_and_revision(
     revision can't be resolved, or it has no Bugzilla bug id (bug-fix needs one).
     """
     transactions = await client.search_transactions(object_phid)
-    comments = find_hackbot_mentions(
+    mentions = find_hackbot_mentions(
         transactions,
         set(triggering_phids),
         bot_phid=webhook.bot_phid,
         token=webhook.mention_token,
     )
-    if not comments:
+    if not mentions:
         log.warning(
             "No %s mention found in triggering transactions %s on %s",
             webhook.mention_token,
             triggering_phids,
             object_phid,
         )
+        return None
+
+    authorized_members = await client.get_project_members(EDITBUGS_GROUP_PHID)
+    comments: list[str] = []
+    for mention in mentions:
+        if mention.author_phid in authorized_members:
+            comments.append(mention.raw)
+        else:
+            log.warning(
+                "Ignoring %s mention from non-editbugs user %s on %s",
+                webhook.mention_token,
+                mention.author_phid or "<missing PHID>",
+                object_phid,
+            )
+    if not comments:
         return None
     comment = _join_comments(comments)
 

--- a/services/hackbot-api/app/routers/webhooks.py
+++ b/services/hackbot-api/app/routers/webhooks.py
@@ -44,7 +44,7 @@ def get_phabricator_authorizer(
     phab_client: PhabricatorClient = Depends(get_phabricator_client),
 ) -> PhabricatorAuthorizer:
     """Dependency: lazily create the app-scoped authorizer and its member cache."""
-    authorizer = getattr(request.app.state, "phabricator_authorizer", None)
+    authorizer = request.app.state.get("phabricator_authorizer")
     if authorizer is None:
         authorizer = PhabricatorAuthorizer(phab_client, AUTHORIZED_GROUP_PHID)
         request.app.state.phabricator_authorizer = authorizer

--- a/services/hackbot-api/app/routers/webhooks.py
+++ b/services/hackbot-api/app/routers/webhooks.py
@@ -15,6 +15,7 @@ from phabricator_client import PhabricatorClient
 from app.auth import require_phabricator_signature
 from app.client import HackbotClient
 from app.config import settings
+from app.phabricator_authorization import PhabricatorAuthorizer
 from app.phabricator_webhook import (
     detect_mention_and_revision,
     triggering_transaction_phids,
@@ -25,14 +26,19 @@ log = logging.getLogger(__name__)
 router = APIRouter(prefix="/webhooks")
 
 
-def get_phabricator_client() -> PhabricatorClient:
-    """Dependency: a Conduit client built from the service's Phabricator config."""
-    return PhabricatorClient(settings.phabricator)
+def get_phabricator_client(request: Request) -> PhabricatorClient:
+    """Dependency: the app-scoped Conduit client."""
+    return request.app.state.phabricator_client
 
 
 def get_hackbot_client() -> HackbotClient:
     """Dependency: a client for triggering runs over the public hackbot API."""
     return HackbotClient(settings.hackbot_api_url, settings.external_api_key)
+
+
+def get_phabricator_authorizer(request: Request) -> PhabricatorAuthorizer:
+    """Dependency: the app-scoped authorizer with its shared member cache."""
+    return request.app.state.phabricator_authorizer
 
 
 # Best-effort dedupe of retried deliveries, keyed by triggering transaction PHID.
@@ -51,6 +57,7 @@ _seen_transactions: TTLCache = TTLCache(
 async def phabricator_webhook(
     request: Request,
     phab_client: PhabricatorClient = Depends(get_phabricator_client),
+    authorizer: PhabricatorAuthorizer = Depends(get_phabricator_authorizer),
     api_client: HackbotClient = Depends(get_hackbot_client),
 ) -> dict:
     payload = await request.json()
@@ -82,6 +89,7 @@ async def phabricator_webhook(
         settings.webhook,
         object_phid,
         fresh,
+        authorizer=authorizer,
     )
     if detected is None:
         return {"status": "ignored", "reason": "no actionable @hackbot mention"}

--- a/services/hackbot-api/app/routers/webhooks.py
+++ b/services/hackbot-api/app/routers/webhooks.py
@@ -15,7 +15,10 @@ from phabricator_client import PhabricatorClient
 from app.auth import require_phabricator_signature
 from app.client import HackbotClient
 from app.config import settings
-from app.phabricator_authorization import PhabricatorAuthorizer
+from app.phabricator_authorization import (
+    AUTHORIZED_GROUP_PHID,
+    PhabricatorAuthorizer,
+)
 from app.phabricator_webhook import (
     detect_mention_and_revision,
     triggering_transaction_phids,
@@ -26,9 +29,9 @@ log = logging.getLogger(__name__)
 router = APIRouter(prefix="/webhooks")
 
 
-def get_phabricator_client(request: Request) -> PhabricatorClient:
-    """Dependency: the app-scoped Conduit client."""
-    return request.app.state.phabricator_client
+def get_phabricator_client() -> PhabricatorClient:
+    """Dependency: a Conduit client built from the service's Phabricator config."""
+    return PhabricatorClient(settings.phabricator)
 
 
 def get_hackbot_client() -> HackbotClient:
@@ -36,9 +39,16 @@ def get_hackbot_client() -> HackbotClient:
     return HackbotClient(settings.hackbot_api_url, settings.external_api_key)
 
 
-def get_phabricator_authorizer(request: Request) -> PhabricatorAuthorizer:
-    """Dependency: the app-scoped authorizer with its shared member cache."""
-    return request.app.state.phabricator_authorizer
+def get_phabricator_authorizer(
+    request: Request,
+    phab_client: PhabricatorClient = Depends(get_phabricator_client),
+) -> PhabricatorAuthorizer:
+    """Dependency: lazily create the app-scoped authorizer and its member cache."""
+    authorizer = getattr(request.app.state, "phabricator_authorizer", None)
+    if authorizer is None:
+        authorizer = PhabricatorAuthorizer(phab_client, AUTHORIZED_GROUP_PHID)
+        request.app.state.phabricator_authorizer = authorizer
+    return authorizer
 
 
 # Best-effort dedupe of retried deliveries, keyed by triggering transaction PHID.

--- a/services/hackbot-api/tests/test_phabricator_authorization.py
+++ b/services/hackbot-api/tests/test_phabricator_authorization.py
@@ -11,18 +11,18 @@ class _FakeClient:
 
 
 async def test_is_authorized_uses_cached_member_list():
-    authorizer = PhabricatorAuthorizer("PHID-PROJ-test")
     client = _FakeClient(frozenset({"PHID-USER-authorized"}))
+    authorizer = PhabricatorAuthorizer(client, "PHID-PROJ-test")
 
-    assert await authorizer.is_authorized(client, "PHID-USER-authorized") is True
-    assert await authorizer.is_authorized(client, "PHID-USER-authorized") is True
+    assert await authorizer.is_authorized("PHID-USER-authorized") is True
+    assert await authorizer.is_authorized("PHID-USER-authorized") is True
     client.get_project_members.assert_awaited_once_with("PHID-PROJ-test")
 
 
 async def test_is_authorized_refreshes_once_for_unknown_authors():
-    authorizer = PhabricatorAuthorizer("PHID-PROJ-test")
     client = _FakeClient(frozenset({"PHID-USER-authorized"}))
+    authorizer = PhabricatorAuthorizer(client, "PHID-PROJ-test")
 
-    assert await authorizer.is_authorized(client, "PHID-USER-unknown-one") is False
-    assert await authorizer.is_authorized(client, "PHID-USER-unknown-two") is False
+    assert await authorizer.is_authorized("PHID-USER-unknown-one") is False
+    assert await authorizer.is_authorized("PHID-USER-unknown-two") is False
     client.get_project_members.assert_awaited_once_with("PHID-PROJ-test")

--- a/services/hackbot-api/tests/test_phabricator_authorization.py
+++ b/services/hackbot-api/tests/test_phabricator_authorization.py
@@ -1,0 +1,28 @@
+"""Tests for Phabricator webhook author authorization."""
+
+from unittest.mock import AsyncMock
+
+from app.phabricator_authorization import PhabricatorAuthorizer
+
+
+class _FakeClient:
+    def __init__(self, members: frozenset[str]) -> None:
+        self.get_project_members = AsyncMock(return_value=members)
+
+
+async def test_is_authorized_uses_cached_member_list():
+    authorizer = PhabricatorAuthorizer("PHID-PROJ-test")
+    client = _FakeClient(frozenset({"PHID-USER-authorized"}))
+
+    assert await authorizer.is_authorized(client, "PHID-USER-authorized") is True
+    assert await authorizer.is_authorized(client, "PHID-USER-authorized") is True
+    client.get_project_members.assert_awaited_once_with("PHID-PROJ-test")
+
+
+async def test_is_authorized_refreshes_once_for_unknown_authors():
+    authorizer = PhabricatorAuthorizer("PHID-PROJ-test")
+    client = _FakeClient(frozenset({"PHID-USER-authorized"}))
+
+    assert await authorizer.is_authorized(client, "PHID-USER-unknown-one") is False
+    assert await authorizer.is_authorized(client, "PHID-USER-unknown-two") is False
+    client.get_project_members.assert_awaited_once_with("PHID-PROJ-test")

--- a/services/hackbot-api/tests/test_webhooks.py
+++ b/services/hackbot-api/tests/test_webhooks.py
@@ -15,7 +15,10 @@ from app.auth import verify_phabricator_signature
 from app.config import settings
 from app.main import app
 from app.phabricator_webhook import (
+    EDITBUGS_GROUP_PHID,
+    HackbotMention,
     _join_comments,
+    detect_mention_and_revision,
     find_hackbot_mentions,
     resolve_revision,
     triggering_transaction_phids,
@@ -70,7 +73,7 @@ def test_find_mention_matches():
     txns = [_comment_txn("PHID-XACT-1", "PHID-USER-a", "hey @hackbot please fix")]
     assert find_hackbot_mentions(
         txns, {"PHID-XACT-1"}, bot_phid="PHID-USER-bot", token="@hackbot"
-    ) == ["hey @hackbot please fix"]
+    ) == [HackbotMention("hey @hackbot please fix", "PHID-USER-a")]
 
 
 def test_find_mention_no_token():
@@ -120,7 +123,7 @@ def test_find_mention_matches_inline_comment():
     ]
     assert find_hackbot_mentions(
         txns, {"PHID-XACT-1"}, bot_phid="PHID-USER-bot", token="@hackbot"
-    ) == ["@hackbot here"]
+    ) == [HackbotMention("@hackbot here", "PHID-USER-a")]
 
 
 def test_find_mention_collects_all_inline_matches():
@@ -136,7 +139,10 @@ def test_find_mention_collects_all_inline_matches():
         {"PHID-XACT-1", "PHID-XACT-2", "PHID-XACT-3"},
         bot_phid="PHID-USER-bot",
         token="@hackbot",
-    ) == ["@hackbot fix this", "@hackbot and this too"]
+    ) == [
+        HackbotMention("@hackbot fix this", "PHID-USER-a"),
+        HackbotMention("@hackbot and this too", "PHID-USER-a"),
+    ]
 
 
 def test_find_mention_one_per_transaction_ignores_comment_versions():
@@ -153,7 +159,7 @@ def test_find_mention_one_per_transaction_ignores_comment_versions():
     }
     assert find_hackbot_mentions(
         [txn], {"PHID-XACT-1"}, bot_phid="PHID-USER-bot", token="@hackbot"
-    ) == ["@hackbot v1"]
+    ) == [HackbotMention("@hackbot v1", "PHID-USER-a")]
 
 
 def test_join_comments_single_passthrough():
@@ -170,11 +176,16 @@ def test_join_comments_numbers_multiple():
 
 
 class _FakeClient:
-    def __init__(self, revision):
+    def __init__(self, revision, members=()):
         self._revision = revision
+        self._members = frozenset(members)
 
     async def search_revision(self, phid):
         return self._revision
+
+    async def get_project_members(self, project_phid):
+        assert project_phid == EDITBUGS_GROUP_PHID
+        return self._members
 
 
 async def test_resolve_revision_with_bug():
@@ -190,6 +201,52 @@ async def test_resolve_revision_no_bug():
 async def test_resolve_revision_not_found():
     client = _FakeClient(None)
     assert await resolve_revision(client, "PHID-DREV-x") == (None, None)
+
+
+async def test_detect_mention_requires_editbugs_membership(monkeypatch):
+    client = _FakeClient(
+        {"id": 42, "fields": {"bugzilla.bug-id": "12345"}},
+        members={"PHID-USER-authorized"},
+    )
+    transactions = [
+        _comment_txn("PHID-XACT-1", "PHID-USER-unauthorized", "@hackbot ignore"),
+    ]
+    monkeypatch.setattr(
+        client,
+        "search_transactions",
+        AsyncMock(return_value=transactions),
+    )
+
+    result = await detect_mention_and_revision(
+        client,
+        settings.webhook,
+        "PHID-DREV-x",
+        ["PHID-XACT-1"],
+    )
+    assert result is None
+
+
+async def test_detect_mention_accepts_editbugs_member(monkeypatch):
+    client = _FakeClient(
+        {"id": 42, "fields": {"bugzilla.bug-id": "12345"}},
+        members={"PHID-USER-authorized"},
+    )
+    transactions = [
+        _comment_txn("PHID-XACT-1", "PHID-USER-authorized", "@hackbot please fix"),
+    ]
+    monkeypatch.setattr(
+        client,
+        "search_transactions",
+        AsyncMock(return_value=transactions),
+    )
+
+    result = await detect_mention_and_revision(
+        client,
+        settings.webhook,
+        "PHID-DREV-x",
+        ["PHID-XACT-1"],
+    )
+    assert result == ("@hackbot please fix", 42, 12345)
 
 
 # --- payload parsing ---

--- a/services/hackbot-api/tests/test_webhooks.py
+++ b/services/hackbot-api/tests/test_webhooks.py
@@ -14,7 +14,10 @@ import pytest
 from app.auth import verify_phabricator_signature
 from app.config import settings
 from app.main import app
-from app.phabricator_authorization import AUTHORIZED_GROUP_PHID
+from app.phabricator_authorization import (
+    AUTHORIZED_GROUP_PHID,
+    PhabricatorAuthorizer,
+)
 from app.phabricator_webhook import (
     HackbotMention,
     _join_comments,
@@ -225,6 +228,7 @@ async def test_detect_mention_requires_editbugs_membership(monkeypatch):
         settings.webhook,
         "PHID-DREV-x",
         ["PHID-XACT-1"],
+        authorizer=PhabricatorAuthorizer(client, AUTHORIZED_GROUP_PHID),
     )
     assert result is None
 
@@ -248,6 +252,7 @@ async def test_detect_mention_accepts_editbugs_member(monkeypatch):
         settings.webhook,
         "PHID-DREV-x",
         ["PHID-XACT-1"],
+        authorizer=PhabricatorAuthorizer(client, AUTHORIZED_GROUP_PHID),
     )
     assert result == ("@hackbot please fix", 42, 12345)
 
@@ -274,11 +279,28 @@ class _FakeHackbotClient:
         return "run-abc"
 
 
+class _FakeAuthorizer:
+    async def is_authorized(self, author_phid):
+        return True
+
+
 @pytest.fixture
-def client(monkeypatch):
+def authorizer():
+    return _FakeAuthorizer()
+
+
+@pytest.fixture
+def phab_client():
+    return object()
+
+
+@pytest.fixture
+def client(monkeypatch, authorizer, phab_client):
     monkeypatch.setattr(settings.webhook, "secret", SECRET)
     # Fresh dedupe cache per test.
     webhooks._seen_transactions.clear()
+    app.dependency_overrides[webhooks.get_phabricator_client] = lambda: phab_client
+    app.dependency_overrides[webhooks.get_phabricator_authorizer] = lambda: authorizer
     try:
         yield TestClient(app)
     finally:
@@ -331,12 +353,9 @@ def test_route_ignores_no_mention(client, monkeypatch):
     assert resp.json()["reason"] == "no actionable @hackbot mention"
 
 
-def test_route_triggers_run(client, monkeypatch):
-    monkeypatch.setattr(
-        webhooks,
-        "detect_mention_and_revision",
-        AsyncMock(return_value=("@hackbot please fix", 42, 12345)),
-    )
+def test_route_triggers_run(client, phab_client, authorizer, monkeypatch):
+    detect = AsyncMock(return_value=("@hackbot please fix", 42, 12345))
+    monkeypatch.setattr(webhooks, "detect_mention_and_revision", detect)
     fake_api = _FakeHackbotClient()
     app.dependency_overrides[webhooks.get_hackbot_client] = lambda: fake_api
 
@@ -349,6 +368,8 @@ def test_route_triggers_run(client, monkeypatch):
     )
     assert resp.status_code == 202
     assert resp.json() == {"status": "triggered", "run_id": "run-abc"}
+    assert detect.call_args.args[0] is phab_client
+    assert detect.call_args.kwargs["authorizer"] is authorizer
     assert fake_api.calls == [
         (
             "bug-fix",

--- a/services/hackbot-api/tests/test_webhooks.py
+++ b/services/hackbot-api/tests/test_webhooks.py
@@ -14,8 +14,8 @@ import pytest
 from app.auth import verify_phabricator_signature
 from app.config import settings
 from app.main import app
+from app.phabricator_authorization import AUTHORIZED_GROUP_PHID
 from app.phabricator_webhook import (
-    EDITBUGS_GROUP_PHID,
     HackbotMention,
     _join_comments,
     detect_mention_and_revision,
@@ -180,11 +180,14 @@ class _FakeClient:
         self._revision = revision
         self._members = frozenset(members)
 
+    async def search_transactions(self, phid):
+        return []
+
     async def search_revision(self, phid):
         return self._revision
 
     async def get_project_members(self, project_phid):
-        assert project_phid == EDITBUGS_GROUP_PHID
+        assert project_phid == AUTHORIZED_GROUP_PHID
         return self._members
 
 


### PR DESCRIPTION

## Changes

- Check the author of each `@hackbot` comment.
- Process comments only from users authorized to edit revisions.
- Ignore comments from unauthorized users before creating a Hackbot run.
- Add test coverage for authorized, unauthorized

Resolves #6423