### PR TITLE
Use one broker URL for broker-backed agents

### DIFF
--- a/agents/autowebcompat-repro/compose.yml
+++ b/agents/autowebcompat-repro/compose.yml
@@ -19,7 +19,7 @@ services:
       - RUN_ID
       - BUG_DATA
       - BUG_ID
-      - BUGZILLA_MCP_URL=http://autowebcompat-repro-broker:8765/mcp
+      - BROKER_URL=http://autowebcompat-repro-broker:8765
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:?error}
       # No uploader locally: summary/logs/attachments are written under
       # /artifacts/<run_id>, bind-mounted to the host's ~/hackbot/artifacts.

--- a/agents/autowebcompat-repro/hackbot_agents/autowebcompat_repro/__main__.py
+++ b/agents/autowebcompat-repro/hackbot_agents/autowebcompat_repro/__main__.py
@@ -22,7 +22,7 @@ logger = logging.getLogger("autowebcompat-repro")
 
 
 class AgentInputs(BaseSettings):
-    bugzilla_mcp_url: str
+    broker_url: str
     bug_data: str | None = None
     bug_id: int | None = None
     model: str | None = None
@@ -37,6 +37,10 @@ class AgentInputs(BaseSettings):
     ) = None
 
     model_config = SettingsConfigDict(extra="ignore")
+
+    @property
+    def bugzilla_mcp_url(self) -> str:
+        return f"{self.broker_url.rstrip('/')}/mcp"
 
 
 class AutowebcompatResult(HackbotAgentResult):

--- a/agents/bug-fix/compose.yml
+++ b/agents/bug-fix/compose.yml
@@ -20,8 +20,7 @@ services:
     environment:
       - RUN_ID
       - BUG_ID=${BUG_ID:?error}
-      - BUGZILLA_MCP_URL=http://bug-fix-broker:8765/bugzilla/mcp
-      - PHABRICATOR_BROKER_URL=http://bug-fix-broker:8765
+      - BROKER_URL=http://bug-fix-broker:8765
       - REVISION_ID
       - COMMENT
       - SOURCE_REPO=/workspace/firefox

--- a/agents/bug-fix/hackbot_agents/bug_fix/__main__.py
+++ b/agents/bug-fix/hackbot_agents/bug_fix/__main__.py
@@ -7,15 +7,21 @@ from .agent import BugFixResult, run_bug_fix
 
 class AgentInputs(BaseSettings):
     bug_id: int
-    bugzilla_mcp_url: str
+    broker_url: str
     revision_id: int | None = None
     comment: str | None = None
-    phabricator_broker_url: str
     model: str | None = None
     max_turns: int | None = None
     effort: str | None = None
 
     model_config = SettingsConfigDict(extra="ignore")
+
+    def broker_endpoint(self, path: str) -> str:
+        return f"{self.broker_url.rstrip('/')}/{path.lstrip('/')}"
+
+    @property
+    def bugzilla_mcp_url(self) -> str:
+        return self.broker_endpoint("/bugzilla/mcp")
 
     @property
     def phabricator_mcp_url(self) -> str:
@@ -25,7 +31,7 @@ class AgentInputs(BaseSettings):
         endpoints are served by the same sidecar, so there is nothing for a
         caller to configure independently.
         """
-        return f"{self.phabricator_broker_url.rstrip('/')}/phabricator/mcp"
+        return self.broker_endpoint("/phabricator/mcp")
 
     @model_validator(mode="after")
     def _follow_up_with_comment(self) -> "AgentInputs":
@@ -43,7 +49,7 @@ async def main(ctx: HackbotContext) -> BugFixResult:
     inputs = AgentInputs()
 
     if inputs.revision_id:
-        await checkout_revision(ctx, inputs.revision_id, inputs.phabricator_broker_url)
+        await checkout_revision(ctx, inputs.revision_id, inputs.broker_url)
     else:
         await ctx.prepare_repo()
 

--- a/agents/bug-fix/tests/test_inputs.py
+++ b/agents/bug-fix/tests/test_inputs.py
@@ -7,46 +7,43 @@ from pydantic import ValidationError
 
 def test_broker_url_required(monkeypatch):
     # Every run mounts the broker's Phabricator tools, follow-up or not.
-    monkeypatch.delenv("PHABRICATOR_BROKER_URL", raising=False)
-    with pytest.raises(ValidationError, match="phabricator_broker_url"):
-        AgentInputs(bug_id=1, bugzilla_mcp_url="http://x")
+    monkeypatch.delenv("BROKER_URL", raising=False)
+    with pytest.raises(ValidationError, match="broker_url"):
+        AgentInputs(bug_id=1)
 
 
 def test_revision_requires_comment():
     with pytest.raises(ValidationError, match="comment"):
         AgentInputs(
             bug_id=1,
-            bugzilla_mcp_url="http://x",
+            broker_url="http://broker",
             revision_id=42,
-            phabricator_broker_url="http://broker",
         )
 
 
 def test_revision_with_broker_url_ok():
     inputs = AgentInputs(
         bug_id=1,
-        bugzilla_mcp_url="http://x",
+        broker_url="http://broker",
         revision_id=42,
         comment="@hackbot please fix",
-        phabricator_broker_url="http://broker",
     )
-    assert inputs.phabricator_broker_url == "http://broker"
+    assert inputs.broker_url == "http://broker"
 
 
 def test_no_revision_ok_without_comment():
     inputs = AgentInputs(
         bug_id=1,
-        bugzilla_mcp_url="http://x",
-        phabricator_broker_url="http://broker",
+        broker_url="http://broker",
     )
     assert inputs.revision_id is None
     assert inputs.comment is None
 
 
-def test_phabricator_mcp_url_derived_from_broker_url():
+def test_mcp_urls_derived_from_broker_url():
     inputs = AgentInputs(
         bug_id=1,
-        bugzilla_mcp_url="http://x",
-        phabricator_broker_url="http://broker:8765/",
+        broker_url="http://broker:8765/",
     )
+    assert inputs.bugzilla_mcp_url == "http://broker:8765/bugzilla/mcp"
     assert inputs.phabricator_mcp_url == "http://broker:8765/phabricator/mcp"

--- a/agents/build-repair/compose.yml
+++ b/agents/build-repair/compose.yml
@@ -25,7 +25,7 @@ services:
       - GIT_COMMIT=${GIT_COMMIT:-}
       - FAILURE_TASKS=${FAILURE_TASKS:-}
       - RUN_TRY_PUSH=${RUN_TRY_PUSH:-false}
-      - BUGZILLA_MCP_URL=http://build-repair-broker:8765/mcp
+      - BROKER_URL=http://build-repair-broker:8765
       - SOURCE_REPO=/workspace/firefox
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:?error}
       # Weave tracing locally: an API key enables it (deploys use W&B WIF instead).
@@ -56,7 +56,7 @@ services:
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:?error}
       - WANDB_API_KEY=${WANDB_API_KEY:-}
-      - BUGZILLA_MCP_URL=http://build-repair-broker:8765/mcp
+      - BROKER_URL=http://build-repair-broker:8765
       - FIREFOX_GIT_REPO=/firefox
     volumes:
       - ${FIREFOX_GIT_REPO:-/firefox}:/firefox

--- a/agents/build-repair/evals/eval.py
+++ b/agents/build-repair/evals/eval.py
@@ -61,11 +61,11 @@ def _collect_diff(worktree_path: Path, base_commit: str) -> str:
 def _bugzilla_server():
     """Bugzilla MCP server for the agent.
 
-    Prefer the broker (``BUGZILLA_MCP_URL``) so the eval container holds no
+    Prefer the broker (``BROKER_URL``) so the eval container holds no
     Bugzilla credentials -- same isolation as production. Falls back to an
     in-process server for local runs without a broker.
     """
-    mcp_url = os.environ.get("BUGZILLA_MCP_URL")
+    mcp_url = _broker_mcp_url()
     if mcp_url:
         return {"type": "http", "url": mcp_url}
     client = bugsy.Bugsy(
@@ -75,6 +75,14 @@ def _bugzilla_server():
         api_key=os.environ.get("BUGZILLA_API_KEY"),
     )
     return build_sdk_server("bugzilla", BugzillaContext(client=client), bugzilla.TOOLS)
+
+
+def _broker_mcp_url() -> str | None:
+    broker_url = os.environ.get("BROKER_URL")
+    if not broker_url:
+        # fall back to in-process Bugzilla server for local runs without a broker
+        return None
+    return f"{broker_url.rstrip('/')}/mcp"
 
 
 class BuildRepairModel(weave.Model):

--- a/agents/build-repair/hackbot_agents/build_repair/__main__.py
+++ b/agents/build-repair/hackbot_agents/build_repair/__main__.py
@@ -9,7 +9,7 @@ class AgentInputs(BaseSettings):
     failure_tasks: dict[str, str]
     git_commit: str | None = None
     bug_id: int | None = None
-    bugzilla_mcp_url: str
+    broker_url: str
     run_try_push: bool = False
     model: str | None = None
     max_turns: int | None = None
@@ -17,6 +17,10 @@ class AgentInputs(BaseSettings):
     # Compose passes unset per-run inputs as empty strings (``${BUG_ID:-}``);
     # treat those as absent so optional fields fall back to their defaults.
     model_config = SettingsConfigDict(extra="ignore", env_ignore_empty=True)
+
+    @property
+    def bugzilla_mcp_url(self) -> str:
+        return f"{self.broker_url.rstrip('/')}/mcp"
 
 
 async def main(ctx: HackbotContext) -> BuildRepairResult:

--- a/agents/frontend-triage/compose.yml
+++ b/agents/frontend-triage/compose.yml
@@ -18,7 +18,7 @@ services:
     environment:
       - RUN_ID
       - BUG_ID=${BUG_ID:?error}
-      - BUGZILLA_MCP_URL=http://frontend-triage-broker:8765/mcp
+      - BROKER_URL=http://frontend-triage-broker:8765
       - SOURCE_REPO=/workspace/firefox
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:?error}
       # No uploader locally: summary/logs/attachments are written under

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/__main__.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/__main__.py
@@ -18,12 +18,16 @@ DEFAULT_MODEL = "claude-opus-5"
 
 class AgentInputs(BaseSettings):
     bug_id: int
-    bugzilla_mcp_url: str
+    broker_url: str
     model: str = DEFAULT_MODEL
     max_turns: int | None = None
     effort: str | None = None
 
     model_config = SettingsConfigDict(extra="ignore")
+
+    @property
+    def bugzilla_mcp_url(self) -> str:
+        return f"{self.broker_url.rstrip('/')}/mcp"
 
 
 async def main(ctx: HackbotContext) -> FrontendTriageResult:


### PR DESCRIPTION

Replace endpoint-specific environment variables with a single BROKER_URL
for bug-fix, autowebcompat-repro, frontend-triage, and build-repair.
MCP endpoint URLs are now derived from the broker base URL 

Resolves #6437

