### PR TITLE
Add separator before Bugzilla comment footer

### DIFF
--- a/libs/hackbot-runtime/hackbot_runtime/actions/bugzilla.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/bugzilla.py
@@ -95,7 +95,7 @@ async def add_comment(
     Use is_private=true for security-sensitive notes. Recorded into the run
     summary for human review — does not post to Bugzilla.
     """
-    text_with_footer = text.rstrip() + "\n\n" + _COMMENT_FOOTER
+    text_with_footer = text.rstrip() + "\n\n---\n\n" + _COMMENT_FOOTER
     recorder.record(
         "bugzilla.add_comment",
         {"bug_id": bug_id, "text": text_with_footer, "is_private": is_private},

--- a/libs/hackbot-runtime/tests/test_bugzilla_actions.py
+++ b/libs/hackbot-runtime/tests/test_bugzilla_actions.py
@@ -9,8 +9,7 @@ async def test_add_comment_appends_footer():
     rec = ActionsRecorder()
     await bugzilla.add_comment(rec, bug_id=1, text="Looks invalid.", reasoning="r")
     text = rec.actions[0]["params"]["text"]
-    assert text.startswith("Looks invalid.")
-    assert text.endswith(bugzilla._COMMENT_FOOTER)
+    assert text == "Looks invalid.\n\n---\n\n" + bugzilla._COMMENT_FOOTER
     assert rec.actions[0]["params"]["is_private"] is False
 
 


### PR DESCRIPTION
Adds a Markdown horizontal rule between Hackbot’s Bugzilla comment body and its feedback footer

Resolve #6546