### PR TITLE
code_review: include the commit message in the review prompt

### DIFF
--- a/bugbug/tools/code_review/agent.py
+++ b/bugbug/tools/code_review/agent.py
@@ -212,10 +212,15 @@ class CodeReviewTool(GenerativeModelTool):
     ) -> str:
         created_before = patch.date_created if self.is_experiment_env else None
 
+        commit_message = patch.patch_title
+        if patch.patch_description:
+            commit_message += f"\n\n{patch.patch_description}"
+
         return FIRST_MESSAGE_TEMPLATE.format(
             current_date=current_date_for_prompt(),
             patch=format_patch_set(patch.patch_set),
             patch_summarization=patch_summary,
+            commit_message=commit_message,
             external_context=external_context,
             comment_examples=self._get_comment_examples(patch, created_before),
             approved_examples=self._get_generated_examples(patch, created_before),

--- a/bugbug/tools/code_review/prompts.py
+++ b/bugbug/tools/code_review/prompts.py
@@ -20,11 +20,13 @@ Follow this systematic approach to review the patch:
 - Understand what the patch is trying to accomplish
 - Use the patch summary for context, but focus primarily on what you can see in the actual diff
 - Identify the intent and structure of the changes
+- Compare the commit message against the diff: does it accurately describe what changed, and does it explain why?
 
 **Step 2: Identify Issues**
 - Look for bugs, logical errors, performance problems, security vulnerabilities, or violations of the coding standards
 - Focus ONLY on new or changed lines (lines that begin with `+`)
 - Never comment on unmodified code
+- Flag a commit message that is unclear, misleading, or missing the rationale for a non-obvious change; anchor the comment to a representative changed line, like the patch-scope check does
 - Prioritize issues in this order: Security vulnerabilities > Functional bugs > Performance issues > Style/readability concerns
 
 **Step 3: Verify and Assess Confidence**
@@ -96,6 +98,12 @@ Here is a summary of the patch:
 <patch_summary>
 {patch_summarization}
 </patch_summary>
+
+Here is the commit message the author wrote for this patch:
+
+<commit_message>
+{commit_message}
+</commit_message>
 
 <external-resources>
 {external_context}


### PR DESCRIPTION
The agent only ever saw an LLM-generated patch summary, never the author's actual title/description, so it couldn't flag unclear or misleading commit messages, or cross-check the description against the diff. Add the verbatim commit message as its own prompt section, and instruct the agent to compare it against the diff and flag commit-message issues alongside code issues.

This quite important for us, since we spend quite some time doing code archeology. Besides, an incorrect commit message can mislead or confused the (human) reviewer, and we'd like to catch this early.