### PR TITLE
frontend-triage: invite feedback via Bugzilla reactions and tags

### DIFF
--- a/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
@@ -56,6 +56,22 @@ HERE = Path(__file__).resolve().parent
 # machine-consumable for downstream handoff (summary.json -> execution agent).
 _JSON_BLOCK = re.compile(r"```json\s*(\{.*?\})\s*```", re.DOTALL)
 
+_FEEDBACK_TAGS = (
+    "If you want to categorize your feedback you can add one of the following "
+    "tags: ai-triage-wrong-file, ai-triage-wrong-cause, ai-triage-hallucination, "
+    "ai-triage-out-of-scope."
+)
+
+
+def feedback_tags_hook(action: dict) -> None:
+    """Offer the triage-specific feedback tags below the runtime's footer."""
+    params = action.get("params")
+    if not isinstance(params, dict):
+        return
+    text = params.get("text")
+    if isinstance(text, str):
+        params["text"] = f"{text.rstrip()}\n{_FEEDBACK_TAGS}"
+
 
 class FrontendTriageResult(HackbotAgentResult):
     bug_id: int
@@ -233,6 +249,7 @@ async def run_frontend_triage(
         "bugzilla.add_comment",
         permalink_hook(permalink_prefix(searchfox_rev), source_repo.resolve()),
     )
+    actions_recorder.add_hook("bugzilla.add_comment", feedback_tags_hook)
 
     system_prompt = load_system_prompt(rules_dir, instructions)
 

--- a/libs/hackbot-runtime/hackbot_runtime/actions/bugzilla.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/bugzilla.py
@@ -21,8 +21,8 @@ from pydantic import Field
 from hackbot_runtime.actions.recorder import ActionsRecorder
 
 _COMMENT_FOOTER = (
-    "*This is an automated analysis result. If this result is incorrect "
-    "please add a needinfo and feel free to correct the error.* "
+    "If you'd like to provide feedback on this comment, please use the 👍 or 👎 "
+    "reaction."
 )
 _ATTACHMENT_COMMENT_FOOTER = (
     "*This is the analysis tool's suggested fix. Feel welcome to adopt "

--- a/libs/hackbot-runtime/tests/test_bugzilla_actions.py
+++ b/libs/hackbot-runtime/tests/test_bugzilla_actions.py
@@ -10,7 +10,7 @@ async def test_add_comment_appends_footer():
     await bugzilla.add_comment(rec, bug_id=1, text="Looks invalid.", reasoning="r")
     text = rec.actions[0]["params"]["text"]
     assert text.startswith("Looks invalid.")
-    assert "automated analysis result" in text
+    assert text.endswith(bugzilla._COMMENT_FOOTER)
     assert rec.actions[0]["params"]["is_private"] is False
 
 


### PR DESCRIPTION
We have no way to get feedback from engineers on the Hackbot comments posted to Bugzilla.. Bugzilla already has
comment reactions and tags that can be used to gather feedback, so this just adds a line pointing readers at them.

Fixes #6489 

Triage comments now end:

    ---

    If you'd like to provide feedback on this comment, please use the 👍 or 👎
    reaction. If you want to categorize your feedback you can add one of the
    following tags: ai-triage-wrong-file, ai-triage-wrong-cause,
    ai-triage-hallucination, ai-triage-out-of-scope.
    