### PR TITLE
Slack notifications for test repair agent

### DIFF
--- a/agents/test-repair/README.md
+++ b/agents/test-repair/README.md
@@ -63,6 +63,17 @@ Stage 2:
 
 - A patch in Hackbot format
 
+## Slack notification
+
+Every run records a `slack.post_message` action carrying its verdict -- the
+recommendation, the classification and confidence, the failing job (linked to the
+push in Treeherder), the culprit or the candidates that could not be ruled out,
+and whether a patch is attached.
+
+The message is posted by the apply step, not from the run, so it is visible in the
+hackbot UI before it lands and is delivered at most once. `test-repair` opts into
+auto-apply, so a succeeded run posts without waiting for a human.
+
 ## Test the agent
 
 ```sh

--- a/agents/test-repair/hackbot_agents/test_repair/__main__.py
+++ b/agents/test-repair/hackbot_agents/test_repair/__main__.py
@@ -3,11 +3,13 @@ import tempfile
 from pathlib import Path
 
 from hackbot_runtime import HackbotContext, run_async
+from hackbot_runtime.actions.slack import ACTION_TYPE, record_message, run_link_hook
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from .agent import TestRepairResult
-from .config import SKIP_FIREFOX_BUILD
+from .config import SKIP_FIREFOX_BUILD, SLACK_CHANNEL
 from .logs import download_failure_logs
+from .notify import build_message
 from .resolve import Investigation, resolve_investigation
 
 logger = logging.getLogger(__name__)
@@ -60,7 +62,7 @@ async def main(ctx: HackbotContext) -> TestRepairResult:
     logger.info("Pinning checkout to %s with depth %s", ref, depth)
     source_repo = await ctx.prepare_repo(ref=ref, depth=depth)
 
-    return await run_test_repair(
+    result = await run_test_repair(
         bugzilla_mcp_server=bugzilla_mcp_server,
         source_repo=source_repo,
         fx_ctx=ctx.firefox,
@@ -74,6 +76,11 @@ async def main(ctx: HackbotContext) -> TestRepairResult:
         verbose=True,
         publish_file=ctx.publish_file,
     )
+
+    # Notifications are active for all runs
+    ctx.actions.add_hook(ACTION_TYPE, run_link_hook(ctx.run_id))
+    record_message(ctx.actions, SLACK_CHANNEL, build_message(result, investigation))
+    return result
 
 
 if __name__ == "__main__":

--- a/agents/test-repair/hackbot_agents/test_repair/__main__.py
+++ b/agents/test-repair/hackbot_agents/test_repair/__main__.py
@@ -3,13 +3,13 @@ import tempfile
 from pathlib import Path
 
 from hackbot_runtime import HackbotContext, run_async
-from hackbot_runtime.actions.slack import ACTION_TYPE, record_message, run_link_hook
+from hackbot_runtime.actions.slack import record_message
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from .agent import TestRepairResult
 from .config import SKIP_FIREFOX_BUILD, SLACK_CHANNEL
 from .logs import download_failure_logs
-from .notify import build_message
+from .notify import build_message, resolve_culprit_author
 from .resolve import Investigation, resolve_investigation
 
 logger = logging.getLogger(__name__)
@@ -78,8 +78,14 @@ async def main(ctx: HackbotContext) -> TestRepairResult:
     )
 
     # Notifications are active for all runs
-    ctx.actions.add_hook(ACTION_TYPE, run_link_hook(ctx.run_id))
-    record_message(ctx.actions, SLACK_CHANNEL, build_message(result, investigation))
+    message = build_message(
+        result,
+        investigation,
+        task_id=task_id,
+        run_id=ctx.run_id,
+        culprit_author=resolve_culprit_author(source_repo, result.culprit_commit),
+    )
+    record_message(ctx.actions, SLACK_CHANNEL, message)
     return result
 
 

--- a/agents/test-repair/hackbot_agents/test_repair/config.py
+++ b/agents/test-repair/hackbot_agents/test_repair/config.py
@@ -12,6 +12,9 @@ FIX_MODEL = "claude-opus-5"
 # on, so the fix stage proposes an unverified patch unless a run asks otherwise.
 SKIP_FIREFOX_BUILD = True
 
+# Where the verdict is reported.
+SLACK_CHANNEL = "#sheriff-notifications"
+
 # Bugzilla MCP tool names as exposed to the agent (mcp__<server>__<tool>).
 BUGZILLA_READ_TOOLS = [
     "mcp__bugzilla__search_bugs",

--- a/agents/test-repair/hackbot_agents/test_repair/notify.py
+++ b/agents/test-repair/hackbot_agents/test_repair/notify.py
@@ -9,30 +9,38 @@ Recorded as a ``slack.post_message`` action rather than posted from the run: it 
 then visible in the hackbot UI before it lands, and the apply step delivers it at
 most once (see ``hackbot_runtime.actions.slack``).
 
-The wording is code rather than a model turn -- every run reaches a verdict worth
-reporting, and sheriffs read these at a glance, so the fields and their order are
-fixed. The agent's own prose is included as a single line so it cannot restructure
-the message.
+Five lines of context, then the verdict in full. Every identifier a sheriff would
+otherwise have to look up -- revisions, task, bug, run -- is a link, the way the
+pulse listener's email does it
+(``services/hackbot-pulse-listener/app/notify.py``); unlike the email this stays
+short enough to read in a channel, since the run holds the detail. The verdict is
+what a sheriff acts on, so it is never truncated.
 """
 
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
+
+from hackbot_runtime.actions.slack import HACKBOT_UI_URL
+
 from .agent import TestRepairResult
 from .resolve import Investigation
 
-TREEHERDER_PUSH = (
-    "https://treeherder.mozilla.org/jobs?repo={project}&revision={revision}"
+GIT_COMMIT_URL = "https://github.com/mozilla-firefox/firefox/commit/{sha}"
+HG_REV_URL = "https://hg.mozilla.org/mozilla-unified/rev/{rev}"
+TASK_URL = "https://firefox-ci-tc.services.mozilla.com/tasks/{task_id}"
+TREEHERDER_JOB_URL = (
+    "https://treeherder.mozilla.org/#/jobs"
+    "?repo={project}&revision={revision}&selectedTaskRun={task_id}"
 )
 BUG_URL = "https://bugzilla.mozilla.org/show_bug.cgi?id={bug_id}"
-
-MAX_GROUPS = 3
-MAX_SUMMARY_LENGTH = 300
+RUN_URL = HACKBOT_UI_URL.rstrip("/") + "/runs/{run_id}"
 
 _RECOMMENDATIONS = {
-    "backout": "back out the culprit",
-    "land_fix": "land a fix",
-    "do_not_backout": "do not back out",
-    "rerun": "retrigger the job",
+    "backout": "BACK OUT the culprit",
+    "do_not_backout": "DO NOT back out (intermittent)",
+    "rerun": "RETRIGGER the job",
 }
 
 
@@ -40,71 +48,102 @@ def _link(url: str, label: str) -> str:
     return f"<{url}|{label}>"
 
 
+def _commit_link(sha: str) -> str:
+    return _link(GIT_COMMIT_URL.format(sha=sha), f"github {sha[:12]}")
+
+
+def _hg_link(rev: str) -> str:
+    return _link(HG_REV_URL.format(rev=rev), f"hg {rev[:12]}")
+
+
 def _bug_link(bug_id: int) -> str:
     return _link(BUG_URL.format(bug_id=bug_id), f"bug {bug_id}")
 
 
-def _short(sha: str) -> str:
-    return sha[:12]
-
-
-def _one_line(text: str) -> str:
-    collapsed = " ".join(text.split())
-    if len(collapsed) > MAX_SUMMARY_LENGTH:
-        collapsed = collapsed[: MAX_SUMMARY_LENGTH - 1].rstrip() + "…"
-    return collapsed
-
-
-def _headline(result: TestRepairResult) -> str:
-    advice = _RECOMMENDATIONS.get(result.recommendation, result.recommendation)
-    return (
-        f"*test-repair: {advice}* ({result.classification}, "
-        f"confidence {result.confidence:.2f})"
-    )
-
-
-def _failure_line(investigation: Investigation) -> str:
-    job = investigation.label or f"{investigation.harness} on {investigation.platform}"
-    push = TREEHERDER_PUSH.format(
-        project=investigation.project, revision=investigation.hg_revision
-    )
-    return f"`{job}` at {_link(push, _short(investigation.hg_revision))}"
-
-
-def _failing_line(investigation: Investigation) -> str | None:
-    groups = investigation.failing_groups[:MAX_GROUPS]
-    if not groups:
+def resolve_culprit_author(source_repo: Path, sha: str | None) -> str | None:
+    """The culprit's author email, so the notification names who to ask."""
+    if not sha:
         return None
-    shown = ", ".join(f"{g.group} ({len(g.tests)} failed)" for g in groups)
-    extra = len(investigation.failing_groups) - len(groups)
-    return "Failing: " + shown + (f", +{extra} more" if extra > 0 else "")
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(source_repo), "show", "-s", "--format=%ae", sha],
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
+    return proc.stdout.strip() or None
 
 
-def _blame_line(result: TestRepairResult) -> str:
+def _failing_line(investigation: Investigation) -> str:
+    groups = (
+        ", ".join(f"`{group.group}`" for group in investigation.failing_groups)
+        or "tests not resolved"
+    )
+    job = investigation.label or f"{investigation.harness} on {investigation.platform}"
+    return f"Failing: {groups} in `{job}`"
+
+
+def _jobs_line(investigation: Investigation, task_id: str) -> str:
+    treeherder = _link(
+        TREEHERDER_JOB_URL.format(
+            project=investigation.project,
+            revision=investigation.hg_revision,
+            task_id=task_id,
+        ),
+        "Treeherder",
+    )
+    task = _link(TASK_URL.format(task_id=task_id), f"Taskcluster {task_id}")
+    return f"Jobs: {treeherder}, {task}"
+
+
+def _push_line(investigation: Investigation) -> str:
+    line = (
+        f"Push: {investigation.project} {_hg_link(investigation.hg_revision)}"
+        f" / {_commit_link(investigation.failure_commit)}"
+    )
+    if investigation.last_green_revision:
+        line += f", last green {_hg_link(investigation.last_green_revision)}"
+    return line
+
+
+def _culprit_line(result: TestRepairResult, culprit_author: str | None) -> str:
     if result.culprit_commit:
-        bug = f" ({_bug_link(result.culprit_bug)})" if result.culprit_bug else ""
-        return f"Culprit: `{_short(result.culprit_commit)}`{bug}"
-    if result.candidate_commits:
-        candidates = ", ".join(f"`{_short(sha)}`" for sha in result.candidate_commits)
-        return f"No single culprit; candidates: {candidates}"
-    return "No culprit identified."
+        author = f" by {culprit_author}" if culprit_author else ""
+        line = f"Culprit: {_commit_link(result.culprit_commit)}{author}"
+    elif result.candidate_commits:
+        candidates = ", ".join(_commit_link(sha) for sha in result.candidate_commits)
+        line = f"Culprit: not narrowed down, candidates {candidates}"
+    else:
+        line = "Culprit: none identified"
 
-
-def build_message(result: TestRepairResult, investigation: Investigation) -> str:
-    """Render the sheriff notification for a finished run."""
-    lines = [_headline(result), _failure_line(investigation)]
-
-    failing = _failing_line(investigation)
-    if failing:
-        lines.append(failing)
-
-    lines.append(_blame_line(result))
-
-    if result.classification == "intermittent" and result.intermittent_bug:
-        lines.append(f"Known intermittent: {_bug_link(result.intermittent_bug)}")
+    bug = result.culprit_bug or result.intermittent_bug
+    if bug:
+        line += f" ({_bug_link(bug)})"
     if result.proposed_patch:
-        lines.append("A candidate fix patch is attached to the run.")
-    if result.summary.strip():
-        lines.append(_one_line(result.summary))
+        line += ", patch attached"
+    return line
 
+
+def build_message(
+    result: TestRepairResult,
+    investigation: Investigation,
+    *,
+    task_id: str,
+    run_id: str,
+    culprit_author: str | None = None,
+) -> str:
+    """Render the notification for a finished run."""
+    recommendation = _RECOMMENDATIONS.get(result.recommendation, result.recommendation)
+    lines = [
+        f"*test-repair: {recommendation}*"
+        f" ({result.classification}, confidence {result.confidence})",
+        _failing_line(investigation),
+        _jobs_line(investigation, task_id),
+        _push_line(investigation),
+        _culprit_line(result, culprit_author),
+        _link(RUN_URL.format(run_id=run_id), "Hackbot run details"),
+    ]
+    if result.summary.strip():
+        lines += ["", result.summary.strip()]
     return "\n".join(lines)

--- a/agents/test-repair/hackbot_agents/test_repair/notify.py
+++ b/agents/test-repair/hackbot_agents/test_repair/notify.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""The Slack message a finished run sends to the channel.
+
+Recorded as a ``slack.post_message`` action rather than posted from the run: it is
+then visible in the hackbot UI before it lands, and the apply step delivers it at
+most once (see ``hackbot_runtime.actions.slack``).
+
+The wording is code rather than a model turn -- every run reaches a verdict worth
+reporting, and sheriffs read these at a glance, so the fields and their order are
+fixed. The agent's own prose is included as a single line so it cannot restructure
+the message.
+"""
+
+from __future__ import annotations
+
+from .agent import TestRepairResult
+from .resolve import Investigation
+
+TREEHERDER_PUSH = (
+    "https://treeherder.mozilla.org/jobs?repo={project}&revision={revision}"
+)
+BUG_URL = "https://bugzilla.mozilla.org/show_bug.cgi?id={bug_id}"
+
+MAX_GROUPS = 3
+MAX_SUMMARY_LENGTH = 300
+
+_RECOMMENDATIONS = {
+    "backout": "back out the culprit",
+    "land_fix": "land a fix",
+    "do_not_backout": "do not back out",
+    "rerun": "retrigger the job",
+}
+
+
+def _link(url: str, label: str) -> str:
+    return f"<{url}|{label}>"
+
+
+def _bug_link(bug_id: int) -> str:
+    return _link(BUG_URL.format(bug_id=bug_id), f"bug {bug_id}")
+
+
+def _short(sha: str) -> str:
+    return sha[:12]
+
+
+def _one_line(text: str) -> str:
+    collapsed = " ".join(text.split())
+    if len(collapsed) > MAX_SUMMARY_LENGTH:
+        collapsed = collapsed[: MAX_SUMMARY_LENGTH - 1].rstrip() + "…"
+    return collapsed
+
+
+def _headline(result: TestRepairResult) -> str:
+    advice = _RECOMMENDATIONS.get(result.recommendation, result.recommendation)
+    return (
+        f"*test-repair: {advice}* ({result.classification}, "
+        f"confidence {result.confidence:.2f})"
+    )
+
+
+def _failure_line(investigation: Investigation) -> str:
+    job = investigation.label or f"{investigation.harness} on {investigation.platform}"
+    push = TREEHERDER_PUSH.format(
+        project=investigation.project, revision=investigation.hg_revision
+    )
+    return f"`{job}` at {_link(push, _short(investigation.hg_revision))}"
+
+
+def _failing_line(investigation: Investigation) -> str | None:
+    groups = investigation.failing_groups[:MAX_GROUPS]
+    if not groups:
+        return None
+    shown = ", ".join(f"{g.group} ({len(g.tests)} failed)" for g in groups)
+    extra = len(investigation.failing_groups) - len(groups)
+    return "Failing: " + shown + (f", +{extra} more" if extra > 0 else "")
+
+
+def _blame_line(result: TestRepairResult) -> str:
+    if result.culprit_commit:
+        bug = f" ({_bug_link(result.culprit_bug)})" if result.culprit_bug else ""
+        return f"Culprit: `{_short(result.culprit_commit)}`{bug}"
+    if result.candidate_commits:
+        candidates = ", ".join(f"`{_short(sha)}`" for sha in result.candidate_commits)
+        return f"No single culprit; candidates: {candidates}"
+    return "No culprit identified."
+
+
+def build_message(result: TestRepairResult, investigation: Investigation) -> str:
+    """Render the sheriff notification for a finished run."""
+    lines = [_headline(result), _failure_line(investigation)]
+
+    failing = _failing_line(investigation)
+    if failing:
+        lines.append(failing)
+
+    lines.append(_blame_line(result))
+
+    if result.classification == "intermittent" and result.intermittent_bug:
+        lines.append(f"Known intermittent: {_bug_link(result.intermittent_bug)}")
+    if result.proposed_patch:
+        lines.append("A candidate fix patch is attached to the run.")
+    if result.summary.strip():
+        lines.append(_one_line(result.summary))
+
+    return "\n".join(lines)

--- a/agents/test-repair/hackbot_agents/test_repair/prompts.py
+++ b/agents/test-repair/hackbot_agents/test_repair/prompts.py
@@ -46,8 +46,13 @@ Steps:
    whole stack has to be backed out -- name it in summary.md, oldest sha first.
    "culprit_commit" stays the single commit that introduced the regression.
 5. Write to {scratch_out}:
-   - summary.md: a 2-4 sentence verdict.
-   - analysis.md: the reasoning, with evidence from the logs and diffs.
+   - summary.md: a 2-4 sentence verdict, in plain prose -- no headings, lists or
+     code blocks. It is posted verbatim to Slack, so it has to read at a glance:
+     what failed, what caused it, what to do. Everything else belongs in
+     analysis.md.
+   - analysis.md: the reasoning, with evidence from the logs and diffs. This is
+     where quoted log lines, diffs and alternatives you ruled out go, at whatever
+     length the case needs.
    - verdict.json: "classification" ("regression" or "intermittent"),
      "culprit_commit" (full sha from the range, or null), "candidate_commits" (up
      to {max_candidates} full shas, most to least likely, whenever no single
@@ -102,7 +107,12 @@ The source tree is at {source_repo} (your working directory). Search it with
 
 1. Make the smallest change that addresses the root cause.
 {verify_step}
-3. Update {scratch_out}/verdict.json in place, preserving its existing keys: set
+3. Describe the patch in {scratch_out}/analysis.md: what it changes and why that
+   addresses the root cause.
+4. Add at most one sentence to {scratch_out}/summary.md saying a patch is
+   proposed. Do not rewrite or restructure it -- it stays the short verdict
+   posted to Slack, and the patch write-up goes in analysis.md.
+5. Update {scratch_out}/verdict.json in place, preserving its existing keys: set
    "proposed_patch" to true if you made a fix, and leave "recommendation" as
    "backout".
 """
@@ -117,12 +127,13 @@ VERIFY_REMOTE = """\
    mach -- see the tree's AGENTS.md / CLAUDE.md for how it runs {harness} tests.
    This container is Linux and the failure is on {platform}: a failure here is
    evidence the patch is wrong, but a pass proves nothing about {platform}. Report
-   a pass as "not verified" and say so in summary.md."""
+   a pass as "not verified" and say so in the summary sentence below."""
 
 VERIFY_SKIPPED = """\
 2. Do not build, and do not try to run the test(s); no build tool is available.
    Check by reading instead that the patch compiles and addresses the root cause.
-   State in summary.md that it is unverified, neither built nor run."""
+   State in the summary sentence below that it is unverified, neither built nor
+   run."""
 
 ENVIRONMENT_NOTE = """
    Environment: a Debian container with a virtual display and the build toolchain

--- a/agents/test-repair/tests/test_notify.py
+++ b/agents/test-repair/tests/test_notify.py
@@ -1,23 +1,33 @@
 from hackbot_agents.test_repair.agent import TestRepairResult
-from hackbot_agents.test_repair.notify import MAX_SUMMARY_LENGTH, build_message
+from hackbot_agents.test_repair.notify import build_message
 from hackbot_agents.test_repair.resolve import (
     CommitRange,
     FailingGroup,
     Investigation,
 )
 
+HG_REVISION = "341517e50536aabbccddeeff00112233445566"
+GIT_REVISION = "7b15e34863cf6b30b613ffadf9d6431fe5a55585"
+LAST_GREEN = "c338a2c1c8d3695b7dec835125af624282555b7e"
+TASK_ID = "JfAGrrtoQPS3fXrwZmq1Pg"
 
-def _investigation(groups=None, label="test-linux1804-64/opt-mochitest-plain-1"):
+GIT_URL = f"https://github.com/mozilla-firefox/firefox/commit/{GIT_REVISION}"
+HG_URL = f"https://hg.mozilla.org/mozilla-unified/rev/{HG_REVISION}"
+
+
+def _investigation(
+    groups=None, last_green=LAST_GREEN, label="test-linux1804-64/opt-xpcshell-1"
+):
     return Investigation(
         project="autoland",
-        hg_revision="0123456789abcdef0123",
-        harness="mochitest",
+        hg_revision=HG_REVISION,
+        harness="xpcshell",
         platform="linux1804-64/opt",
         failing_groups=groups
         if groups is not None
-        else [FailingGroup("dom/base/test/mochitest.ini", ["a.js", "b.js"])],
-        last_green_revision="green",
-        commit_range=CommitRange(head="head", base="base", span=2, complete=True),
+        else [FailingGroup("toolkit/modules/tests/xpcshell/xpcshell.toml", ["a.js"])],
+        last_green_revision=last_green,
+        commit_range=CommitRange(head=GIT_REVISION, base="base", span=4, complete=True),
         label=label,
     )
 
@@ -26,32 +36,54 @@ def _result(**overrides):
     fields = {
         "classification": "regression",
         "recommendation": "backout",
-        "culprit_commit": "abcdef0123456789abcdef",
-        "culprit_bug": 1900000,
-        "confidence": 0.825,
-        "summary": "The culprit changed the assertion the test relies on.",
+        "culprit_commit": GIT_REVISION,
+        "culprit_bug": 2061487,
+        "confidence": 0.7,
+        "summary": "Verdict\n\ntest_Region.js fails 20/20 times in chaos mode.",
         "num_turns": 12,
     }
     return TestRepairResult(**{**fields, **overrides})
 
 
-def test_reports_the_verdict_the_sheriff_acts_on():
-    message = build_message(_result(), _investigation())
-    assert message.splitlines() == [
-        "*test-repair: back out the culprit* (regression, confidence 0.82)",
-        "`test-linux1804-64/opt-mochitest-plain-1` at "
-        "<https://treeherder.mozilla.org/jobs?repo=autoland&revision=0123456789abcdef0123"
-        "|0123456789ab>",
-        "Failing: dom/base/test/mochitest.ini (2 failed)",
-        "Culprit: `abcdef012345` "
-        "(<https://bugzilla.mozilla.org/show_bug.cgi?id=1900000|bug 1900000>)",
-        "The culprit changed the assertion the test relies on.",
+def _message(result=None, investigation=None, **kwargs):
+    return build_message(
+        result or _result(),
+        investigation or _investigation(),
+        task_id=TASK_ID,
+        run_id="1218e630-78c8",
+        **kwargs,
+    )
+
+
+def test_reports_the_verdict_and_its_context_in_five_lines():
+    assert _message(culprit_author="standard8@mozilla.com").splitlines() == [
+        "*test-repair: BACK OUT the culprit* (regression, confidence 0.7)",
+        "Failing: `toolkit/modules/tests/xpcshell/xpcshell.toml` in "
+        "`test-linux1804-64/opt-xpcshell-1`",
+        "Jobs: <https://treeherder.mozilla.org/#/jobs"
+        f"?repo=autoland&revision={HG_REVISION}&selectedTaskRun={TASK_ID}|Treeherder>, "
+        f"<https://firefox-ci-tc.services.mozilla.com/tasks/{TASK_ID}"
+        f"|Taskcluster {TASK_ID}>",
+        f"Push: autoland <{HG_URL}|hg 341517e50536> / <{GIT_URL}|github 7b15e34863cf>, "
+        f"last green <https://hg.mozilla.org/mozilla-unified/rev/{LAST_GREEN}"
+        "|hg c338a2c1c8d3>",
+        f"Culprit: <{GIT_URL}|github 7b15e34863cf> by standard8@mozilla.com "
+        "(<https://bugzilla.mozilla.org/show_bug.cgi?id=2061487|bug 2061487>)",
+        "<https://hackbot.moz.tools/runs/1218e630-78c8|hackbot run details>",
+        "",
+        "Verdict",
+        "",
+        "test_Region.js fails 20/20 times in chaos mode.",
     ]
 
 
-def test_falls_back_to_the_harness_when_the_label_is_unknown():
-    message = build_message(_result(), _investigation(label=""))
-    assert "`mochitest on linux1804-64/opt`" in message
+def test_reports_the_verdict_in_full():
+    verdict = "A long verdict. " * 60
+    assert verdict.strip() in _message(_result(summary=verdict))
+
+
+def test_omits_the_author_when_it_could_not_be_resolved():
+    assert " by " not in _message()
 
 
 def test_lists_candidates_when_no_single_commit_was_blamed():
@@ -61,19 +93,18 @@ def test_lists_candidates_when_no_single_commit_was_blamed():
         culprit_bug=None,
         candidate_commits=["1111111111111111", "2222222222222222"],
     )
-    message = build_message(result, _investigation())
-    assert message.startswith("*test-repair: retrigger the job*")
-    assert "No single culprit; candidates: `111111111111`, `222222222222`" in message
+    message = _message(result)
+    assert message.startswith("*test-repair: RETRIGGER the job* (regression,")
+    assert "Culprit: not narrowed down, candidates <" in message
+    assert "|github 111111111111>, <" in message
 
 
-def test_says_so_when_nothing_was_blamed_at_all():
-    result = _result(
-        recommendation="do_not_backout", culprit_commit=None, culprit_bug=None
-    )
-    assert "No culprit identified." in build_message(result, _investigation())
+def test_says_so_when_nothing_was_blamed():
+    result = _result(culprit_commit=None, culprit_bug=None)
+    assert "Culprit: none identified" in _message(result)
 
 
-def test_links_the_intermittent_bug():
+def test_names_a_known_intermittent():
     result = _result(
         classification="intermittent",
         recommendation="do_not_backout",
@@ -81,33 +112,36 @@ def test_links_the_intermittent_bug():
         culprit_bug=None,
         intermittent_bug=1234,
     )
-    message = build_message(result, _investigation())
-    assert "Known intermittent: " in message
-    assert "id=1234|bug 1234>" in message
-
-
-def test_mentions_a_proposed_patch():
-    message = build_message(_result(proposed_patch=True), _investigation())
-    assert "A candidate fix patch is attached to the run." in message
-
-
-def test_omits_the_failing_line_when_groups_were_not_resolved():
-    message = build_message(_result(), _investigation(groups=[]))
-    assert "Failing:" not in message
-
-
-def test_caps_the_extra_groups_it_names():
-    groups = [FailingGroup(f"g{i}.ini", ["a.js"]) for i in range(5)]
-    message = build_message(_result(), _investigation(groups=groups))
+    message = _message(result)
+    assert message.startswith(
+        "*test-repair: DO NOT back out (intermittent)* (intermittent,"
+    )
     assert (
-        "Failing: g0.ini (1 failed), g1.ini (1 failed), g2.ini (1 failed), +2 more"
-        in message
+        "Culprit: none identified "
+        "(<https://bugzilla.mozilla.org/show_bug.cgi?id=1234|bug 1234>)" in message
     )
 
 
-def test_agent_prose_cannot_restructure_the_message():
-    summary = "line one\nCulprit: `deadbeef`\n" + "x" * 500
-    message = build_message(_result(summary=summary), _investigation())
-    last = message.splitlines()[-1]
-    assert last.startswith("line one Culprit: `deadbeef` xxx")
-    assert len(last) == MAX_SUMMARY_LENGTH
+def test_mentions_a_proposed_patch():
+    assert (
+        _message(_result(proposed_patch=True))
+        .splitlines()[4]
+        .endswith(", patch attached")
+    )
+
+
+def test_lists_every_failing_group():
+    groups = [FailingGroup(f"g{i}.ini", ["a.js"]) for i in range(4)]
+    message = _message(investigation=_investigation(groups=groups))
+    assert "Failing: `g0.ini`, `g1.ini`, `g2.ini`, `g3.ini` in " in message
+
+
+def test_falls_back_when_groups_and_label_are_unknown():
+    message = _message(investigation=_investigation(groups=[], label=""))
+    assert "Failing: tests not resolved in `xpcshell on linux1804-64/opt`" in message
+
+
+def test_omits_the_last_green_revision_when_unknown():
+    message = _message(investigation=_investigation(last_green=None))
+    assert "last green" not in message
+    assert message.splitlines()[3].endswith("|github 7b15e34863cf>")

--- a/agents/test-repair/tests/test_notify.py
+++ b/agents/test-repair/tests/test_notify.py
@@ -69,7 +69,7 @@ def test_reports_the_verdict_and_its_context_in_five_lines():
         "|hg c338a2c1c8d3>",
         f"Culprit: <{GIT_URL}|github 7b15e34863cf> by standard8@mozilla.com "
         "(<https://bugzilla.mozilla.org/show_bug.cgi?id=2061487|bug 2061487>)",
-        "<https://hackbot.moz.tools/runs/1218e630-78c8|hackbot run details>",
+        "<https://hackbot.moz.tools/runs/1218e630-78c8|Hackbot run details>",
         "",
         "Verdict",
         "",

--- a/agents/test-repair/tests/test_notify.py
+++ b/agents/test-repair/tests/test_notify.py
@@ -1,0 +1,113 @@
+from hackbot_agents.test_repair.agent import TestRepairResult
+from hackbot_agents.test_repair.notify import MAX_SUMMARY_LENGTH, build_message
+from hackbot_agents.test_repair.resolve import (
+    CommitRange,
+    FailingGroup,
+    Investigation,
+)
+
+
+def _investigation(groups=None, label="test-linux1804-64/opt-mochitest-plain-1"):
+    return Investigation(
+        project="autoland",
+        hg_revision="0123456789abcdef0123",
+        harness="mochitest",
+        platform="linux1804-64/opt",
+        failing_groups=groups
+        if groups is not None
+        else [FailingGroup("dom/base/test/mochitest.ini", ["a.js", "b.js"])],
+        last_green_revision="green",
+        commit_range=CommitRange(head="head", base="base", span=2, complete=True),
+        label=label,
+    )
+
+
+def _result(**overrides):
+    fields = {
+        "classification": "regression",
+        "recommendation": "backout",
+        "culprit_commit": "abcdef0123456789abcdef",
+        "culprit_bug": 1900000,
+        "confidence": 0.825,
+        "summary": "The culprit changed the assertion the test relies on.",
+        "num_turns": 12,
+    }
+    return TestRepairResult(**{**fields, **overrides})
+
+
+def test_reports_the_verdict_the_sheriff_acts_on():
+    message = build_message(_result(), _investigation())
+    assert message.splitlines() == [
+        "*test-repair: back out the culprit* (regression, confidence 0.82)",
+        "`test-linux1804-64/opt-mochitest-plain-1` at "
+        "<https://treeherder.mozilla.org/jobs?repo=autoland&revision=0123456789abcdef0123"
+        "|0123456789ab>",
+        "Failing: dom/base/test/mochitest.ini (2 failed)",
+        "Culprit: `abcdef012345` "
+        "(<https://bugzilla.mozilla.org/show_bug.cgi?id=1900000|bug 1900000>)",
+        "The culprit changed the assertion the test relies on.",
+    ]
+
+
+def test_falls_back_to_the_harness_when_the_label_is_unknown():
+    message = build_message(_result(), _investigation(label=""))
+    assert "`mochitest on linux1804-64/opt`" in message
+
+
+def test_lists_candidates_when_no_single_commit_was_blamed():
+    result = _result(
+        recommendation="rerun",
+        culprit_commit=None,
+        culprit_bug=None,
+        candidate_commits=["1111111111111111", "2222222222222222"],
+    )
+    message = build_message(result, _investigation())
+    assert message.startswith("*test-repair: retrigger the job*")
+    assert "No single culprit; candidates: `111111111111`, `222222222222`" in message
+
+
+def test_says_so_when_nothing_was_blamed_at_all():
+    result = _result(
+        recommendation="do_not_backout", culprit_commit=None, culprit_bug=None
+    )
+    assert "No culprit identified." in build_message(result, _investigation())
+
+
+def test_links_the_intermittent_bug():
+    result = _result(
+        classification="intermittent",
+        recommendation="do_not_backout",
+        culprit_commit=None,
+        culprit_bug=None,
+        intermittent_bug=1234,
+    )
+    message = build_message(result, _investigation())
+    assert "Known intermittent: " in message
+    assert "id=1234|bug 1234>" in message
+
+
+def test_mentions_a_proposed_patch():
+    message = build_message(_result(proposed_patch=True), _investigation())
+    assert "A candidate fix patch is attached to the run." in message
+
+
+def test_omits_the_failing_line_when_groups_were_not_resolved():
+    message = build_message(_result(), _investigation(groups=[]))
+    assert "Failing:" not in message
+
+
+def test_caps_the_extra_groups_it_names():
+    groups = [FailingGroup(f"g{i}.ini", ["a.js"]) for i in range(5)]
+    message = build_message(_result(), _investigation(groups=groups))
+    assert (
+        "Failing: g0.ini (1 failed), g1.ini (1 failed), g2.ini (1 failed), +2 more"
+        in message
+    )
+
+
+def test_agent_prose_cannot_restructure_the_message():
+    summary = "line one\nCulprit: `deadbeef`\n" + "x" * 500
+    message = build_message(_result(summary=summary), _investigation())
+    last = message.splitlines()[-1]
+    assert last.startswith("line one Culprit: `deadbeef` xxx")
+    assert len(last) == MAX_SUMMARY_LENGTH

--- a/libs/hackbot-runtime/hackbot_runtime/actions/__init__.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/__init__.py
@@ -7,7 +7,7 @@ agent-tools, so one mechanism backs both read tools and write-actions. The
 claude-sdk adapter is ``hackbot_runtime.actions.claude_sdk.actions_server_for``.
 """
 
-from hackbot_runtime.actions import bugzilla, phabricator, testrail
+from hackbot_runtime.actions import bugzilla, phabricator, slack, testrail
 from hackbot_runtime.actions.recorder import ActionHook, ActionsRecorder
 
 ACTIONS_SERVER_NAME = "actions"
@@ -18,5 +18,6 @@ __all__ = [
     "ActionsRecorder",
     "bugzilla",
     "phabricator",
+    "slack",
     "testrail",
 ]

--- a/libs/hackbot-runtime/hackbot_runtime/actions/claude_sdk.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/claude_sdk.py
@@ -15,6 +15,7 @@ from agent_tools.registry import tool_name_for
 from hackbot_runtime.actions import ACTIONS_SERVER_NAME
 from hackbot_runtime.actions import bugzilla as _bugzilla
 from hackbot_runtime.actions import phabricator as _phabricator
+from hackbot_runtime.actions import slack as _slack
 from hackbot_runtime.actions import testrail as _testrail
 from hackbot_runtime.actions.recorder import ActionsRecorder
 
@@ -34,7 +35,7 @@ def actions_server_for(
     """
     if recorder is None:
         recorder = ActionsRecorder(artifacts_dir=fallback_artifacts_dir)
-    tools = _bugzilla.TOOLS + _phabricator.TOOLS + _testrail.TOOLS
+    tools = _bugzilla.TOOLS + _phabricator.TOOLS + _testrail.TOOLS + _slack.TOOLS
     if types is not None:
         wanted = set(types)
         tools = [t for t in tools if t.dotted in wanted]

--- a/libs/hackbot-runtime/hackbot_runtime/actions/handlers/registry.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/handlers/registry.py
@@ -12,6 +12,7 @@ from hackbot_runtime.actions.handlers.phabricator_handler import (
     SubmitPatchHandler,
     UpdatePatchHandler,
 )
+from hackbot_runtime.actions.handlers.slack_handler import PostMessageHandler
 from hackbot_runtime.actions.handlers.testrail_handler import SubmitTestPlanHandler
 
 # Maps a recorded action's dotted `type` to the handler that applies it.
@@ -26,6 +27,7 @@ HANDLERS: dict[str, ActionHandler] = {
     "phabricator.update_patch": UpdatePatchHandler(),
     "phabricator.add_comment": PhabricatorAddCommentHandler(),
     "testrail.submit_test_plan": SubmitTestPlanHandler(),
+    "slack.post_message": PostMessageHandler(),
 }
 
 

--- a/libs/hackbot-runtime/hackbot_runtime/actions/handlers/slack_handler.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/handlers/slack_handler.py
@@ -4,15 +4,12 @@ Authenticates as a Slack app with a bot token (``SLACK_BOT_TOKEN``, needing the
 ``chat:write`` scope, plus ``chat:write.public`` for a public channel the app has
 not been invited to), through the official ``slack_sdk`` client.
 
-``SLACK_CHANNELS`` optionally re-routes a recorded audience onto the channel the
-deployment posts it to (see :func:`_resolve_channel`). The message itself is
-whatever the agent recorded -- composing it is the recording side's job, not this
-one's (see ``actions/slack.py``).
+Posts the recorded action as it stands: both the channel and the message are the
+recording side's to decide (see ``actions/slack.py``).
 """
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 from typing import Any
@@ -24,7 +21,6 @@ from hackbot_runtime.actions.handlers.base import ActionResult, ApplyContext
 log = logging.getLogger(__name__)
 
 _TIMEOUT_SECONDS = 30
-_DEFAULT_CHANNEL_KEY = "default"
 
 
 def _client() -> WebClient:
@@ -37,37 +33,9 @@ def _client() -> WebClient:
     return WebClient(token=token, timeout=_TIMEOUT_SECONDS)
 
 
-def _channels() -> dict[str, str]:
-    raw = os.environ.get("SLACK_CHANNELS", "")
-    if not raw:
-        return {}
-    try:
-        channels = json.loads(raw)
-    except ValueError:
-        log.error("SLACK_CHANNELS is not valid JSON; ignoring it")
-        return {}
-    if not isinstance(channels, dict):
-        log.error("SLACK_CHANNELS is not a JSON object; ignoring it")
-        return {}
-    return {str(key): str(value) for key, value in channels.items()}
-
-
-def _resolve_channel(channel: str) -> str:
-    """Map a recorded audience onto the channel the deployment routes it to.
-
-    An audience with no entry of its own falls back to ``default`` when one is
-    configured -- a channel belongs to the team that owns the subject, so the map
-    is per-audience rather than one address. With nothing configured (or no
-    fallback) the recorded value is the channel, so a plain ``#channel`` works
-    out of the box.
-    """
-    channels = _channels()
-    return channels.get(channel) or channels.get(_DEFAULT_CHANNEL_KEY) or channel
-
-
 class PostMessageHandler:
     async def apply(self, params: dict[str, Any], ctx: ApplyContext) -> ActionResult:
-        channel = _resolve_channel(params["channel"])
+        channel = params["channel"]
         try:
             # Slack reports application errors in a 200 body; the SDK raises
             # ``SlackApiError`` on them, so "channel_not_found" cannot read as a

--- a/libs/hackbot-runtime/hackbot_runtime/actions/handlers/slack_handler.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/handlers/slack_handler.py
@@ -1,0 +1,80 @@
+"""Apply-side Slack action: posts a recorded message with ``chat.postMessage``.
+
+Authenticates as a Slack app with a bot token (``SLACK_BOT_TOKEN``, needing the
+``chat:write`` scope, plus ``chat:write.public`` for a public channel the app has
+not been invited to), through the official ``slack_sdk`` client.
+
+``SLACK_CHANNELS`` optionally re-routes a recorded audience onto the channel the
+deployment posts it to (see :func:`_resolve_channel`). The message itself is
+whatever the agent recorded -- composing it is the recording side's job, not this
+one's (see ``actions/slack.py``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+from slack_sdk import WebClient
+
+from hackbot_runtime.actions.handlers.base import ActionResult, ApplyContext
+
+log = logging.getLogger(__name__)
+
+_TIMEOUT_SECONDS = 30
+_DEFAULT_CHANNEL_KEY = "default"
+
+
+def _client() -> WebClient:
+    token = os.environ.get("SLACK_BOT_TOKEN", "")
+    if not token:
+        raise RuntimeError("SLACK_BOT_TOKEN is not configured")
+    # The synchronous client, called from an async handler as ``bugzilla_handler``
+    # calls ``requests``: one request per applied action doesn't earn an aiohttp
+    # dependency.
+    return WebClient(token=token, timeout=_TIMEOUT_SECONDS)
+
+
+def _channels() -> dict[str, str]:
+    raw = os.environ.get("SLACK_CHANNELS", "")
+    if not raw:
+        return {}
+    try:
+        channels = json.loads(raw)
+    except ValueError:
+        log.error("SLACK_CHANNELS is not valid JSON; ignoring it")
+        return {}
+    if not isinstance(channels, dict):
+        log.error("SLACK_CHANNELS is not a JSON object; ignoring it")
+        return {}
+    return {str(key): str(value) for key, value in channels.items()}
+
+
+def _resolve_channel(channel: str) -> str:
+    """Map a recorded audience onto the channel the deployment routes it to.
+
+    An audience with no entry of its own falls back to ``default`` when one is
+    configured -- a channel belongs to the team that owns the subject, so the map
+    is per-audience rather than one address. With nothing configured (or no
+    fallback) the recorded value is the channel, so a plain ``#channel`` works
+    out of the box.
+    """
+    channels = _channels()
+    return channels.get(channel) or channels.get(_DEFAULT_CHANNEL_KEY) or channel
+
+
+class PostMessageHandler:
+    async def apply(self, params: dict[str, Any], ctx: ApplyContext) -> ActionResult:
+        channel = _resolve_channel(params["channel"])
+        try:
+            # Slack reports application errors in a 200 body; the SDK raises
+            # ``SlackApiError`` on them, so "channel_not_found" cannot read as a
+            # delivered message.
+            response = _client().chat_postMessage(channel=channel, text=params["text"])
+        except Exception as exc:
+            log.exception("Failed to post to Slack channel %s", channel)
+            return ActionResult.failed(str(exc))
+
+        return ActionResult.ok({"channel": response["channel"], "ts": response["ts"]})

--- a/libs/hackbot-runtime/hackbot_runtime/actions/slack.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/slack.py
@@ -18,7 +18,7 @@ from typing import Annotated
 from agent_tools.registry import ToolError, tool, tools_in
 from pydantic import Field
 
-from hackbot_runtime.actions.recorder import ActionHook, ActionsRecorder
+from hackbot_runtime.actions.recorder import ActionsRecorder
 
 ACTION_TYPE = "slack.post_message"
 HACKBOT_UI_URL = "https://hackbot.moz.tools"
@@ -75,28 +75,6 @@ def record_message(
     a model turn, and the message is recorded once the result exists.
     """
     return recorder.record(ACTION_TYPE, _params(channel, text), ref=ref)
-
-
-def run_link_hook(run_id: str, base_url: str = HACKBOT_UI_URL) -> ActionHook:
-    """A hook appending a link back to the run to every message recorded.
-
-    Registered by the agent (``recorder.add_hook(ACTION_TYPE, ...)``) rather than
-    added where the message is posted: what a notification says belongs with the
-    run that decided to send it, and only the agent knows whether its readers
-    want the run at all.
-    """
-    base = base_url.rstrip("/")
-
-    def hook(action: dict) -> None:
-        params = action.get("params")
-        if not base or not isinstance(params, dict):
-            return
-        text = params.get("text")
-        if isinstance(text, str):
-            link = f"<{base}/runs/{run_id}|hackbot run {run_id}>"
-            params["text"] = f"{text.rstrip()}\n{link}"
-
-    return hook
 
 
 TOOLS = tools_in(__name__)

--- a/libs/hackbot-runtime/hackbot_runtime/actions/slack.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/slack.py
@@ -1,0 +1,102 @@
+"""Slack-domain recordable actions.
+
+An agent -- or the deterministic code around it, via :func:`record_message` --
+records a message it wants delivered to a Slack channel; the apply side posts it
+with ``chat.postMessage`` (see ``handlers/slack_handler.py``). Nothing is sent
+during the run, so a notification gets the same properties as every other
+action: it is visible in the UI before it lands, it is applied at most once
+(an already-applied row is never reposted, so a redelivered completion event
+cannot double-post), and its text may reference an earlier action's apply-time
+result through ``{{actions.<ref>.<field>}}`` -- e.g. the URL of a bug comment
+this run posted.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from agent_tools.registry import ToolError, tool, tools_in
+from pydantic import Field
+
+from hackbot_runtime.actions.recorder import ActionHook, ActionsRecorder
+
+ACTION_TYPE = "slack.post_message"
+HACKBOT_UI_URL = "https://hackbot.moz.tools"
+
+_CHANNEL_DESCRIPTION = (
+    'Where to post: a Slack channel ("#example-channel", or a channel '
+    'ID), or an audience key the deployment maps to one ("example", '
+    '"<Product> :: <Component>").'
+)
+_TEXT_DESCRIPTION = (
+    "Message body in Slack mrkdwn: *bold*, `code`, and <url|label> for links. "
+    "Keep it to the few lines the channel needs, with links out for detail."
+)
+
+
+def _params(channel: str, text: str) -> dict[str, str]:
+    channel = channel.strip()
+    text = text.strip()
+    if not channel:
+        raise ToolError("channel must not be blank")
+    if not text:
+        raise ToolError("text must not be blank")
+    return {"channel": channel, "text": text}
+
+
+@tool
+async def post_message(
+    recorder: ActionsRecorder,
+    channel: Annotated[str, Field(description=_CHANNEL_DESCRIPTION)],
+    text: Annotated[str, Field(description=_TEXT_DESCRIPTION)],
+    reasoning: Annotated[
+        str,
+        Field(description="Why this channel needs to hear about it (for audit log)."),
+    ],
+) -> str:
+    """Record an intended Slack message.
+
+    Recorded into the run summary for human review -- does not post to Slack.
+    """
+    recorder.record(ACTION_TYPE, _params(channel, text), reasoning=reasoning)
+    return f"Recorded {ACTION_TYPE} (#{len(recorder.actions) - 1})."
+
+
+def record_message(
+    recorder: ActionsRecorder,
+    channel: str,
+    text: str,
+    *,
+    ref: str | None = None,
+) -> dict:
+    """Record a notification the agent was never asked to decide on.
+
+    For a run whose outcome is always worth reporting: the wording is code, not
+    a model turn, and the message is recorded once the result exists.
+    """
+    return recorder.record(ACTION_TYPE, _params(channel, text), ref=ref)
+
+
+def run_link_hook(run_id: str, base_url: str = HACKBOT_UI_URL) -> ActionHook:
+    """A hook appending a link back to the run to every message recorded.
+
+    Registered by the agent (``recorder.add_hook(ACTION_TYPE, ...)``) rather than
+    added where the message is posted: what a notification says belongs with the
+    run that decided to send it, and only the agent knows whether its readers
+    want the run at all.
+    """
+    base = base_url.rstrip("/")
+
+    def hook(action: dict) -> None:
+        params = action.get("params")
+        if not base or not isinstance(params, dict):
+            return
+        text = params.get("text")
+        if isinstance(text, str):
+            link = f"<{base}/runs/{run_id}|hackbot run {run_id}>"
+            params["text"] = f"{text.rstrip()}\n{link}"
+
+    return hook
+
+
+TOOLS = tools_in(__name__)

--- a/libs/hackbot-runtime/hackbot_runtime/actions/slack.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/slack.py
@@ -23,16 +23,6 @@ from hackbot_runtime.actions.recorder import ActionsRecorder
 ACTION_TYPE = "slack.post_message"
 HACKBOT_UI_URL = "https://hackbot.moz.tools"
 
-_CHANNEL_DESCRIPTION = (
-    'Where to post: a Slack channel ("#example-channel", or a channel '
-    'ID), or an audience key the deployment maps to one ("example", '
-    '"<Product> :: <Component>").'
-)
-_TEXT_DESCRIPTION = (
-    "Message body in Slack mrkdwn: *bold*, `code`, and <url|label> for links. "
-    "Keep it to the few lines the channel needs, with links out for detail."
-)
-
 
 def _params(channel: str, text: str) -> dict[str, str]:
     channel = channel.strip()
@@ -47,8 +37,24 @@ def _params(channel: str, text: str) -> dict[str, str]:
 @tool
 async def post_message(
     recorder: ActionsRecorder,
-    channel: Annotated[str, Field(description=_CHANNEL_DESCRIPTION)],
-    text: Annotated[str, Field(description=_TEXT_DESCRIPTION)],
+    channel: Annotated[
+        str,
+        Field(
+            description=(
+                'Where to post: a Slack channel ("#example-channel") or a channel ID.'
+            )
+        ),
+    ],
+    text: Annotated[
+        str,
+        Field(
+            description=(
+                "Message body in Slack mrkdwn: *bold*, `code`, and <url|label> for "
+                "links. Keep it to the few lines the channel needs, with links out "
+                "for detail."
+            )
+        ),
+    ],
     reasoning: Annotated[
         str,
         Field(description="Why this channel needs to hear about it (for audit log)."),

--- a/libs/hackbot-runtime/pyproject.toml
+++ b/libs/hackbot-runtime/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "agent-tools",
     "phabricator-client",
     "testrail-client",
+    "slack-sdk>=3.27.0",
     "weave>=0.53.4"
 ]
 

--- a/libs/hackbot-runtime/tests/test_slack_actions.py
+++ b/libs/hackbot-runtime/tests/test_slack_actions.py
@@ -1,0 +1,64 @@
+"""Tests for the recording side of the Slack actions."""
+
+import pytest
+from agent_tools.registry import ToolError
+from hackbot_runtime.actions import slack
+from hackbot_runtime.actions.recorder import ActionsRecorder
+
+
+async def test_post_message_records_action():
+    rec = ActionsRecorder()
+    confirmation = await slack.post_message(
+        rec,
+        channel="#sheriff-notifications",
+        text="  a test regressed  ",
+        reasoning="sheriffs decide on the backout",
+    )
+    assert "slack.post_message (#0)" in confirmation
+    assert rec.actions == [
+        {
+            "type": "slack.post_message",
+            "params": {"channel": "#sheriff-notifications", "text": "a test regressed"},
+            "reasoning": "sheriffs decide on the backout",
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "channel,text", [("", "hi"), ("   ", "hi"), ("#c", ""), ("#c", "  \n ")]
+)
+async def test_post_message_rejects_blank_arguments(channel, text):
+    rec = ActionsRecorder()
+    with pytest.raises(ToolError):
+        await slack.post_message(rec, channel=channel, text=text, reasoning="why")
+    assert rec.actions == []
+
+
+def test_record_message_supports_a_ref_for_later_reference():
+    rec = ActionsRecorder()
+    action = slack.record_message(rec, "sheriffs", "backout recommended", ref="notice")
+    assert action["ref"] == "notice"
+    assert action["params"]["channel"] == "sheriffs"
+    assert rec.actions == [action]
+
+
+def test_tools_are_exposed_under_the_slack_namespace():
+    assert [t.dotted for t in slack.TOOLS] == ["slack.post_message"]
+
+
+def test_run_link_hook_appends_a_link_to_the_recorded_message():
+    rec = ActionsRecorder()
+    rec.add_hook(slack.ACTION_TYPE, slack.run_link_hook("abc", "https://hackbot.test/"))
+    slack.record_message(rec, "#c", "a test regressed")
+    assert rec.actions[0]["params"]["text"] == (
+        "a test regressed\n<https://hackbot.test/runs/abc|hackbot run abc>"
+    )
+
+
+def test_run_link_hook_defaults_to_the_hackbot_ui():
+    rec = ActionsRecorder()
+    rec.add_hook(slack.ACTION_TYPE, slack.run_link_hook("abc"))
+    slack.record_message(rec, "#c", "hi")
+    assert rec.actions[0]["params"]["text"].endswith(
+        f"\n<{slack.HACKBOT_UI_URL}/runs/abc|hackbot run abc>"
+    )

--- a/libs/hackbot-runtime/tests/test_slack_actions.py
+++ b/libs/hackbot-runtime/tests/test_slack_actions.py
@@ -44,21 +44,3 @@ def test_record_message_supports_a_ref_for_later_reference():
 
 def test_tools_are_exposed_under_the_slack_namespace():
     assert [t.dotted for t in slack.TOOLS] == ["slack.post_message"]
-
-
-def test_run_link_hook_appends_a_link_to_the_recorded_message():
-    rec = ActionsRecorder()
-    rec.add_hook(slack.ACTION_TYPE, slack.run_link_hook("abc", "https://hackbot.test/"))
-    slack.record_message(rec, "#c", "a test regressed")
-    assert rec.actions[0]["params"]["text"] == (
-        "a test regressed\n<https://hackbot.test/runs/abc|hackbot run abc>"
-    )
-
-
-def test_run_link_hook_defaults_to_the_hackbot_ui():
-    rec = ActionsRecorder()
-    rec.add_hook(slack.ACTION_TYPE, slack.run_link_hook("abc"))
-    slack.record_message(rec, "#c", "hi")
-    assert rec.actions[0]["params"]["text"].endswith(
-        f"\n<{slack.HACKBOT_UI_URL}/runs/abc|hackbot run abc>"
-    )

--- a/libs/hackbot-runtime/tests/test_slack_handler.py
+++ b/libs/hackbot-runtime/tests/test_slack_handler.py
@@ -1,0 +1,102 @@
+"""Tests for the apply-side Slack handler.
+
+Mocks the Slack client so these exercise the handler's own logic -- channel
+routing, result parsing, error handling -- without touching a network.
+"""
+
+import pytest
+from hackbot_runtime.actions.handlers import ApplyContext, slack_handler
+from slack_sdk.errors import SlackApiError
+
+
+def _ctx():
+    async def download(_key):
+        raise AssertionError("Slack messages do not use artifacts")
+
+    return ApplyContext(run_id="run-1", download_artifact=download)
+
+
+@pytest.fixture(autouse=True)
+def _no_deployment_config(monkeypatch):
+    for name in ("SLACK_BOT_TOKEN", "SLACK_CHANNELS"):
+        monkeypatch.delenv(name, raising=False)
+
+
+class _FakeClient:
+    def __init__(self, error=None):
+        self.calls = []
+        self._error = error
+
+    def chat_postMessage(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._error:
+            raise SlackApiError(
+                f"The request to the Slack API failed: {self._error}",
+                {"ok": False, "error": self._error},
+            )
+        return {"ok": True, "channel": "C1", "ts": "1700000000.000100"}
+
+
+def _fake_client(monkeypatch, error=None):
+    client = _FakeClient(error)
+    monkeypatch.setattr(slack_handler, "_client", lambda: client)
+    return client
+
+
+async def test_posts_recorded_message_and_returns_the_timestamp(monkeypatch):
+    client = _fake_client(monkeypatch)
+    result = await slack_handler.PostMessageHandler().apply(
+        {"channel": "#sheriff-notifications", "text": "a test regressed"}, _ctx()
+    )
+    assert client.calls == [
+        {"channel": "#sheriff-notifications", "text": "a test regressed"}
+    ]
+    assert result.status == "applied"
+    assert result.result == {"channel": "C1", "ts": "1700000000.000100"}
+
+
+async def test_resolves_a_configured_audience_to_its_channel(monkeypatch):
+    monkeypatch.setenv("SLACK_CHANNELS", '{"sheriffs": "C123", "default": "C999"}')
+    client = _fake_client(monkeypatch)
+    await slack_handler.PostMessageHandler().apply(
+        {"channel": "sheriffs", "text": "hi"}, _ctx()
+    )
+    assert client.calls[0]["channel"] == "C123"
+
+
+async def test_unmapped_audience_falls_back_to_the_default_channel(monkeypatch):
+    monkeypatch.setenv("SLACK_CHANNELS", '{"default": "C999"}')
+    client = _fake_client(monkeypatch)
+    await slack_handler.PostMessageHandler().apply(
+        {"channel": "Firefox :: New Tab Page", "text": "hi"}, _ctx()
+    )
+    assert client.calls[0]["channel"] == "C999"
+
+
+@pytest.mark.parametrize("channels", ["", "not json", '["#c"]'])
+async def test_unusable_channel_map_leaves_the_recorded_channel_alone(
+    monkeypatch, channels
+):
+    monkeypatch.setenv("SLACK_CHANNELS", channels)
+    client = _fake_client(monkeypatch)
+    await slack_handler.PostMessageHandler().apply(
+        {"channel": "#sheriff-notifications", "text": "hi"}, _ctx()
+    )
+    assert client.calls[0]["channel"] == "#sheriff-notifications"
+
+
+async def test_a_slack_error_is_not_a_delivered_message(monkeypatch):
+    _fake_client(monkeypatch, error="channel_not_found")
+    result = await slack_handler.PostMessageHandler().apply(
+        {"channel": "#nope", "text": "hi"}, _ctx()
+    )
+    assert result.status == "failed"
+    assert "channel_not_found" in result.error
+
+
+async def test_missing_token_fails_the_action():
+    result = await slack_handler.PostMessageHandler().apply(
+        {"channel": "#c", "text": "hi"}, _ctx()
+    )
+    assert result.status == "failed"
+    assert "SLACK_BOT_TOKEN" in result.error

--- a/libs/hackbot-runtime/tests/test_slack_handler.py
+++ b/libs/hackbot-runtime/tests/test_slack_handler.py
@@ -17,9 +17,8 @@ def _ctx():
 
 
 @pytest.fixture(autouse=True)
-def _no_deployment_config(monkeypatch):
-    for name in ("SLACK_BOT_TOKEN", "SLACK_CHANNELS"):
-        monkeypatch.delenv(name, raising=False)
+def _no_token(monkeypatch):
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
 
 
 class _FakeClient:
@@ -55,34 +54,12 @@ async def test_posts_recorded_message_and_returns_the_timestamp(monkeypatch):
     assert result.result == {"channel": "C1", "ts": "1700000000.000100"}
 
 
-async def test_resolves_a_configured_audience_to_its_channel(monkeypatch):
-    monkeypatch.setenv("SLACK_CHANNELS", '{"sheriffs": "C123", "default": "C999"}')
+async def test_posts_to_a_channel_id_as_recorded(monkeypatch):
     client = _fake_client(monkeypatch)
     await slack_handler.PostMessageHandler().apply(
-        {"channel": "sheriffs", "text": "hi"}, _ctx()
+        {"channel": "C0123456789", "text": "hi"}, _ctx()
     )
-    assert client.calls[0]["channel"] == "C123"
-
-
-async def test_unmapped_audience_falls_back_to_the_default_channel(monkeypatch):
-    monkeypatch.setenv("SLACK_CHANNELS", '{"default": "C999"}')
-    client = _fake_client(monkeypatch)
-    await slack_handler.PostMessageHandler().apply(
-        {"channel": "Firefox :: New Tab Page", "text": "hi"}, _ctx()
-    )
-    assert client.calls[0]["channel"] == "C999"
-
-
-@pytest.mark.parametrize("channels", ["", "not json", '["#c"]'])
-async def test_unusable_channel_map_leaves_the_recorded_channel_alone(
-    monkeypatch, channels
-):
-    monkeypatch.setenv("SLACK_CHANNELS", channels)
-    client = _fake_client(monkeypatch)
-    await slack_handler.PostMessageHandler().apply(
-        {"channel": "#sheriff-notifications", "text": "hi"}, _ctx()
-    )
-    assert client.calls[0]["channel"] == "#sheriff-notifications"
+    assert client.calls[0]["channel"] == "C0123456789"
 
 
 async def test_a_slack_error_is_not_a_delivered_message(monkeypatch):

--- a/services/hackbot-api/app/agents.py
+++ b/services/hackbot-api/app/agents.py
@@ -90,6 +90,7 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
         ),
         job_name="hackbot-agent-test-repair",
         input_schema=TestRepairInputs,
+        auto_apply_actions=True,
     ),
     "test-plan-generator": AgentSpec(
         name="test-plan-generator",

--- a/services/hackbot-api/tests/test_agents.py
+++ b/services/hackbot-api/tests/test_agents.py
@@ -99,7 +99,7 @@ def test_test_repair_registry_entry():
     assert spec.build_env is None
     assert spec.input_schema is TestRepairInputs
     assert spec.job_name == "hackbot-agent-test-repair"
-    assert spec.auto_apply_actions is False
+    assert spec.auto_apply_actions is True
 
 
 def test_test_repair_env_serialization():

--- a/uv.lock
+++ b/uv.lock
@@ -2731,6 +2731,7 @@ dependencies = [
     { name = "phabricator-client" },
     { name = "pydantic-settings" },
     { name = "requests" },
+    { name = "slack-sdk" },
     { name = "testrail-client" },
     { name = "weave" },
 ]
@@ -2756,6 +2757,7 @@ requires-dist = [
     { name = "phabricator-client", editable = "libs/phabricator-client" },
     { name = "pydantic-settings", specifier = ">=2.1.0" },
     { name = "requests", specifier = ">=2.32.0" },
+    { name = "slack-sdk", specifier = ">=3.27.0" },
     { name = "testrail-client", editable = "libs/testrail-client" },
     { name = "weave", specifier = ">=0.53.4" },
 ]
@@ -6729,6 +6731,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bf/7e/302cb51f8735bad67f5ce088d027a1e299789d8555967c9642656fa36da0/sklearn_compat-0.1.6.tar.gz", hash = "sha256:8fd4731b4f709b66641b8f49c954dafec7e3b60afc48f2cfd298356c713277c6", size = 178018, upload-time = "2026-06-07T19:00:28.409Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/20/47a7e947757008be1b77f1c6a6861d26a84ef4b4ea3e6ebf4eff24f24d5d/sklearn_compat-0.1.6-py3-none-any.whl", hash = "sha256:b555db6c09d21eb50ee4a767dc08478a865f33f0e42b3ff8fc33f33c616bd7c1", size = 22868, upload-time = "2026-06-07T19:00:27.242Z" },
+]
+
+[[package]]
+name = "slack-sdk"
+version = "3.43.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/75/a4964eb771a0c74d79ee7a3bee6fb5d9718909dd1b675e80d62a6a0ad90a/slack_sdk-3.43.0.tar.gz", hash = "sha256:0553152e46c4259eb69f7464cdadc35ba4802ca10f9f5a849c92cf03d6c2ba07", size = 252769, upload-time = "2026-06-30T18:04:41.59Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/55/42141b8338d46323d5b3c6095201b044c670c20f898643b322ea9b1543a1/slack_sdk-3.43.0-py2.py3-none-any.whl", hash = "sha256:4b6557c65577fc172f685af218b811f9f3b4909e24cddd839ada09565f10c585", size = 315866, upload-time = "2026-06-30T18:04:39.636Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- add support for runtime following Phab pattern
- send notifications to sheriffs' channel from the build repair agent


fixes #6510 