### PR TITLE
Add expected results for verifiable steps in the `test-plan-generator` agent

### DIFF
--- a/agents/test-plan-generator/hackbot_agents/test_plan_generator/prompts/system.md
+++ b/agents/test-plan-generator/hackbot_agents/test_plan_generator/prompts/system.md
@@ -12,6 +12,7 @@ report only pass/fail/unsuitable results. Do not try to fix, patch or make chang
    - A title.
    - A primary execution context label: `chrome` or `content`.
    - Ordered test steps.
+   - Step indexed expectations for the verification step(s).
 3. Run the generated cases and steps in order.
 4. Submit one final structured result with `submit_result`.
    - Use the provided feature name as the structured result feature.
@@ -47,6 +48,11 @@ bypass a failing content interaction.
   expected observable behavior. Keep exact inputs, actions, and detailed
   conditions in the test steps.
 - Write concise, ordered test steps.
+- Put only the action a QA engineer should perform in each step.
+- Put expected results in `step_expectations` only for the step or steps that
+  directly verify the observable behavior described by the test case title.
+  Each test case must include at least one expected result. Leave non verifying
+  steps empty.
 
 ## Unsuitable cases
 

--- a/agents/test-plan-generator/hackbot_agents/test_plan_generator/prompts/system.md
+++ b/agents/test-plan-generator/hackbot_agents/test_plan_generator/prompts/system.md
@@ -52,7 +52,7 @@ bypass a failing content interaction.
 - Put expected results in `step_expectations` only for the step or steps that
   directly verify the observable behavior described by the test case title.
 - Do not add expectations for setup, navigation, or routine happy-path
-  confirmation steps, leave those steps empty.
+  confirmation steps, leave the corresponding `step_expectations` entries null.
 
 ## Unsuitable cases
 

--- a/agents/test-plan-generator/hackbot_agents/test_plan_generator/prompts/system.md
+++ b/agents/test-plan-generator/hackbot_agents/test_plan_generator/prompts/system.md
@@ -12,7 +12,7 @@ report only pass/fail/unsuitable results. Do not try to fix, patch or make chang
    - A title.
    - A primary execution context label: `chrome` or `content`.
    - Ordered test steps.
-   - Step indexed expectations for the verification step(s).
+   - Step-indexed expectations for only the verification step(s).
 3. Run the generated cases and steps in order.
 4. Submit one final structured result with `submit_result`.
    - Use the provided feature name as the structured result feature.
@@ -51,8 +51,8 @@ bypass a failing content interaction.
 - Put only the action a QA engineer should perform in each step.
 - Put expected results in `step_expectations` only for the step or steps that
   directly verify the observable behavior described by the test case title.
-  Each test case must include at least one expected result. Leave non verifying
-  steps empty.
+- Do not add expectations for setup, navigation, or routine happy-path
+  confirmation steps, leave those steps empty.
 
 ## Unsuitable cases
 

--- a/agents/test-plan-generator/hackbot_agents/test_plan_generator/prompts/system.md
+++ b/agents/test-plan-generator/hackbot_agents/test_plan_generator/prompts/system.md
@@ -11,8 +11,7 @@ report only pass/fail/unsuitable results. Do not try to fix, patch or make chang
 2. Each test case must have:
    - A title.
    - A primary execution context label: `chrome` or `content`.
-   - Ordered test steps.
-   - Step-indexed expectations for only the verification step(s).
+   - Ordered test steps, each with an `action` and optional `expectation`.
 3. Run the generated cases and steps in order.
 4. Submit one final structured result with `submit_result`.
    - Use the provided feature name as the structured result feature.
@@ -47,12 +46,12 @@ bypass a failing content interaction.
 - Write each title as a clear, direct declarative statement describing the
   expected observable behavior. Keep exact inputs, actions, and detailed
   conditions in the test steps.
-- Write concise, ordered test steps.
-- Put only the action a QA engineer should perform in each step.
-- Put expected results in `step_expectations` only for the step or steps that
-  directly verify the observable behavior described by the test case title.
+- Write concise, ordered test steps with one action per step.
+- Put only the action a QA engineer should perform in each step's `action`.
+- Put expected results in a step's `expectation` only when that step's `action`
+  directly verifies the observable behavior described by the test case title.
 - Do not add expectations for setup, navigation, or routine happy-path
-  confirmation steps, leave the corresponding `step_expectations` entries null.
+  confirmation steps, leave those step `expectation` values null.
 
 ## Unsuitable cases
 

--- a/agents/test-plan-generator/hackbot_agents/test_plan_generator/result.py
+++ b/agents/test-plan-generator/hackbot_agents/test_plan_generator/result.py
@@ -16,6 +16,14 @@ RESULT_SERVER_NAME = "test-plan-generator"
 SUBMIT_RESULT_TOOL = f"mcp__{RESULT_SERVER_NAME}__submit_result"
 
 
+class GeneratedTestStep(BaseModel):
+    action: str = Field(description="The action a QA engineer should perform.")
+    expectation: str | None = Field(
+        default=None,
+        description=("Expected result for this step."),
+    )
+
+
 class GeneratedTestCase(BaseModel):
     id: int = Field(description="Sequential case id starting at 1.")
     title: str
@@ -27,12 +35,10 @@ class GeneratedTestCase(BaseModel):
         )
     )
     preconditions: str | None = None
-    steps: list[str] = Field(description="Concise ordered test steps for this case.")
-    step_expectations: list[str | None] = Field(
+    steps: list[GeneratedTestStep] = Field(
         description=(
-            "Expected results aligned by index with steps when present. Use null "
-            "for setup, navigation, or happy-path steps that do not directly "
-            "verify the case title."
+            "Concise ordered test steps. Each step has an action and an optional "
+            "expectation."
         )
     )
 
@@ -40,7 +46,7 @@ class GeneratedTestCase(BaseModel):
     def _validate_steps(self) -> "GeneratedTestCase":
         if not self.steps:
             raise ValueError("each generated test case must have at least one step")
-        if not any(self.step_expectations):
+        if not any(step.expectation for step in self.steps):
             raise ValueError(
                 "each generated test case must include an expected result on at "
                 "least one verification step"

--- a/agents/test-plan-generator/hackbot_agents/test_plan_generator/result.py
+++ b/agents/test-plan-generator/hackbot_agents/test_plan_generator/result.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import Literal
 
 from claude_agent_sdk import McpServerConfig, create_sdk_mcp_server, tool
-from pydantic import BaseModel, Field, ValidationError, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    ValidationError,
+    model_validator,
+)
 
 RESULT_SERVER_NAME = "test-plan-generator"
 SUBMIT_RESULT_TOOL = f"mcp__{RESULT_SERVER_NAME}__submit_result"
@@ -22,14 +27,24 @@ class GeneratedTestCase(BaseModel):
         )
     )
     preconditions: str | None = None
-    steps: list[str] = Field(
-        description="Concise test steps for this case; between 1 and 6 steps."
+    steps: list[str] = Field(description="Concise ordered test steps for this case.")
+    step_expectations: list[str | None] = Field(
+        description=(
+            "Expected results aligned by index with steps when present. Use null "
+            "for setup, navigation, or happy-path steps that do not directly "
+            "verify the case title."
+        )
     )
 
     @model_validator(mode="after")
     def _validate_steps(self) -> "GeneratedTestCase":
-        if not 1 <= len(self.steps) <= 6:
-            raise ValueError("each generated test case must have 1 to 6 steps")
+        if not self.steps:
+            raise ValueError("each generated test case must have at least one step")
+        if not any(self.step_expectations):
+            raise ValueError(
+                "each generated test case must include an expected result on at "
+                "least one verification step"
+            )
         return self
 
 

--- a/libs/hackbot-runtime/hackbot_runtime/actions/handlers/testrail_handler.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/handlers/testrail_handler.py
@@ -70,17 +70,33 @@ def _case_payload(
     case_type_id: int,
     template_id: int,
 ) -> dict[str, Any]:
-    steps = [str(step) for step in test_case.get("steps", [])]
     payload: dict[str, Any] = {
         "title": test_case["title"],
         "type_id": case_type_id,
         "template_id": template_id,
         "labels": [_CASE_LABEL],
-        "custom_steps_separated": [{"content": step, "expected": ""} for step in steps],
+        "custom_steps_separated": _separated_steps(test_case),
     }
     if test_case.get("preconditions"):
         payload["custom_preconds"] = test_case["preconditions"]
     return payload
+
+
+def _separated_steps(test_case: dict[str, Any]) -> list[dict[str, str]]:
+    steps = [str(step) for step in test_case.get("steps", [])]
+    expectations = list(test_case.get("step_expectations") or [])
+
+    separated_steps = []
+    for index, step in enumerate(steps):
+        expected = expectations[index] if index < len(expectations) else ""
+        separated_steps.append(
+            {
+                "content": step,
+                "expected": str(expected or ""),
+            }
+        )
+
+    return separated_steps
 
 
 class SubmitTestPlanHandler:

--- a/libs/hackbot-runtime/hackbot_runtime/actions/handlers/testrail_handler.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/handlers/testrail_handler.py
@@ -83,16 +83,13 @@ def _case_payload(
 
 
 def _separated_steps(test_case: dict[str, Any]) -> list[dict[str, str]]:
-    steps = [str(step) for step in test_case.get("steps", [])]
-    expectations = list(test_case.get("step_expectations") or [])
-
     separated_steps = []
-    for index, step in enumerate(steps):
-        expected = expectations[index] if index < len(expectations) else ""
+    for step in test_case.get("steps", []):
+        expectation = step.get("expectation")
         separated_steps.append(
             {
-                "content": step,
-                "expected": str(expected or ""),
+                "content": str(step["action"]),
+                "expected": "" if expectation is None else str(expectation),
             }
         )
 

--- a/libs/hackbot-runtime/hackbot_runtime/actions/handlers/testrail_handler.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/handlers/testrail_handler.py
@@ -83,17 +83,13 @@ def _case_payload(
 
 
 def _separated_steps(test_case: dict[str, Any]) -> list[dict[str, str]]:
-    separated_steps = []
-    for step in test_case.get("steps", []):
-        expectation = step.get("expectation")
-        separated_steps.append(
-            {
-                "content": str(step["action"]),
-                "expected": "" if expectation is None else str(expectation),
-            }
-        )
-
-    return separated_steps
+    return [
+        {
+            "content": str(step["action"]),
+            "expected": str(step.get("expectation") or ""),
+        }
+        for step in test_case.get("steps", [])
+    ]
 
 
 class SubmitTestPlanHandler:

--- a/libs/hackbot-runtime/hackbot_runtime/actions/testrail.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/testrail.py
@@ -10,7 +10,13 @@ from __future__ import annotations
 from typing import Annotated, Any
 
 from agent_tools.registry import ToolError, tool, tools_in
-from pydantic import BaseModel, Field, ValidationError, field_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 
 from hackbot_runtime.actions.recorder import ActionsRecorder
 
@@ -29,6 +35,12 @@ class TestRailCaseInput(BaseModel):
     steps: list[str] = Field(
         min_length=1, description="Ordered steps a QA engineer should follow."
     )
+    step_expectations: list[str | None] = Field(
+        description=(
+            "Expected results aligned by index with steps when present. Use null "
+            "for steps that do not directly verify the case title."
+        ),
+    )
 
     @field_validator("title")
     @classmethod
@@ -45,6 +57,12 @@ class TestRailCaseInput(BaseModel):
         if any(not step for step in steps):
             raise ValueError("steps must not contain blank items")
         return steps
+
+    @model_validator(mode="after")
+    def expectations_must_include_verification(self) -> "TestRailCaseInput":
+        if not any(self.step_expectations):
+            raise ValueError("at least one step must include an expected result")
+        return self
 
 
 class SubmitTestPlanInput(BaseModel):

--- a/libs/hackbot-runtime/hackbot_runtime/actions/testrail.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/testrail.py
@@ -23,6 +23,14 @@ from hackbot_runtime.actions.recorder import ActionsRecorder
 ACTION_TYPE = "testrail.submit_test_plan"
 
 
+class TestRailStepInput(BaseModel):
+    action: str = Field(description="Test step action.")
+    expectation: str | None = Field(
+        default=None,
+        description=("Expected result for this step."),
+    )
+
+
 class TestRailCaseInput(BaseModel):
     id: int
     title: str = Field(description="TestRail test case title.")
@@ -32,13 +40,11 @@ class TestRailCaseInput(BaseModel):
     preconditions: str | None = Field(
         default=None, description="Optional setup required before running this case."
     )
-    steps: list[str] = Field(
-        min_length=1, description="Ordered steps a QA engineer should follow."
-    )
-    step_expectations: list[str | None] = Field(
+    steps: list[TestRailStepInput] = Field(
+        min_length=1,
         description=(
-            "Expected results aligned by index with steps when present. Use null "
-            "for steps that do not directly verify the case title."
+            "Ordered steps a QA engineer should follow. Each step has an action "
+            "and an optional expectation."
         ),
     )
 
@@ -52,15 +58,16 @@ class TestRailCaseInput(BaseModel):
 
     @field_validator("steps")
     @classmethod
-    def steps_must_not_be_blank(cls, value: list[str]) -> list[str]:
-        steps = [step.strip() for step in value]
-        if any(not step for step in steps):
-            raise ValueError("steps must not contain blank items")
-        return steps
+    def steps_must_not_be_blank(
+        cls, value: list[TestRailStepInput]
+    ) -> list[TestRailStepInput]:
+        if any(not step.action.strip() for step in value):
+            raise ValueError("step's actions must not contain blank items")
+        return value
 
     @model_validator(mode="after")
     def expectations_must_include_verification(self) -> "TestRailCaseInput":
-        if not any(self.step_expectations):
+        if not any(step.expectation for step in self.steps):
             raise ValueError("at least one step must include an expected result")
         return self
 

--- a/libs/hackbot-runtime/tests/test_testrail_action.py
+++ b/libs/hackbot-runtime/tests/test_testrail_action.py
@@ -13,8 +13,9 @@ def _cases():
             "title": "The PDF opens",
             "context": "content",
             "preconditions": "A PDF is available.",
-            "steps": ["Open the PDF"],
-            "step_expectations": ["The PDF is displayed."],
+            "steps": [
+                {"action": "Open the PDF", "expectation": "The PDF is displayed."}
+            ],
         }
     ]
 
@@ -59,8 +60,7 @@ async def test_submit_test_plan_tool_rejects_cases_without_expectation():
                 {
                     "id": 1,
                     "title": "Case",
-                    "steps": ["Open the PDF"],
-                    "step_expectations": [""],
+                    "steps": [{"action": "Open the PDF", "expectation": None}],
                 }
             ],
         )
@@ -79,15 +79,18 @@ async def test_submit_test_plan_tool_preserves_blank_expectations():
             {
                 "id": 1,
                 "title": "Case",
-                "steps": ["Open the PDF", "Select text"],
-                "step_expectations": ["", "Text is selected."],
+                "steps": [
+                    {"action": "Open the PDF", "expectation": ""},
+                    {"action": "Select text", "expectation": "Text is selected."},
+                ],
             }
         ],
     )
 
-    assert recorder.actions[0]["params"]["generated_test_cases"][0][
-        "step_expectations"
-    ] == ["", "Text is selected."]
+    assert recorder.actions[0]["params"]["generated_test_cases"][0]["steps"] == [
+        {"action": "Open the PDF", "expectation": ""},
+        {"action": "Select text", "expectation": "Text is selected."},
+    ]
 
 
 def test_submit_test_plan_handler_is_registered():

--- a/libs/hackbot-runtime/tests/test_testrail_action.py
+++ b/libs/hackbot-runtime/tests/test_testrail_action.py
@@ -14,6 +14,7 @@ def _cases():
             "context": "content",
             "preconditions": "A PDF is available.",
             "steps": ["Open the PDF"],
+            "step_expectations": ["The PDF is displayed."],
         }
     ]
 
@@ -45,6 +46,48 @@ async def test_submit_test_plan_tool_rejects_invalid_input():
 
     assert "invalid TestRail submission" in str(exc.value)
     assert recorder.actions == []
+
+
+async def test_submit_test_plan_tool_rejects_cases_without_expectation():
+    recorder = ActionsRecorder()
+
+    with pytest.raises(ToolError) as exc:
+        await testrail.submit_test_plan(
+            recorder,
+            feature="Feature",
+            generated_test_cases=[
+                {
+                    "id": 1,
+                    "title": "Case",
+                    "steps": ["Open the PDF"],
+                    "step_expectations": [""],
+                }
+            ],
+        )
+
+    assert "invalid TestRail submission" in str(exc.value)
+    assert recorder.actions == []
+
+
+async def test_submit_test_plan_tool_preserves_blank_expectations():
+    recorder = ActionsRecorder()
+
+    await testrail.submit_test_plan(
+        recorder,
+        feature="Feature",
+        generated_test_cases=[
+            {
+                "id": 1,
+                "title": "Case",
+                "steps": ["Open the PDF", "Select text"],
+                "step_expectations": ["", "Text is selected."],
+            }
+        ],
+    )
+
+    assert recorder.actions[0]["params"]["generated_test_cases"][0][
+        "step_expectations"
+    ] == ["", "Text is selected."]
 
 
 def test_submit_test_plan_handler_is_registered():

--- a/libs/hackbot-runtime/tests/test_testrail_handler.py
+++ b/libs/hackbot-runtime/tests/test_testrail_handler.py
@@ -19,10 +19,12 @@ def _plan():
                 "title": "The PDF opens",
                 "context": "content",
                 "preconditions": "A PDF is available.",
-                "steps": ["Open the PDF", "Select some text"],
-                "step_expectations": [
-                    None,
-                    "Text selection is highlighted in the PDF.",
+                "steps": [
+                    {"action": "Open the PDF", "expectation": None},
+                    {
+                        "action": "Select some text",
+                        "expectation": "Text selection is highlighted in the PDF.",
+                    },
                 ],
             },
             {
@@ -30,9 +32,11 @@ def _plan():
                 "title": "The toolbar remains available",
                 "context": "chrome",
                 "preconditions": None,
-                "steps": ["Open the toolbar"],
-                "step_expectations": [
-                    "The toolbar remains visible and usable.",
+                "steps": [
+                    {
+                        "action": "Open the toolbar",
+                        "expectation": "The toolbar remains visible and usable.",
+                    },
                 ],
             },
         ],
@@ -158,28 +162,19 @@ async def test_submit_test_plan_creates_suite_section_and_cases(monkeypatch):
     }
 
 
-def test_separated_steps_maps_expectations_by_step_index():
+def test_separated_steps_maps_expectations_from_step_objects():
     assert testrail_handler._separated_steps(
         {
-            "steps": ["Open the PDF", "Select text", "Copy text"],
-            "step_expectations": [None, "", "Text is copied."],
+            "steps": [
+                {"action": "Open the PDF", "expectation": None},
+                {"action": "Select text", "expectation": ""},
+                {"action": "Copy text", "expectation": "Text is copied."},
+            ],
         }
     ) == [
         {"content": "Open the PDF", "expected": ""},
         {"content": "Select text", "expected": ""},
         {"content": "Copy text", "expected": "Text is copied."},
-    ]
-
-
-def test_separated_steps_allows_fewer_expectations_than_steps():
-    assert testrail_handler._separated_steps(
-        {
-            "steps": ["Open the PDF", "Select text"],
-            "step_expectations": ["The PDF is displayed."],
-        }
-    ) == [
-        {"content": "Open the PDF", "expected": "The PDF is displayed."},
-        {"content": "Select text", "expected": ""},
     ]
 
 

--- a/libs/hackbot-runtime/tests/test_testrail_handler.py
+++ b/libs/hackbot-runtime/tests/test_testrail_handler.py
@@ -20,6 +20,10 @@ def _plan():
                 "context": "content",
                 "preconditions": "A PDF is available.",
                 "steps": ["Open the PDF", "Select some text"],
+                "step_expectations": [
+                    None,
+                    "Text selection is highlighted in the PDF.",
+                ],
             },
             {
                 "id": 2,
@@ -27,6 +31,9 @@ def _plan():
                 "context": "chrome",
                 "preconditions": None,
                 "steps": ["Open the toolbar"],
+                "step_expectations": [
+                    "The toolbar remains visible and usable.",
+                ],
             },
         ],
         "results": [
@@ -143,9 +150,37 @@ async def test_submit_test_plan_creates_suite_section_and_cases(monkeypatch):
         "custom_preconds": "A PDF is available.",
         "custom_steps_separated": [
             {"content": "Open the PDF", "expected": ""},
-            {"content": "Select some text", "expected": ""},
+            {
+                "content": "Select some text",
+                "expected": "Text selection is highlighted in the PDF.",
+            },
         ],
     }
+
+
+def test_separated_steps_maps_expectations_by_step_index():
+    assert testrail_handler._separated_steps(
+        {
+            "steps": ["Open the PDF", "Select text", "Copy text"],
+            "step_expectations": [None, "", "Text is copied."],
+        }
+    ) == [
+        {"content": "Open the PDF", "expected": ""},
+        {"content": "Select text", "expected": ""},
+        {"content": "Copy text", "expected": "Text is copied."},
+    ]
+
+
+def test_separated_steps_allows_fewer_expectations_than_steps():
+    assert testrail_handler._separated_steps(
+        {
+            "steps": ["Open the PDF", "Select text"],
+            "step_expectations": ["The PDF is displayed."],
+        }
+    ) == [
+        {"content": "Open the PDF", "expected": "The PDF is displayed."},
+        {"content": "Select text", "expected": ""},
+    ]
 
 
 async def test_submit_test_plan_reports_api_failure(monkeypatch):

--- a/services/hackbot-ui/app/globals.css
+++ b/services/hackbot-ui/app/globals.css
@@ -776,6 +776,26 @@ ul.chips li.chip {
 .test-step-list li:last-child {
   margin-bottom: 0;
 }
+.test-step-list li > p {
+  margin: 0;
+}
+.test-step-expectation {
+  margin-top: 6px;
+  padding: 8px 10px;
+  border-left: 3px solid var(--border);
+  border-radius: 4px;
+  background: rgba(154, 163, 178, 0.08);
+  font-size: 13px;
+}
+.test-step-expectation strong {
+  display: block;
+  margin-bottom: 3px;
+  color: var(--muted);
+}
+.test-step-expectation p {
+  margin: 0;
+  color: var(--text);
+}
 .badge.test-passed {
   background: rgba(46, 160, 67, 0.18);
   color: var(--green);

--- a/services/hackbot-ui/components/TestPlanView.tsx
+++ b/services/hackbot-ui/components/TestPlanView.tsx
@@ -1,4 +1,4 @@
-import { isPlainObject, isStringArray } from "@/lib/findings-format";
+import { isPlainObject } from "@/lib/findings-format";
 
 type TestCaseStatus = "passed" | "failed" | "unsuitable";
 
@@ -6,7 +6,11 @@ interface GeneratedTestCase {
   id: number;
   title: string;
   preconditions: string | null;
-  steps: string[];
+  steps: TestStep[];
+}
+
+interface TestStep {
+  action: string;
 }
 
 interface TestCaseResult {
@@ -27,6 +31,20 @@ function isStatus(value: unknown): value is TestCaseStatus {
   return value === "passed" || value === "failed" || value === "unsuitable";
 }
 
+function parseStep(value: unknown): TestStep | null {
+  if (typeof value === "string") {
+    return { action: value };
+  }
+  if (!isPlainObject(value) || typeof value.action !== "string") {
+    return null;
+  }
+  return { action: value.action };
+}
+
+function isTestStep(value: TestStep | null): value is TestStep {
+  return value !== null;
+}
+
 export function parseTestPlan(
   findings: Record<string, unknown>
 ): TestPlan | null {
@@ -41,9 +59,12 @@ export function parseTestPlan(
       !isPlainObject(value) ||
       typeof value.id !== "number" ||
       typeof value.title !== "string" ||
-      !Array.isArray(value.steps) ||
-      !isStringArray(value.steps)
+      !Array.isArray(value.steps)
     ) {
+      return null;
+    }
+    const steps = value.steps.map(parseStep);
+    if (!steps.every(isTestStep)) {
       return null;
     }
     generatedTestCases.push({
@@ -51,7 +72,7 @@ export function parseTestPlan(
       title: value.title,
       preconditions:
         typeof value.preconditions === "string" ? value.preconditions : null,
-      steps: value.steps,
+      steps,
     });
   }
 
@@ -130,7 +151,7 @@ export function TestPlanView({ testPlan }: { testPlan: TestPlan }) {
               <h4>Test steps</h4>
               <ol className="test-step-list">
                 {testCase.steps.map((step, index) => (
-                  <li key={index}>{step}</li>
+                  <li key={index}>{step.action}</li>
                 ))}
               </ol>
             </li>

--- a/services/hackbot-ui/components/TestPlanView.tsx
+++ b/services/hackbot-ui/components/TestPlanView.tsx
@@ -32,9 +32,6 @@ function isStatus(value: unknown): value is TestCaseStatus {
 }
 
 function parseStep(value: unknown): TestStep | null {
-  if (typeof value === "string") {
-    return { action: value };
-  }
   if (!isPlainObject(value) || typeof value.action !== "string") {
     return null;
   }

--- a/services/hackbot-ui/components/TestPlanView.tsx
+++ b/services/hackbot-ui/components/TestPlanView.tsx
@@ -11,6 +11,7 @@ interface GeneratedTestCase {
 
 interface TestStep {
   action: string;
+  expectation: string | null;
 }
 
 interface TestCaseResult {
@@ -32,10 +33,19 @@ function isStatus(value: unknown): value is TestCaseStatus {
 }
 
 function parseStep(value: unknown): TestStep | null {
+  // Accept legacy string only steps for old run summaries while normalizing new
+  // step objects to the action/expectation shape rendered by this view.
+  if (typeof value === "string") {
+    return { action: value, expectation: null };
+  }
   if (!isPlainObject(value) || typeof value.action !== "string") {
     return null;
   }
-  return { action: value.action };
+  return {
+    action: value.action,
+    expectation:
+      typeof value.expectation === "string" ? value.expectation : null,
+  };
 }
 
 function isTestStep(value: TestStep | null): value is TestStep {
@@ -148,7 +158,15 @@ export function TestPlanView({ testPlan }: { testPlan: TestPlan }) {
               <h4>Test steps</h4>
               <ol className="test-step-list">
                 {testCase.steps.map((step, index) => (
-                  <li key={index}>{step.action}</li>
+                  <li key={index}>
+                    <p>{step.action}</p>
+                    {step.expectation && (
+                      <div className="test-step-expectation">
+                        <strong>Expected</strong>
+                        <p>{step.expectation}</p>
+                      </div>
+                    )}
+                  </li>
                 ))}
               </ol>
             </li>


### PR DESCRIPTION
Fixes #6432 

This pull request introduces significant improvements to how test case steps and their expected results are handled and validated throughout the test plan generation and submission process. 