### PR TITLE
Improvements for CI agents and listener

### DIFF
--- a/agents/build-repair/README.md
+++ b/agents/build-repair/README.md
@@ -22,11 +22,12 @@ It also optionally bootstraps Firefox build if needed.
 
 First stage - analysis:
 
-- `summary.md` - a quick summary for a developer
-- `analysis.md` - detailed analysis
+- `summary.md` - 2-3 sentences: whether a commit in the push broke the build, the error,
+  the fix
+- `analysis.md` - verdict, error, cause and fix, under a page
 - `planning.md` - intermediate file that outlines fixing steps for the second stage
-- `blame.json` - the commit that introduced the failure (`blamed_commit`, `reason`); written
-  only when the push has more than one commit
+- `blame.json` - the commit that introduced the failure (`blamed_commit`, `reason`), null
+  when no commit in the push is to blame
 
 Second stage - fixing:
 

--- a/agents/build-repair/hackbot_agents/build_repair/agent.py
+++ b/agents/build-repair/hackbot_agents/build_repair/agent.py
@@ -71,8 +71,8 @@ class BuildRepairResult(HackbotAgentResult):
     try_build_passed: bool | None = None
     lando_job_id: str | None = None
     treeherder_url: str | None = None
-    # Which commit in the push introduced the failure. Equals ``git_commit`` when
-    # the push has a single commit; chosen by the agent otherwise.
+    # Which commit introduced the failure, or None when the agent found that none
+    # of the push's commits did (infra, toolchain, or already failing).
     blamed_commit: str | None = None
 
 
@@ -348,9 +348,11 @@ def _push_context(git_commits: list[str]) -> str:
 
 
 def _blame_step(git_commits: list[str], scratch_out: Path) -> str:
-    """The blame.json instruction, only when the push has more than one commit."""
-    if len(git_commits) <= 1:
-        return ""
+    """The blame.json instruction.
+
+    Asked for even on a single-commit push: without it the agent has no way to say
+    that the lone commit is innocent and the bustage came from somewhere else.
+    """
     return BLAME_STEP.format(scratch_out=scratch_out)
 
 
@@ -364,25 +366,31 @@ def _match_commit(sha: str | None, git_commits: list[str]) -> str | None:
     return None
 
 
-def _resolve_blame(scratch_out: Path, git_commits: list[str]) -> str | None:
-    """Return the commit the agent blamed for the failure.
+def _read_blame(scratch_out: Path) -> dict:
+    path = scratch_out / "blame.json"
+    if not path.exists():
+        return {}
+    try:
+        blame = json.loads(path.read_text())
+    except (ValueError, OSError):
+        return {}
+    return blame if isinstance(blame, dict) else {}
 
-    Single-commit pushes are trivially blamed on that commit. Otherwise the agent
-    records its choice in ``blame.json``; we normalize it to a full hash from
-    ``git_commits`` and fall back to the failure commit when the file is missing
-    or unparsable.
+
+def _resolve_blame(scratch_out: Path, git_commits: list[str]) -> str | None:
+    """The commit the agent blamed, or None when it cleared the whole push.
+
+    An explicit null is a verdict and is kept; blaming a commit the agent just
+    cleared is worse than naming none. A missing or unparsable file is not a
+    verdict, so that still falls back to the failure commit.
     """
     if not git_commits:
         return None
     failure_commit = git_commits[0]
-    if len(git_commits) == 1:
+    blame = _read_blame(scratch_out)
+    if "blamed_commit" not in blame:
         return failure_commit
-
-    blamed: str | None = None
-    path = scratch_out / "blame.json"
-    if path.exists():
-        try:
-            blamed = (json.loads(path.read_text()).get("blamed_commit") or "").strip()
-        except (ValueError, OSError):
-            blamed = None
+    blamed = str(blame["blamed_commit"] or "").strip()
+    if not blamed:
+        return None
     return _match_commit(blamed, git_commits) or failure_commit

--- a/agents/build-repair/hackbot_agents/build_repair/prompts.py
+++ b/agents/build-repair/hackbot_agents/build_repair/prompts.py
@@ -35,9 +35,12 @@ determine which single commit introduced the build failure.
 
 PUSH_COMMIT_LINE = "- {commit}"
 
-BLAME_STEP = """4. {scratch_out}/blame.json identifying the single commit that introduced the failure,
-   as JSON: {{"blamed_commit": "<full git sha>", "reason": "<one sentence>"}}. Choose
-   blamed_commit from the push commits listed above.
+BLAME_STEP = """4. {scratch_out}/blame.json naming the commit that introduced the failure, as JSON:
+   {{"blamed_commit": "<full git sha>", "reason": "<one sentence>"}}. Use one of the
+   push commits listed above when there are several, otherwise the checked-out
+   commit. Set "blamed_commit" to null if none of them caused the failure -- it is
+   infrastructure, a toolchain or fetch problem, or it already failed before this
+   push -- rather than naming the least implausible commit.
 """
 
 BUG_CONTEXT = "\nThe commit attempted to fix Bugzilla bug {bug_id}.\n"

--- a/agents/build-repair/hackbot_agents/build_repair/prompts.py
+++ b/agents/build-repair/hackbot_agents/build_repair/prompts.py
@@ -16,10 +16,19 @@ Analyze the following:
 {failure_logs}
 
 Create these documents:
-1. {scratch_out}/analysis.md with your detailed analysis of what caused the failure
-2. {scratch_out}/planning.md with a fixing plan
-3. {scratch_out}/summary.md with a brief one-paragraph summary of the analysis and plan
-   that can point a developer in the right direction
+1. {scratch_out}/analysis.md -- the developer's reference, readable in under a
+   minute. Under 40 lines, in exactly these sections, each a short paragraph or a
+   few bullets:
+     ## Verdict -- which commit broke the build, or that none of them did
+     ## Error -- what the build reports, with the line that shows it
+     ## Cause -- the change that produces that error
+     ## Fix -- what to change
+   Quote only what decides something. Do not restate a diff you already pointed
+   at, and do not narrate the steps you took to get here.
+2. {scratch_out}/planning.md with the fix as a short numbered list of edits
+3. {scratch_out}/summary.md -- 2-3 sentences of plain prose, no headings or lists.
+   Open with whether a commit in this push broke the build and which one, then
+   give the error and the fix in a clause each.
 {blame_step}
 Do not prompt to edit those documents. Do not write any code yet. Work fully
 autonomously and do not ask any questions.

--- a/agents/test-repair/README.md
+++ b/agents/test-repair/README.md
@@ -49,8 +49,8 @@ failure here is evidence the patch is wrong while a pass proves nothing.
 
 Stage 1:
 
-- `summary.md` - a short verdict
-- `analysis.md` - detailed reasoning, with evidence from the logs and diffs
+- `summary.md` - 2-3 sentences: the action, the fact that settles it, what failed
+- `analysis.md` - verdict, failure, cause and alternatives ruled out, under a page
 - `verdict.json` - `classification` (`regression` / `intermittent`),
   `culprit_commit`, `candidate_commits`, `culprit_bug`, `intermittent_bug`,
   `recommendation` (`backout` / `do_not_backout` / `rerun`) and `confidence`

--- a/agents/test-repair/hackbot_agents/test_repair/notify.py
+++ b/agents/test-repair/hackbot_agents/test_repair/notify.py
@@ -9,7 +9,7 @@ Recorded as a ``slack.post_message`` action rather than posted from the run: it 
 then visible in the hackbot UI before it lands, and the apply step delivers it at
 most once (see ``hackbot_runtime.actions.slack``).
 
-Five lines of context, then the verdict in full. Every identifier a sheriff would
+A few lines of context, then the verdict in full. Every identifier a sheriff would
 otherwise have to look up -- revisions, task, bug, run -- is a link, the way the
 pulse listener's email does it
 (``services/hackbot-pulse-listener/app/notify.py``); unlike the email this stays
@@ -120,9 +120,17 @@ def _culprit_line(result: TestRepairResult, culprit_author: str | None) -> str:
     bug = result.culprit_bug or result.intermittent_bug
     if bug:
         line += f" ({_bug_link(bug)})"
-    if result.proposed_patch:
-        line += ", patch attached"
     return line
+
+
+def _patch_line(result: TestRepairResult) -> str | None:
+    """Who the attached patch is for, so it is not read as an alternative action."""
+    if not result.proposed_patch:
+        return None
+    return (
+        "Patch attached for the author: squash it into the existing patches and"
+        " reland, rather than landing it as a follow-up. The backout still stands."
+    )
 
 
 def build_message(
@@ -144,6 +152,9 @@ def build_message(
         _culprit_line(result, culprit_author),
         _link(RUN_URL.format(run_id=run_id), "Hackbot run details"),
     ]
+    patch = _patch_line(result)
+    if patch:
+        lines.insert(-1, patch)
     if result.summary.strip():
         lines += ["", result.summary.strip()]
     return "\n".join(lines)

--- a/agents/test-repair/hackbot_agents/test_repair/notify.py
+++ b/agents/test-repair/hackbot_agents/test_repair/notify.py
@@ -123,14 +123,14 @@ def _culprit_line(result: TestRepairResult, culprit_author: str | None) -> str:
     return line
 
 
-def _patch_line(result: TestRepairResult) -> str | None:
+def _patch_lines(result: TestRepairResult) -> list[str]:
     """Who the attached patch is for, so it is not read as an alternative action."""
     if not result.proposed_patch:
-        return None
-    return (
+        return []
+    return [
         "Patch attached for the author: squash it into the existing patches and"
         " reland, rather than landing it as a follow-up. The backout still stands."
-    )
+    ]
 
 
 def build_message(
@@ -150,11 +150,9 @@ def build_message(
         _jobs_line(investigation, task_id),
         _push_line(investigation),
         _culprit_line(result, culprit_author),
+        *_patch_lines(result),
         _link(RUN_URL.format(run_id=run_id), "Hackbot run details"),
     ]
-    patch = _patch_line(result)
-    if patch:
-        lines.insert(-1, patch)
     if result.summary.strip():
         lines += ["", result.summary.strip()]
     return "\n".join(lines)

--- a/agents/test-repair/hackbot_agents/test_repair/prompts.py
+++ b/agents/test-repair/hackbot_agents/test_repair/prompts.py
@@ -46,13 +46,20 @@ Steps:
    whole stack has to be backed out -- name it in summary.md, oldest sha first.
    "culprit_commit" stays the single commit that introduced the regression.
 5. Write to {scratch_out}:
-   - summary.md: a 2-4 sentence verdict, in plain prose -- no headings, lists or
-     code blocks. It is posted verbatim to Slack, so it has to read at a glance:
-     what failed, what caused it, what to do. Everything else belongs in
-     analysis.md.
-   - analysis.md: the reasoning, with evidence from the logs and diffs. This is
-     where quoted log lines, diffs and alternatives you ruled out go, at whatever
-     length the case needs.
+   - summary.md: 2-3 sentences of plain prose -- no headings, lists or code
+     blocks. It is posted verbatim to Slack and has to answer "do I back this
+     out?" at a glance. Open with the action -- back out <sha>, do not back out,
+     or retrigger -- and the one fact that settles it, then say what failed.
+   - analysis.md: the developer's reference, readable in under a minute. Under 50
+     lines, in exactly these sections, each a short paragraph or a few bullets:
+       ## Verdict -- the action, the culprit and its bug, the confidence
+       ## Failure -- how the test fails, with the log line that shows it
+       ## Cause -- the hunk in the culprit that produces that failure
+       ## Ruled out -- a line per alternative you seriously weighed; drop the
+          section when there was none
+     Quote only what decides something. Do not narrate the searches you ran, do
+     not restate a diff you already pointed at, and do not add a section to
+     report that a check passed.
    - verdict.json: "classification" ("regression" or "intermittent"),
      "culprit_commit" (full sha from the range, or null), "candidate_commits" (up
      to {max_candidates} full shas, most to least likely, whenever no single
@@ -107,11 +114,11 @@ The source tree is at {source_repo} (your working directory). Search it with
 
 1. Make the smallest change that addresses the root cause.
 {verify_step}
-3. Describe the patch in {scratch_out}/analysis.md: what it changes and why that
-   addresses the root cause.
+3. Append a "## Patch" section to {scratch_out}/analysis.md, under 10 lines: the
+   files it touches, the root cause it addresses, and whether it was verified.
+   The diff is attached, so do not walk through it.
 4. Add at most one sentence to {scratch_out}/summary.md saying a patch is
-   proposed. Do not rewrite or restructure it -- it stays the short verdict
-   posted to Slack, and the patch write-up goes in analysis.md.
+   proposed and whether it is verified. Leave the rest of it alone.
 5. Update {scratch_out}/verdict.json in place, preserving its existing keys: set
    "proposed_patch" to true if you made a fix, and leave "recommendation" as
    "backout".

--- a/agents/test-repair/tests/test_notify.py
+++ b/agents/test-repair/tests/test_notify.py
@@ -122,12 +122,16 @@ def test_names_a_known_intermittent():
     )
 
 
-def test_mentions_a_proposed_patch():
-    assert (
-        _message(_result(proposed_patch=True))
-        .splitlines()[4]
-        .endswith(", patch attached")
-    )
+def test_a_patch_is_advice_for_the_author_not_an_alternative_action():
+    message = _message(_result(proposed_patch=True))
+    assert "*test-repair: BACK OUT the culprit*" in message.splitlines()[0]
+    assert "squash it into the existing patches and reland" in message
+    assert "rather than landing it as a follow-up" in message
+    assert "The backout still stands." in message
+
+
+def test_no_patch_line_without_a_patch():
+    assert "Patch attached" not in _message()
 
 
 def test_lists_every_failing_group():

--- a/agents/test-repair/tests/test_notify.py
+++ b/agents/test-repair/tests/test_notify.py
@@ -130,6 +130,13 @@ def test_a_patch_is_advice_for_the_author_not_an_alternative_action():
     assert "The backout still stands." in message
 
 
+def test_the_patch_line_comes_before_the_run_link():
+    lines = _message(_result(proposed_patch=True)).splitlines()
+    patch = next(i for i, line in enumerate(lines) if "Patch attached" in line)
+    run = next(i for i, line in enumerate(lines) if "Hackbot run details" in line)
+    assert patch < run
+
+
 def test_no_patch_line_without_a_patch():
     assert "Patch attached" not in _message()
 

--- a/services/hackbot-pulse-listener/app/config.py
+++ b/services/hackbot-pulse-listener/app/config.py
@@ -10,7 +10,7 @@ class Settings(BaseSettings):
     # hackbot-api
     hackbot_api_url: str = ""
     hackbot_api_key: str = ""
-    hackbot_ui_url: str = ""
+    hackbot_ui_url: str = "https://hackbot.moz.tools"
     agent_name: str = "build-repair"
     # Agent that analyzes test failures (separate Cloud Run Job from build-repair).
     test_repair_agent_name: str = "test-repair"

--- a/services/hackbot-pulse-listener/app/config.py
+++ b/services/hackbot-pulse-listener/app/config.py
@@ -47,6 +47,8 @@ class Settings(BaseSettings):
     # Dedupe (in-memory, by hg revision)
     dedupe_ttl_seconds: int = 6 * 60 * 60
     dedupe_max_size: int = 4096
+    # Dedupe by failing manifest, on top of the per-push one above.
+    group_dedupe_ttl_seconds: int = 12 * 60 * 60
 
     # Cap on test-repair runs started in any rolling 24 hours. Each run clones and
     # builds Firefox in its own container, so a bad day on autoland -- a broken

--- a/services/hackbot-pulse-listener/app/consumer.py
+++ b/services/hackbot-pulse-listener/app/consumer.py
@@ -50,6 +50,13 @@ _seen_tests: TTLCache = TTLCache(
 )
 _seen_tests_lock = threading.Lock()
 
+# A manifest stays broken on the pushes following the one that broke it, so per-push
+# dedupe alone still mails a near-identical analysis for each.
+_seen_groups: TTLCache = TTLCache(
+    maxsize=settings.dedupe_max_size, ttl=settings.group_dedupe_ttl_seconds
+)
+_seen_groups_lock = threading.Lock()
+
 # When each test-repair run of the last day was started, oldest first, capping how
 # many may run in any rolling 24 hours. A slot is taken at the moment of triggering
 # and given back if the trigger fails, so only runs that really started count.
@@ -273,6 +280,7 @@ def _process_test(body: dict, tags: dict, executor: Executor) -> str | None:
     # once. The same record carries the configuration the regression check compares
     # against.
     job = treeherder.job_for_task(project, task_id)
+
     # Populated at ingestion, so this needs no wait for a sheriff to star the job.
     intermittent = treeherder.intermittent_match(project, job)
     if intermittent.known:
@@ -363,6 +371,15 @@ def _process_test(body: dict, tags: dict, executor: Executor) -> str | None:
         )
         return None
 
+    if _groups_claimed(project, fresh):
+        logger.info(
+            "Every failing group of task %s was already investigated on a recent "
+            "push; skipping -- %s",
+            task_id,
+            job_link,
+        )
+        return None
+
     # One last cheap look before spending a run. The gate above already waited for a
     # verdict, so this catches one that landed during the walk: a sheriff's
     # classification, or autoclassification once a retrigger came back green.
@@ -405,6 +422,24 @@ def _claim_push(hg_revision: str) -> bool:
             return False
         _seen_tests[hg_revision] = True
         return True
+
+
+def _groups_claimed(project: str, groups: list[str]) -> bool:
+    """Whether a recent run already covered every one of these groups.
+
+    All, not any: a task that also broke an unanalysed manifest is still worth a run.
+    """
+    with _seen_groups_lock:
+        return bool(groups) and all((project, g) in _seen_groups for g in groups)
+
+
+def _claim_groups(project: str, groups: list[str]) -> list[tuple[str, str]]:
+    """Record the groups a run covers; returns the keys to release if it fails."""
+    keys = [(project, group) for group in groups]
+    with _seen_groups_lock:
+        for key in keys:
+            _seen_groups[key] = True
+    return keys
 
 
 def _test_runs_today() -> int:
@@ -500,6 +535,8 @@ def _trigger_test_repair(
         _release_test_run()
         return None
 
+    group_keys = _claim_groups(project, test_groups)
+
     try:
         run_id = client.trigger_run(
             {"failure_tasks": {label: task_id}},
@@ -510,6 +547,7 @@ def _trigger_test_repair(
             "Failed to trigger test-repair run for task %s -- %s", task_id, job_link
         )
         _release(_seen_tests, _seen_tests_lock, [hg_revision])
+        _release(_seen_groups, _seen_groups_lock, group_keys)
         _release_test_run()
         return None
 

--- a/services/hackbot-pulse-listener/app/consumer.py
+++ b/services/hackbot-pulse-listener/app/consumer.py
@@ -273,6 +273,18 @@ def _process_test(body: dict, tags: dict, executor: Executor) -> str | None:
     # once. The same record carries the configuration the regression check compares
     # against.
     job = treeherder.job_for_task(project, task_id)
+    # Populated at ingestion, so this needs no wait for a sheriff to star the job.
+    intermittent = treeherder.intermittent_match(project, job)
+    if intermittent.known:
+        logger.info(
+            "Task %s failed only lines already known in this revision and tracked by "
+            "intermittent bug(s) %s; skipping -- %s",
+            task_id,
+            ", ".join(str(bug) for bug in intermittent.bug_ids),
+            job_link,
+        )
+        return None
+
     reason = treeherder.await_skip_reason(project, task_id, job)
     if reason:
         logger.info(

--- a/services/hackbot-pulse-listener/app/consumer.py
+++ b/services/hackbot-pulse-listener/app/consumer.py
@@ -164,6 +164,21 @@ def _process_build(body: dict, tags: dict, executor: Executor) -> str | None:
         )
         return None
 
+    # Builds bust for reasons no commit caused -- a timed-out fetch, a toolchain or
+    # signing hiccup -- which Treeherder classifies as infra; the agent otherwise
+    # reports that the push is innocent. Read after the walk rather than before it:
+    # by then Treeherder has had minutes to ingest and classify, and this costs one
+    # request instead of the wait the test path pays.
+    reason = treeherder.recheck_skip_reason(project, task_id)
+    if reason:
+        logger.info(
+            "Treeherder classified build task %s as %s; skipping -- %s",
+            task_id,
+            reason,
+            job_link,
+        )
+        return None
+
     with _seen_lock:
         if hg_revision in _seen:
             logger.info(

--- a/services/hackbot-pulse-listener/app/consumer.py
+++ b/services/hackbot-pulse-listener/app/consumer.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import threading
 import time
 from collections import deque
@@ -27,6 +28,9 @@ EXCHANGES = ("exchange/taskcluster-queue/v1/task-failed",)
 # are closer to a build than to a test, and none is repaired by the agent's method
 # (clone, build Firefox, re-run the failing test with mach). Left out for now.
 TEST_KINDS = {"test", "mochitest", "web-platform-tests"}
+
+# "test-verify" and its "-tv" chunked variants, anywhere in the label.
+_TEST_VERIFY = re.compile(r"(^|[-/])test-verify([-/]|$)")
 
 # In-memory dedupe of hg revisions already handed to the build-repair agent. A
 # revision is recorded only once we actually trigger a run, so an inherited
@@ -243,6 +247,19 @@ def _process_test(body: dict, tags: dict, executor: Executor) -> str | None:
         logger.info(
             "Task %s (%s) was scheduled by an action task, not by the push "
             "(backfill or retrigger); skipping -- %s",
+            task_id,
+            label,
+            job_link,
+        )
+        return None
+
+    # test-verify re-runs the tests the push itself changed, many times over, to shake
+    # out flakiness. Ancestors rarely ran the same thing, so the regression check
+    # cannot settle and fails open: in a dry run every test-verify task seen reached
+    # the agent, against 2% of tasks overall.
+    if _TEST_VERIFY.search(label):
+        logger.info(
+            "Task %s (%s) is a test-verify task; skipping -- %s",
             task_id,
             label,
             job_link,

--- a/services/hackbot-pulse-listener/app/notify.py
+++ b/services/hackbot-pulse-listener/app/notify.py
@@ -147,15 +147,16 @@ def _recipients(primary: str | None, secondary: str | None = None) -> list[str]:
     return recipients
 
 
+# The headline names the sheriff's action, which is always a backout.
 _RECOMMENDATION_BANNER = {
     "backout": "BACK OUT the culprit",
     "do_not_backout": "DO NOT back out (intermittent)",
-    "land_fix": "LAND the proposed fix",
+    "land_fix": "BACK OUT the culprit, reland with the proposed fix squashed in",
 }
 
 
 def _banner(findings: dict) -> str:
-    """The recommendation as a human-readable headline."""
+    """The recommendation as a human-readable headline, or the raw value."""
     recommendation = findings.get("recommendation")
     return _RECOMMENDATION_BANNER.get(recommendation, recommendation or "analysis")
 
@@ -216,8 +217,19 @@ def _build_test_repair_body(
         lines.append(f"- **Bug:** [{bug}]({_bug_url(bug)})")
 
     lines += _run_details(ctx) + _analysis_sections(findings) + _patch_section(patch)
-    lines += _team_footer()
+    lines += _patch_advice(patch) + _team_footer()
     return "\n".join(lines)
+
+
+def _patch_advice(patch: str | None) -> list[str]:
+    """Say who the patch is for, next to the patch itself."""
+    if not patch:
+        return []
+    return [
+        "",
+        "_For the author: squash this into your existing patches and reland. It is a "
+        "suggestion, not a follow-up to land on its own._",
+    ]
 
 
 def _run_details(ctx: RunContext) -> list[str]:

--- a/services/hackbot-pulse-listener/app/notify.py
+++ b/services/hackbot-pulse-listener/app/notify.py
@@ -12,18 +12,23 @@ PATCH_ARTIFACT = "changes/changes.patch"
 MAX_PATCH_LINES = 400
 
 
-def send_email(ctx: RunContext, run_doc: dict) -> None:
+def send_email(
+    ctx: RunContext, run_doc: dict, already_actioned: str | None = None
+) -> None:
     """Email the failure analysis. Only succeeded runs are notified.
 
     Routes on the agent that produced the run: test-repair sends a
     verdict-led body to the test-repair notification address; build-repair keeps its
     existing behavior.
+
+    ``already_actioned`` is Treeherder's classification when a sheriff has already
+    dealt with the failure.
     """
     if run_doc.get("status") != "succeeded":
         logger.info("Run %s did not succeed; skipping notification", ctx.run_id)
         return
     if ctx.agent == settings.test_repair_agent_name:
-        _send_test_repair_email(ctx, run_doc)
+        _send_test_repair_email(ctx, run_doc, already_actioned)
     else:
         _send_build_repair_email(ctx, run_doc)
 
@@ -52,7 +57,9 @@ def _send_build_repair_email(ctx: RunContext, run_doc: dict) -> None:
     _deliver(subject, body_md, recipients, patch)
 
 
-def _send_test_repair_email(ctx: RunContext, run_doc: dict) -> None:
+def _send_test_repair_email(
+    ctx: RunContext, run_doc: dict, already_actioned: str | None = None
+) -> None:
     findings = (run_doc.get("summary") or {}).get("findings") or {}
     culprit = findings.get("culprit_commit")
     culprit_author = (
@@ -77,10 +84,15 @@ def _send_test_repair_email(ctx: RunContext, run_doc: dict) -> None:
         return
 
     patch = _fetch_patch(ctx.run_id, run_doc)
+    # In the subject too, so a sheriff can skip it from the inbox.
+    prefix = "[already actioned] " if already_actioned else ""
     subject = (
-        f"[test-repair] {_banner(findings)} - {_test_groups_label(ctx)} ({ctx.repo})"
+        f"[test-repair] {prefix}{_banner(findings)} - "
+        f"{_test_groups_label(ctx)} ({ctx.repo})"
     )
-    body_md = _build_test_repair_body(ctx, findings, patch, culprit_author)
+    body_md = _build_test_repair_body(
+        ctx, findings, patch, culprit_author, already_actioned
+    )
     _deliver(subject, body_md, recipients, patch)
 
 
@@ -169,14 +181,28 @@ def _test_groups_label(ctx: RunContext) -> str:
     return f"{first} (+{len(rest)} more)" if rest else first
 
 
+def _already_actioned_banner(reason: str | None) -> list[str]:
+    """Say up front that the tree has been dealt with, when it has."""
+    if not reason:
+        return []
+    return [
+        f"> **Already actioned by a sheriff.** Treeherder now classifies this job as "
+        f"_{reason}_, so the tree has been dealt with and this analysis needs no "
+        f"action from a sheriff. It is sent for the developer's reland.",
+        "",
+    ]
+
+
 def _build_test_repair_body(
     ctx: RunContext,
     findings: dict,
     patch: str | None,
     culprit_author: str | None,
+    already_actioned: str | None = None,
 ) -> str:
     groups = ", ".join(f"`{g}`" for g in ctx.test_groups) or "not resolved"
     lines = [
+        *_already_actioned_banner(already_actioned),
         "# Test failure analysis",
         "",
         f"- **Recommendation:** {_banner(findings)}",

--- a/services/hackbot-pulse-listener/app/notify.py
+++ b/services/hackbot-pulse-listener/app/notify.py
@@ -326,6 +326,8 @@ def _build_body(
 ) -> str:
     summary = run_doc.get("summary") or {}
     findings = summary.get("findings") or {}
+    # A null verdict is the agent clearing the push; an absent one is no verdict.
+    cleared = "blamed_commit" in findings and not findings["blamed_commit"]
     blamed_commit = findings.get("blamed_commit")
 
     lines = [
@@ -339,7 +341,12 @@ def _build_body(
         f"[jobs]({treeherder.job_url(ctx.repo, ctx.hg_revision, ctx.task_id)})",
     ]
 
-    if blamed_commit:
+    if cleared:
+        lines.append(
+            "- **Not caused by this push:** the failure is pre-existing or "
+            "infrastructure, so no commit here is blamed."
+        )
+    elif blamed_commit:
         by = f" by {blamed_author}" if blamed_author else ""
         lines.append(
             f"- **Likely culprit:** "

--- a/services/hackbot-pulse-listener/app/treeherder.py
+++ b/services/hackbot-pulse-listener/app/treeherder.py
@@ -22,12 +22,23 @@ from urllib.parse import quote
 
 import httpx
 from cachetools import TTLCache
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
 
 from app.config import settings
 
 logger = logging.getLogger(__name__)
 
 _TIMEOUT = 15
+# Treeherder 502s under load. A failed read makes the caller fail open and spend a
+# run, so transient statuses are retried before that happens.
+_RETRY_STATUS = {429, 502, 503, 504}
+_ATTEMPTS = 3
 
 # Read-through caches, so one ancestor walk fetches each push once instead of once
 # per failing group, and the many failing tasks of a push share a fetch. The TTL is
@@ -75,6 +86,33 @@ def job_url(project: str, revision: str | None, task_id: str) -> str:
     return f"{push_url(project, revision)}&selectedTaskRun={task_id}"
 
 
+def _is_transient(exc: BaseException) -> bool:
+    if isinstance(exc, httpx.TransportError):
+        return True
+    return (
+        isinstance(exc, httpx.HTTPStatusError)
+        and exc.response.status_code in _RETRY_STATUS
+    )
+
+
+@retry(
+    retry=retry_if_exception(_is_transient),
+    stop=stop_after_attempt(_ATTEMPTS),
+    wait=wait_exponential_jitter(initial=2, max=15, jitter=1),
+    before_sleep=before_sleep_log(logger, logging.INFO),
+    reraise=True,
+)
+def _fetch(url: str) -> httpx.Response:
+    """GET, retrying the transient failures Treeherder returns under load.
+
+    A caller that cannot read fails open and spends an agent run, so a single 502 --
+    routine on this API -- must not be taken as an answer.
+    """
+    resp = httpx.get(url, timeout=_TIMEOUT, follow_redirects=True)
+    resp.raise_for_status()
+    return resp
+
+
 def _job(project: str, task_id: str) -> dict | None:
     """The Treeherder job for a Taskcluster task, or None if not ingested yet.
 
@@ -86,17 +124,13 @@ def _job(project: str, task_id: str) -> dict | None:
         f"{settings.treeherder_url.rstrip('/')}/api/project/{project}/jobs/"
         f"?task_id={task_id}"
     )
-    resp = httpx.get(url, timeout=_TIMEOUT, follow_redirects=True)
-    resp.raise_for_status()
-    results = resp.json().get("results") or []
+    results = _fetch(url).json().get("results") or []
     return results[0] if results else None
 
 
 def _get(path: str) -> dict | list:
     url = f"{settings.treeherder_url.rstrip('/')}/api/project/{path}"
-    resp = httpx.get(url, timeout=_TIMEOUT, follow_redirects=True)
-    resp.raise_for_status()
-    return resp.json()
+    return _fetch(url).json()
 
 
 def group_results(

--- a/services/hackbot-pulse-listener/app/treeherder.py
+++ b/services/hackbot-pulse-listener/app/treeherder.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
+from dataclasses import dataclass, field
 from urllib.parse import quote
 
 import httpx
@@ -37,6 +38,8 @@ _group_cache: TTLCache = TTLCache(maxsize=128, ttl=_TTL_SECONDS)
 _jobs_cache: TTLCache = TTLCache(maxsize=512, ttl=_TTL_SECONDS)
 # A revision never maps to a different push, so this one is held far longer.
 _push_id_cache: TTLCache = TTLCache(maxsize=512, ttl=6 * 60 * 60)
+# Derived from a parsed log, which no longer changes, so held longer than the rest.
+_bug_suggestions_cache: TTLCache = TTLCache(maxsize=512, ttl=30 * 60)
 _cache_lock = threading.Lock()
 
 # /api/failureclassification/
@@ -89,7 +92,7 @@ def _job(project: str, task_id: str) -> dict | None:
     return results[0] if results else None
 
 
-def _get(path: str) -> dict:
+def _get(path: str) -> dict | list:
     url = f"{settings.treeherder_url.rstrip('/')}/api/project/{path}"
     resp = httpx.get(url, timeout=_TIMEOUT, follow_redirects=True)
     resp.raise_for_status()
@@ -311,3 +314,83 @@ def skip_reason(job: dict | None) -> str | None:
     if classification in _NOT_A_REGRESSION:
         return _CLASSIFICATIONS.get(classification, str(classification))
     return None
+
+
+# Harness noise like "[taskcluster:error] exit status 1" matches unrelated bugs on
+# nearly every failing job, so only real failure lines are judged.
+_FAILURE_LINE_PREFIX = "TEST-UNEXPECTED-"
+_INTERMITTENT_KEYWORD = "intermittent-failure"
+
+
+def bug_suggestions(project: str, job_id: int) -> list[dict]:
+    """Treeherder's bug matches for a job, one entry per parsed failure line."""
+    key = (project, job_id)
+    with _cache_lock:
+        if key in _bug_suggestions_cache:
+            return _bug_suggestions_cache[key]
+
+    suggestions = _get(f"{project}/jobs/{job_id}/bug_suggestions/") or []
+    with _cache_lock:
+        _bug_suggestions_cache[key] = suggestions
+    return suggestions
+
+
+@dataclass(frozen=True)
+class IntermittentMatch:
+    """What Treeherder's bug suggestions say about a failing job.
+
+    ``known`` means every unexpected-failure line is both already seen in this
+    revision and matched to one of ``bug_ids``.
+    """
+
+    bug_ids: list[int] = field(default_factory=list)
+    known: bool = False
+
+
+def intermittent_match(project: str, job: dict | None) -> IntermittentMatch:
+    """Read the bug suggestions of a failing job and judge it a known intermittent.
+
+    Both signals are required: genuine regressions also match open intermittent bugs,
+    so the bug alone would drop them. Fails open on any error or missing data.
+    """
+    job_id = (job or {}).get("id")
+    if job_id is None:
+        return IntermittentMatch()
+
+    try:
+        lines = [
+            line
+            for line in bug_suggestions(project, job_id)
+            if (line.get("search") or "").startswith(_FAILURE_LINE_PREFIX)
+        ]
+        if not lines:
+            return IntermittentMatch()
+
+        bug_ids: list[int] = []
+        known = True
+        for line in lines:
+            matched = _open_intermittent_bugs(line)
+            bug_ids += [bug for bug in matched if bug not in bug_ids]
+            # A missing flag counts as new, never as known.
+            if not matched or line.get("failure_new_in_rev", True):
+                known = False
+        return IntermittentMatch(bug_ids, known)
+    except Exception:
+        logger.exception(
+            "Could not read the bug suggestions of job %s; investigating -- %s",
+            job_id,
+            job_url(project, None, (job or {}).get("task_id") or ""),
+        )
+        return IntermittentMatch()
+
+
+def _open_intermittent_bugs(suggestion: dict) -> list[int]:
+    """Ids of the unresolved intermittent-failure bugs a failure line matches."""
+    bugs = suggestion.get("bugs") or {}
+    matched = []
+    for bug in (bugs.get("open_recent") or []) + (bugs.get("all_others") or []):
+        keywords = (bug.get("keywords") or "").split(",")
+        if bug.get("id") and not bug.get("resolution"):
+            if _INTERMITTENT_KEYWORD in [k.strip() for k in keywords]:
+                matched.append(bug["id"])
+    return matched

--- a/services/hackbot-pulse-listener/app/worker.py
+++ b/services/hackbot-pulse-listener/app/worker.py
@@ -1,7 +1,7 @@
 import logging
 import time
 
-from app import client, notify
+from app import client, notify, treeherder
 from app.config import settings
 from app.models import RunContext
 
@@ -30,9 +30,33 @@ def poll_and_notify(ctx: RunContext) -> None:
         return
 
     try:
-        notify.send_email(ctx, run_doc)
+        notify.send_email(ctx, run_doc, _already_actioned(ctx))
     except Exception:
         logger.exception("Failed to send notification for run %s", ctx.run_id)
+
+
+def _already_actioned(ctx: RunContext) -> str | None:
+    """Treeherder's verdict now that the run has finished, or None.
+
+    A sheriff often acts while a run works. Never raises: the email goes out unmarked.
+    """
+    try:
+        reason = treeherder.recheck_skip_reason(ctx.repo, ctx.task_id)
+    except Exception:
+        logger.exception(
+            "Could not re-check the classification of task %s before notifying",
+            ctx.task_id,
+        )
+        return None
+    if reason:
+        logger.info(
+            "Task %s was classified as %s while run %s was working; "
+            "the notification will say so",
+            ctx.task_id,
+            reason,
+            ctx.run_id,
+        )
+    return reason
 
 
 def _poll_until_terminal(run_id: str) -> dict | None:

--- a/services/hackbot-pulse-listener/pyproject.toml
+++ b/services/hackbot-pulse-listener/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "markdown2>=2.4.0",
     "cachetools>=5.3.0",
     "sentry-sdk>=2.51.0",
+    "tenacity~=9.1.4",
     # mozci imports zstandard eagerly (default cache serializer) but only
     # declares it under its optional `cache` extra, so pull it in explicitly.
     "zstandard~=0.25.0",

--- a/services/hackbot-pulse-listener/tests/test_consumer.py
+++ b/services/hackbot-pulse-listener/tests/test_consumer.py
@@ -118,6 +118,7 @@ def test_build_failure_triggers_run_and_submits_poll():
     with (
         patch.object(consumer.taskcluster, "get_task", return_value=_task_def()),
         patch.object(consumer.lando, "hg_to_git", return_value="deadbeef"),
+        patch.object(consumer.treeherder, "recheck_skip_reason", return_value=None),
         patch.object(consumer.regression, "is_new_build_failure", return_value=True),
         patch.object(consumer.client, "trigger_run", return_value="run-1") as trigger,
     ):
@@ -144,6 +145,7 @@ def test_only_failure_tasks_sent_to_agent():
     with (
         patch.object(consumer.taskcluster, "get_task", return_value=_task_def()),
         patch.object(consumer.lando, "hg_to_git", return_value="deadbeef"),
+        patch.object(consumer.treeherder, "recheck_skip_reason", return_value=None),
         patch.object(consumer.regression, "is_new_build_failure", return_value=True),
         patch.object(consumer.client, "trigger_run", return_value="run-1") as trigger,
     ):
@@ -161,6 +163,7 @@ def test_same_revision_triggers_once():
     with (
         patch.object(consumer.taskcluster, "get_task", return_value=_task_def()),
         patch.object(consumer.lando, "hg_to_git", return_value="deadbeef"),
+        patch.object(consumer.treeherder, "recheck_skip_reason", return_value=None),
         patch.object(consumer.regression, "is_new_build_failure", return_value=True),
         patch.object(consumer.client, "trigger_run", return_value="run-1") as trigger,
     ):
@@ -174,6 +177,7 @@ def test_inherited_failure_is_skipped_before_mapping():
     executor = MagicMock()
     with (
         patch.object(consumer.taskcluster, "get_task", return_value=_task_def()),
+        patch.object(consumer.treeherder, "recheck_skip_reason", return_value=None),
         patch.object(consumer.regression, "is_new_build_failure", return_value=False),
         patch.object(consumer.lando, "hg_to_git") as hg_to_git,
         patch.object(consumer.client, "trigger_run") as trigger,
@@ -190,6 +194,7 @@ def test_multiple_builds_same_revision_trigger_once():
     with (
         patch.object(consumer.taskcluster, "get_task", return_value=_task_def()),
         patch.object(consumer.lando, "hg_to_git", return_value="deadbeef"),
+        patch.object(consumer.treeherder, "recheck_skip_reason", return_value=None),
         patch.object(consumer.regression, "is_new_build_failure", return_value=True),
         patch.object(consumer.client, "trigger_run", return_value="run-1") as trigger,
     ):
@@ -244,6 +249,7 @@ def test_backfilled_task_skipped_before_push_checks(fresh_push):
     backfill = _task_def(parent="ACTION-CALLBACK")
     with (
         patch.object(consumer.taskcluster, "get_task", return_value=backfill),
+        patch.object(consumer.treeherder, "recheck_skip_reason", return_value=None),
         patch.object(consumer.regression, "is_new_build_failure") as is_new,
         patch.object(consumer.client, "trigger_run") as trigger,
     ):
@@ -260,6 +266,7 @@ def test_stale_push_skipped_before_regression_check(fresh_push):
     fresh_push.return_value = True
     with (
         patch.object(consumer.taskcluster, "get_task", return_value=_task_def()),
+        patch.object(consumer.treeherder, "recheck_skip_reason", return_value=None),
         patch.object(consumer.regression, "is_new_build_failure") as is_new,
         patch.object(consumer.client, "trigger_run") as trigger,
     ):
@@ -280,6 +287,7 @@ def test_stale_push_is_not_marked_seen():
         patch.object(consumer.taskcluster, "get_task", return_value=_task_def()),
         patch.object(consumer.regression, "is_stale_push", side_effect=[True, False]),
         patch.object(consumer.lando, "hg_to_git", return_value="deadbeef"),
+        patch.object(consumer.treeherder, "recheck_skip_reason", return_value=None),
         patch.object(consumer.regression, "is_new_build_failure", return_value=True),
         patch.object(consumer.client, "trigger_run", return_value="run-1"),
     ):
@@ -293,6 +301,7 @@ def test_unmappable_revision_skipped():
     executor = MagicMock()
     with (
         patch.object(consumer.taskcluster, "get_task", return_value=_task_def()),
+        patch.object(consumer.treeherder, "recheck_skip_reason", return_value=None),
         patch.object(consumer.regression, "is_new_build_failure", return_value=True),
         patch.object(consumer.lando, "hg_to_git", return_value=None),
         patch.object(consumer.client, "trigger_run") as trigger,
@@ -308,6 +317,7 @@ def test_trigger_failure_releases_revision_for_retry():
     with (
         patch.object(consumer.taskcluster, "get_task", return_value=_task_def()),
         patch.object(consumer.lando, "hg_to_git", return_value="deadbeef"),
+        patch.object(consumer.treeherder, "recheck_skip_reason", return_value=None),
         patch.object(consumer.regression, "is_new_build_failure", return_value=True),
         patch.object(
             consumer.client, "trigger_run", side_effect=[RuntimeError("boom"), "run-2"]
@@ -767,6 +777,7 @@ def test_the_limit_does_not_apply_to_build_repair(env, monkeypatch):
     # The cap is on test-repair; build failures are far rarer and cheaper to judge.
     monkeypatch.setattr(consumer.settings, "max_test_repairs_per_day", 0)
     with (
+        patch.object(consumer.treeherder, "recheck_skip_reason", return_value=None),
         patch.object(consumer.regression, "is_new_build_failure", return_value=True),
         patch.object(consumer.lando, "hg_to_git", return_value="gitH"),
         patch.object(consumer.client, "trigger_run", return_value="br-1") as trigger,
@@ -1045,3 +1056,35 @@ def test_a_chunked_test_verify_task_is_skipped(env):
 
 def test_an_ordinary_task_is_not_mistaken_for_test_verify(env):
     assert consumer.process(_test_msg(), env.executor) == "tr-1"
+
+
+def _build_env(monkeypatch, reason=None, introduced=True):
+    trigger = MagicMock(return_value="run-1")
+    monkeypatch.setattr(consumer.taskcluster, "get_task", lambda tid: _task_def())
+    monkeypatch.setattr(consumer.lando, "hg_to_git", lambda rev: "deadbeef")
+    walk = MagicMock(return_value=introduced)
+    monkeypatch.setattr(consumer.regression, "is_new_build_failure", walk)
+    monkeypatch.setattr(
+        consumer.treeherder, "recheck_skip_reason", MagicMock(return_value=reason)
+    )
+    monkeypatch.setattr(consumer.client, "trigger_run", trigger)
+    return SimpleNamespace(trigger=trigger, walk=walk, executor=MagicMock())
+
+
+def test_an_infra_build_failure_is_skipped(monkeypatch):
+    env = _build_env(monkeypatch, reason="infra")
+    assert consumer.process(_build_msg(), env.executor) is None
+    env.trigger.assert_not_called()
+
+
+def test_a_classified_build_failure_is_read_after_the_walk(monkeypatch):
+    # Before the walk it would cost the ingest and classification waits the test
+    # path pays; after it, Treeherder has had minutes and it is one request.
+    env = _build_env(monkeypatch, reason="intermittent")
+    assert consumer.process(_build_msg(), env.executor) is None
+    env.walk.assert_called_once()
+
+
+def test_an_unclassified_build_failure_still_runs(monkeypatch):
+    env = _build_env(monkeypatch)
+    assert consumer.process(_build_msg(), env.executor) == "run-1"

--- a/services/hackbot-pulse-listener/tests/test_consumer.py
+++ b/services/hackbot-pulse-listener/tests/test_consumer.py
@@ -1028,3 +1028,20 @@ def _distinct_groups(env):
     env.failing_groups.side_effect = lambda project, rev, task_id: [
         f"{task_id}/mochitest.ini"
     ]
+
+
+def test_test_verify_tasks_are_skipped(env):
+    label = "test-linux2404-64/opt-test-verify"
+    assert consumer.process(_test_msg(label=label), env.executor) is None
+    env.job_for_task.assert_not_called()
+    env.trigger_run.assert_not_called()
+
+
+def test_a_chunked_test_verify_task_is_skipped(env):
+    label = "test-linux64/opt-test-verify-wpt-1"
+    assert consumer.process(_test_msg(label=label), env.executor) is None
+    env.trigger_run.assert_not_called()
+
+
+def test_an_ordinary_task_is_not_mistaken_for_test_verify(env):
+    assert consumer.process(_test_msg(), env.executor) == "tr-1"

--- a/services/hackbot-pulse-listener/tests/test_consumer.py
+++ b/services/hackbot-pulse-listener/tests/test_consumer.py
@@ -15,6 +15,7 @@ DECISION_TASK_ID = "DECISION"
 def setup_function():
     consumer._seen.clear()
     consumer._seen_tests.clear()
+    consumer._seen_groups.clear()
     consumer._test_run_times.clear()
 
 
@@ -584,11 +585,11 @@ def test_backfill_in_a_new_task_group_is_deduped(env):
 
 
 def test_different_pushes_are_not_deduped(env):
-    # Dedupe is per push: the same manifest newly failing on a later push is a
+    # Dedupe is per push: a different manifest newly failing on a later push is a
     # separate regression and must be investigated again.
-    revisions = iter(["rev-one", "rev-two"])
-    env.get_task.side_effect = lambda task_id: _task_def(next(revisions))
+    _consecutive_pushes(env, "rev-one", "rev-two")
     consumer.process(_test_msg(task_id="A"), env.executor)
+    env.failing_groups.return_value = ["other/test/mochitest.ini"]
     consumer.process(_test_msg(task_id="B"), env.executor)
     assert env.trigger_run.call_count == 2
 
@@ -704,6 +705,7 @@ def test_runs_stop_at_the_daily_limit(env, monkeypatch):
     monkeypatch.setattr(consumer.settings, "max_test_repairs_per_day", 2)
     revisions = iter(["rev-1", "rev-2", "rev-3"])
     env.get_task.side_effect = lambda task_id: _task_def(next(revisions))
+    _distinct_groups(env)
 
     assert consumer.process(_test_msg(task_id="A"), env.executor) == "tr-1"
     assert consumer.process(_test_msg(task_id="B"), env.executor) == "tr-1"
@@ -716,6 +718,7 @@ def test_the_limit_is_a_rolling_window(env, monkeypatch):
     monkeypatch.setattr(consumer.settings, "max_test_repairs_per_day", 1)
     revisions = iter(["rev-1", "rev-2"])
     env.get_task.side_effect = lambda task_id: _task_def(next(revisions))
+    _distinct_groups(env)
 
     assert consumer.process(_test_msg(task_id="A"), env.executor) == "tr-1"
     consumer._test_run_times[0] -= consumer._RATE_WINDOW_SECONDS + 1
@@ -752,6 +755,7 @@ def test_a_budget_blocked_task_does_not_claim_its_push(env, monkeypatch):
     monkeypatch.setattr(consumer.settings, "max_test_repairs_per_day", 1)
     revisions = iter(["rev-1", "rev-2", "rev-2"])
     env.get_task.side_effect = lambda task_id: _task_def(next(revisions))
+    env.failing_groups.side_effect = [[_GROUP], ["other/mochitest.ini"]] * 2
 
     assert consumer.process(_test_msg(task_id="A"), env.executor) == "tr-1"
     assert consumer.process(_test_msg(task_id="B"), env.executor) is None
@@ -944,3 +948,83 @@ def test_a_known_intermittent_does_not_claim_its_push(env):
 def test_no_intermittent_match_still_runs(env):
     env.intermittent_match.return_value = consumer.treeherder.IntermittentMatch()
     assert consumer.process(_test_msg(), env.executor) == "tr-1"
+
+
+def _consecutive_pushes(env, *revisions):
+    """Make each message look like it came from a different push."""
+    it = iter(revisions)
+    env.get_task.side_effect = lambda task_id: _task_def(next(it))
+
+
+def test_the_same_manifest_on_later_pushes_is_deduped(env):
+    _consecutive_pushes(env, "rev-one", "rev-two", "rev-three")
+    assert consumer.process(_test_msg(task_id="A"), env.executor) == "tr-1"
+    assert consumer.process(_test_msg(task_id="B"), env.executor) is None
+    assert consumer.process(_test_msg(task_id="C"), env.executor) is None
+    env.trigger_run.assert_called_once()
+
+
+def test_a_new_manifest_on_a_later_push_still_runs(env):
+    _consecutive_pushes(env, "rev-one", "rev-two")
+    assert consumer.process(_test_msg(task_id="A"), env.executor) == "tr-1"
+    env.failing_groups.return_value = ["layout/style/test/mochitest.toml"]
+    assert consumer.process(_test_msg(task_id="B"), env.executor) == "tr-1"
+    assert env.trigger_run.call_count == 2
+
+
+def test_one_unseen_manifest_is_enough_to_run(env):
+    _consecutive_pushes(env, "rev-one", "rev-two")
+    assert consumer.process(_test_msg(task_id="A"), env.executor) == "tr-1"
+    env.failing_groups.return_value = [_GROUP, "layout/style/test/mochitest.toml"]
+    assert consumer.process(_test_msg(task_id="B"), env.executor) == "tr-1"
+
+
+def test_manifest_dedupe_is_per_project():
+    consumer._claim_groups("autoland", [_GROUP])
+    assert consumer._groups_claimed("autoland", [_GROUP]) is True
+    assert consumer._groups_claimed("mozilla-central", [_GROUP]) is False
+
+
+def test_a_skipped_task_does_not_claim_its_manifests(env):
+    _consecutive_pushes(env, "rev-one", "rev-two")
+    env.await_skip_reason.side_effect = ["intermittent", None]
+    assert consumer.process(_test_msg(task_id="A"), env.executor) is None
+    assert consumer.process(_test_msg(task_id="B"), env.executor) == "tr-1"
+
+
+def test_a_failed_trigger_releases_the_manifests(env):
+    _consecutive_pushes(env, "rev-one", "rev-two")
+    env.trigger_run.side_effect = [RuntimeError("boom"), "tr-2"]
+    assert consumer.process(_test_msg(task_id="A"), env.executor) is None
+    assert consumer.process(_test_msg(task_id="B"), env.executor) == "tr-2"
+
+
+def test_a_group_less_task_is_not_suppressed_by_the_manifest_cache(env):
+    _consecutive_pushes(env, "rev-one", "rev-two")
+    assert consumer.process(_test_msg(task_id="A"), env.executor) == "tr-1"
+    env.failing_groups.side_effect = consumer.treeherder.GroupResultsUnavailable("none")
+    assert consumer.process(_test_msg(task_id="B"), env.executor) == "tr-1"
+
+
+def test_the_deduped_task_is_logged_with_a_treeherder_link(env, caplog):
+    _consecutive_pushes(env, "rev-one", "hgrev")
+    assert consumer.process(_test_msg(task_id="A"), env.executor) == "tr-1"
+    with caplog.at_level(logging.INFO, logger="app.consumer"):
+        assert consumer.process(_test_msg(task_id="TT"), env.executor) is None
+    assert "already investigated on a recent push" in caplog.text
+    assert _LINK in caplog.text
+
+
+def test_a_manifest_dedupe_costs_no_recheck(env):
+    _consecutive_pushes(env, "rev-one", "rev-two")
+    assert consumer.process(_test_msg(task_id="A"), env.executor) == "tr-1"
+    env.recheck_skip_reason.reset_mock()
+    assert consumer.process(_test_msg(task_id="B"), env.executor) is None
+    env.recheck_skip_reason.assert_not_called()
+
+
+def _distinct_groups(env):
+    """Give every task its own failing manifest, so only the gate under test applies."""
+    env.failing_groups.side_effect = lambda project, rev, task_id: [
+        f"{task_id}/mochitest.ini"
+    ]

--- a/services/hackbot-pulse-listener/tests/test_consumer.py
+++ b/services/hackbot-pulse-listener/tests/test_consumer.py
@@ -341,6 +341,9 @@ def env(monkeypatch):
         ),
         recheck_skip_reason=MagicMock(return_value=None),
         await_skip_reason=MagicMock(return_value=None),
+        intermittent_match=MagicMock(
+            return_value=consumer.treeherder.IntermittentMatch()
+        ),
         new_test_failures=MagicMock(
             side_effect=lambda p, r, cfg, groups, abort=None: set(groups)
         ),
@@ -357,6 +360,9 @@ def env(monkeypatch):
     )
     monkeypatch.setattr(
         consumer.treeherder, "await_skip_reason", mocks.await_skip_reason
+    )
+    monkeypatch.setattr(
+        consumer.treeherder, "intermittent_match", mocks.intermittent_match
     )
     monkeypatch.setattr(
         consumer.regression, "new_test_failures", mocks.new_test_failures
@@ -896,3 +902,45 @@ def test_the_group_less_walk_is_also_abandoned(env):
     env.is_new_task_failure.side_effect = consumer.regression.WalkAborted("task at rev")
     assert consumer.process(_test_msg(), env.executor) is None
     env.trigger_run.assert_not_called()
+
+
+def _known_intermittent(*bug_ids):
+    return consumer.treeherder.IntermittentMatch(list(bug_ids), known=True)
+
+
+def test_a_known_intermittent_bug_skips_before_waiting_for_a_verdict(env):
+    env.intermittent_match.return_value = _known_intermittent(2016093)
+    assert consumer.process(_test_msg(), env.executor) is None
+    env.await_skip_reason.assert_not_called()
+    env.failing_groups.assert_not_called()
+    env.trigger_run.assert_not_called()
+
+
+def test_the_skipped_bug_is_logged(env, caplog):
+    env.intermittent_match.return_value = _known_intermittent(2016093)
+    with caplog.at_level(logging.INFO, logger="app.consumer"):
+        assert consumer.process(_test_msg(), env.executor) is None
+    assert "2016093" in caplog.text
+    assert _LINK in caplog.text
+
+
+def test_the_ingested_job_is_what_the_gate_reads(env):
+    assert consumer.process(_test_msg(), env.executor) == "tr-1"
+    assert env.intermittent_match.call_args.args == (
+        "autoland",
+        env.job_for_task.return_value,
+    )
+
+
+def test_a_known_intermittent_does_not_claim_its_push(env):
+    env.intermittent_match.side_effect = [
+        _known_intermittent(2016093),
+        consumer.treeherder.IntermittentMatch(),
+    ]
+    assert consumer.process(_test_msg(task_id="A"), env.executor) is None
+    assert consumer.process(_test_msg(task_id="B"), env.executor) == "tr-1"
+
+
+def test_no_intermittent_match_still_runs(env):
+    env.intermittent_match.return_value = consumer.treeherder.IntermittentMatch()
+    assert consumer.process(_test_msg(), env.executor) == "tr-1"

--- a/services/hackbot-pulse-listener/tests/test_notify.py
+++ b/services/hackbot-pulse-listener/tests/test_notify.py
@@ -551,3 +551,65 @@ def test_an_unknown_recommendation_is_shown_verbatim():
         "backout_and_reland"
     )
     assert notify._banner({}) == "analysis"
+
+
+def test_already_actioned_body_leads_with_the_banner():
+    body = notify._build_test_repair_body(
+        _test_repair_ctx(),
+        _test_repair_findings(),
+        None,
+        None,
+        already_actioned="fixed by commit",
+    )
+    banner, _ = body.split("# Test failure analysis", 1)
+    assert "Already actioned by a sheriff" in banner
+    assert "fixed by commit" in banner
+    assert "BACK OUT the culprit" in body
+    assert "## Analysis" in body
+
+
+def test_an_unactioned_body_has_no_banner():
+    body = notify._build_test_repair_body(
+        _test_repair_ctx(), _test_repair_findings(), None, None
+    )
+    assert "Already actioned" not in body
+    assert body.startswith("# Test failure analysis")
+
+
+def test_already_actioned_is_marked_in_the_subject(monkeypatch):
+    monkeypatch.setattr(notify.settings, "sendgrid_api_key", "key")
+    monkeypatch.setattr(notify.settings, "notification_sender", "from@mozilla.com")
+    monkeypatch.setattr(
+        notify.settings, "notification_override_email", "me@mozilla.com"
+    )
+
+    run_doc = {"status": "succeeded", "summary": {"findings": _test_repair_findings()}}
+    fake_client = MagicMock()
+    fake_client.send.return_value = MagicMock(status_code=202)
+    with (
+        patch("sendgrid.SendGridAPIClient", return_value=fake_client),
+        patch.object(notify.github, "commit_author_email", return_value=None),
+    ):
+        notify.send_email(_test_repair_ctx(), run_doc, "fixed by commit")
+
+    message = fake_client.send.call_args.kwargs["message"].get()
+    assert message["subject"].startswith("[test-repair] [already actioned] ")
+    assert "Already actioned by a sheriff" in message["content"][0]["value"]
+
+
+def test_build_repair_ignores_the_actioned_flag(monkeypatch):
+    monkeypatch.setattr(notify.settings, "sendgrid_api_key", "key")
+    monkeypatch.setattr(notify.settings, "notification_sender", "from@mozilla.com")
+    monkeypatch.setattr(
+        notify.settings, "notification_override_email", "me@mozilla.com"
+    )
+    monkeypatch.setattr(notify.settings, "notify_only_with_patch", False)
+
+    run_doc = {"status": "succeeded", "summary": {"findings": {}}}
+    fake_client = MagicMock()
+    fake_client.send.return_value = MagicMock(status_code=202)
+    with patch("sendgrid.SendGridAPIClient", return_value=fake_client):
+        notify.send_email(_ctx(), run_doc, "fixed by commit")
+
+    message = fake_client.send.call_args.kwargs["message"].get()
+    assert "already actioned" not in message["subject"]

--- a/services/hackbot-pulse-listener/tests/test_notify.py
+++ b/services/hackbot-pulse-listener/tests/test_notify.py
@@ -613,3 +613,43 @@ def test_build_repair_ignores_the_actioned_flag(monkeypatch):
 
     message = fake_client.send.call_args.kwargs["message"].get()
     assert "already actioned" not in message["subject"]
+
+
+def _pre_existing_doc():
+    return {
+        "status": "succeeded",
+        "summary": {"findings": {"blamed_commit": None}},
+    }
+
+
+def test_a_cleared_push_blames_nobody():
+    body = notify._build_body(_ctx(), _pre_existing_doc())
+    assert "Likely culprit" not in body
+    assert "Not caused by this push" in body
+
+
+def test_a_cleared_push_does_not_claim_an_author_introduced_it():
+    body = notify._build_body(
+        _ctx(), _pre_existing_doc(), blamed_author="innocent@mozilla.com"
+    )
+    assert "introduced the failure" not in body
+
+
+def test_no_verdict_is_not_reported_as_cleared():
+    # An absent blamed_commit is missing data, not the agent clearing the push.
+    body = notify._build_body(_ctx(), {"status": "succeeded", "summary": {}})
+    assert "Not caused by this push" not in body
+    assert "Likely culprit" not in body
+
+
+def test_a_cleared_push_does_not_mail_an_author(monkeypatch):
+    monkeypatch.setattr(notify.settings, "sendgrid_api_key", "k")
+    monkeypatch.setattr(notify.settings, "notification_sender", "from@mozilla.com")
+    monkeypatch.setattr(notify.settings, "notification_override_email", None)
+    monkeypatch.setattr(notify.settings, "notify_only_with_patch", False)
+    author = MagicMock(return_value="innocent@mozilla.com")
+    monkeypatch.setattr(notify.github, "commit_author_email", author)
+    with patch.object(notify, "_deliver") as deliver:
+        notify.send_email(_ctx(), _pre_existing_doc())
+    author.assert_not_called()
+    assert "innocent@mozilla.com" not in deliver.call_args.args[2]

--- a/services/hackbot-pulse-listener/tests/test_notify.py
+++ b/services/hackbot-pulse-listener/tests/test_notify.py
@@ -521,3 +521,33 @@ def test_attaches_patch_file(monkeypatch):
     assert len(attachments) == 1
     assert attachments[0]["filename"] == "changes.patch"
     assert base64.b64decode(attachments[0]["content"]).decode() == "DIFF-CONTENT"
+
+
+def test_the_headline_names_the_sheriffs_action_not_a_landing():
+    findings = _test_repair_findings(recommendation="land_fix")
+    body = notify._build_test_repair_body(_test_repair_ctx(), findings, None, None)
+    assert "LAND the proposed fix" not in body
+    assert "BACK OUT the culprit, reland with the proposed fix squashed in" in body
+
+
+def test_the_patch_is_presented_as_advice_for_a_squashed_reland():
+    findings = _test_repair_findings(recommendation="land_fix")
+    body = notify._build_test_repair_body(
+        _test_repair_ctx(), findings, "--- a/f\n+++ b/f\n", None
+    )
+    assert "squash this into your existing patches and reland" in body
+    assert "not a follow-up to land on its own" in body
+
+
+def test_no_patch_advice_without_a_patch():
+    body = notify._build_test_repair_body(
+        _test_repair_ctx(), _test_repair_findings(), None, None
+    )
+    assert "squash this into your existing patches" not in body
+
+
+def test_an_unknown_recommendation_is_shown_verbatim():
+    assert notify._banner({"recommendation": "backout_and_reland"}) == (
+        "backout_and_reland"
+    )
+    assert notify._banner({}) == "analysis"

--- a/services/hackbot-pulse-listener/tests/test_treeherder.py
+++ b/services/hackbot-pulse-listener/tests/test_treeherder.py
@@ -108,18 +108,16 @@ def test_not_ingested_returns_none(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _clear_group_cache():
-    for cache in (
+    caches = (
         treeherder._group_cache,
         treeherder._jobs_cache,
         treeherder._push_id_cache,
-    ):
+        treeherder._bug_suggestions_cache,
+    )
+    for cache in caches:
         cache.clear()
     yield
-    for cache in (
-        treeherder._group_cache,
-        treeherder._jobs_cache,
-        treeherder._push_id_cache,
-    ):
+    for cache in caches:
         cache.clear()
 
 
@@ -363,6 +361,151 @@ def test_await_skip_reason_gives_up_and_investigates(monkeypatch):
     ticks = iter([0.0, treeherder.settings.treeherder_classification_wait_seconds + 1])
     monkeypatch.setattr(treeherder.time, "monotonic", lambda: next(ticks))
     assert treeherder.await_skip_reason("autoland", "T1", _job(6)) is None
+
+
+def _bug(bug_id, resolution="", keywords="intermittent-failure,intermittent-testcase"):
+    return {
+        "id": bug_id,
+        "status": "NEW",
+        "resolution": resolution,
+        "keywords": keywords,
+    }
+
+
+def _suggestion(search, new_in_rev, open_recent=(), all_others=()):
+    return {
+        "search": search,
+        "failure_new_in_rev": new_in_rev,
+        "bugs": {"open_recent": list(open_recent), "all_others": list(all_others)},
+    }
+
+
+_FAIL_LINE = "TEST-UNEXPECTED-FAIL | test_dataChannel.html | Test timed out."
+
+
+@pytest.fixture
+def suggestions(monkeypatch):
+    """Stub the bug_suggestions fetch; call it with the entries to return."""
+
+    def use(*entries):
+        monkeypatch.setattr(
+            treeherder, "bug_suggestions", lambda project, job_id: list(entries)
+        )
+
+    return use
+
+
+def _failing_job():
+    return {"id": 42, "task_id": "TT", "failure_classification_id": 1}
+
+
+def test_known_intermittent_needs_both_signals(suggestions):
+    suggestions(_suggestion(_FAIL_LINE, False, open_recent=[_bug(2016093)]))
+    match = treeherder.intermittent_match("autoland", _failing_job())
+    assert match.known is True
+    assert match.bug_ids == [2016093]
+
+
+def test_a_new_failure_with_an_intermittent_bug_still_runs(suggestions):
+    # Genuine regressions also match open intermittent bugs, so the bug alone
+    # must never be enough to skip.
+    suggestions(_suggestion(_FAIL_LINE, True, open_recent=[_bug(1828735)]))
+    match = treeherder.intermittent_match("autoland", _failing_job())
+    assert match.known is False
+    assert match.bug_ids == [1828735]
+
+
+def test_an_old_failure_without_a_bug_still_runs(suggestions):
+    suggestions(_suggestion(_FAIL_LINE, False))
+    assert treeherder.intermittent_match("autoland", _failing_job()).known is False
+
+
+def test_one_unknown_line_keeps_the_whole_job(suggestions):
+    suggestions(
+        _suggestion(_FAIL_LINE, False, open_recent=[_bug(2016093)]),
+        _suggestion("TEST-UNEXPECTED-FAIL | browser_startup.js | Got 1", True),
+    )
+    assert treeherder.intermittent_match("autoland", _failing_job()).known is False
+
+
+def test_harness_noise_does_not_decide(suggestions):
+    # Harness noise matches junk bugs on nearly every job.
+    suggestions(
+        _suggestion("[taskcluster:error] exit status 1", False, [_bug(2034259)]),
+        _suggestion(_FAIL_LINE, True),
+    )
+    match = treeherder.intermittent_match("autoland", _failing_job())
+    assert match.known is False
+    assert match.bug_ids == []
+
+
+def test_resolved_bugs_are_not_evidence(suggestions):
+    suggestions(
+        _suggestion(_FAIL_LINE, False, all_others=[_bug(1798750, "INCOMPLETE")])
+    )
+    match = treeherder.intermittent_match("autoland", _failing_job())
+    assert match.known is False
+    assert match.bug_ids == []
+
+
+def test_a_bug_without_the_keyword_is_not_evidence(suggestions):
+    suggestions(_suggestion(_FAIL_LINE, False, [_bug(2055984, keywords="regression")]))
+    assert treeherder.intermittent_match("autoland", _failing_job()).known is False
+
+
+def test_no_suggestions_fails_open(suggestions):
+    suggestions()
+    assert treeherder.intermittent_match("autoland", _failing_job()).known is False
+
+
+def test_a_suggestions_error_fails_open(monkeypatch):
+    def boom(project, job_id):
+        raise RuntimeError("treeherder down")
+
+    monkeypatch.setattr(treeherder, "bug_suggestions", boom)
+    assert treeherder.intermittent_match("autoland", _failing_job()).known is False
+
+
+def test_a_job_without_an_id_fails_open(monkeypatch):
+    monkeypatch.setattr(
+        treeherder,
+        "bug_suggestions",
+        lambda *_: pytest.fail("nothing to look up without a job id"),
+    )
+    assert treeherder.intermittent_match("autoland", None).known is False
+    assert treeherder.intermittent_match("autoland", {"task_id": "TT"}).known is False
+
+
+def test_a_missing_new_in_rev_flag_is_treated_as_new(suggestions):
+    entry = _suggestion(_FAIL_LINE, False, [_bug(2016093)])
+    del entry["failure_new_in_rev"]
+    suggestions(entry)
+    assert treeherder.intermittent_match("autoland", _failing_job()).known is False
+
+
+def test_bug_ids_are_deduped_across_lines(suggestions):
+    suggestions(
+        _suggestion(_FAIL_LINE, False, [_bug(2016093)]),
+        _suggestion(_FAIL_LINE + " (retry)", False, [_bug(2016093)]),
+    )
+    assert treeherder.intermittent_match("autoland", _failing_job()).bug_ids == [
+        2016093
+    ]
+
+
+def test_bug_suggestions_are_fetched_once_per_job(monkeypatch):
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append(url)
+        return _response([_suggestion(_FAIL_LINE, False)])
+
+    monkeypatch.setattr(treeherder.httpx, "get", fake_get)
+    assert treeherder.bug_suggestions("autoland", 42) == treeherder.bug_suggestions(
+        "autoland", 42
+    )
+    assert len(calls) == 1
+    assert calls[0].endswith("/project/autoland/jobs/42/bug_suggestions/")
 
 
 def test_push_url_points_at_the_push():

--- a/services/hackbot-pulse-listener/tests/test_treeherder.py
+++ b/services/hackbot-pulse-listener/tests/test_treeherder.py
@@ -526,3 +526,59 @@ def test_job_url_without_a_revision_still_selects_the_task():
     assert treeherder.job_url("autoland", None, "TT") == (
         "https://treeherder.mozilla.org/#/jobs?repo=autoland&selectedTaskRun=TT"
     )
+
+
+def _status_response(code, payload=None):
+    request = httpx.Request("GET", "https://treeherder.example/api")
+    return httpx.Response(code, json=payload or {}, request=request)
+
+
+@pytest.fixture(autouse=True)
+def no_retry_sleep(monkeypatch):
+    monkeypatch.setattr(treeherder._fetch.retry, "sleep", lambda s: None)
+
+
+def test_a_transient_status_is_retried_then_succeeds(monkeypatch):
+    responses = [_status_response(502), _status_response(200, {"ok": True})]
+    monkeypatch.setattr(treeherder.httpx, "get", lambda *a, **k: responses.pop(0))
+    assert treeherder._get("autoland/push/") == {"ok": True}
+    assert not responses
+
+
+def test_a_transient_status_raises_once_the_retries_are_spent(monkeypatch):
+    calls = []
+
+    def fake_get(*a, **k):
+        calls.append(1)
+        return _status_response(502)
+
+    monkeypatch.setattr(treeherder.httpx, "get", fake_get)
+    with pytest.raises(httpx.HTTPStatusError):
+        treeherder._get("autoland/push/")
+    assert len(calls) == treeherder._ATTEMPTS
+
+
+def test_a_network_error_is_retried(monkeypatch):
+    outcomes = [httpx.ConnectError("boom"), _status_response(200, {"ok": True})]
+
+    def fake_get(*a, **k):
+        outcome = outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr(treeherder.httpx, "get", fake_get)
+    assert treeherder._get("autoland/push/") == {"ok": True}
+
+
+def test_a_real_error_is_not_retried(monkeypatch):
+    calls = []
+
+    def fake_get(*a, **k):
+        calls.append(1)
+        return _status_response(404)
+
+    monkeypatch.setattr(treeherder.httpx, "get", fake_get)
+    with pytest.raises(httpx.HTTPStatusError):
+        treeherder._get("autoland/push/")
+    assert len(calls) == 1

--- a/services/hackbot-pulse-listener/tests/test_worker.py
+++ b/services/hackbot-pulse-listener/tests/test_worker.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import pytest
 from app import worker
 from app.models import RunContext
 
@@ -13,6 +14,15 @@ CTX = RunContext(
 )
 
 
+@pytest.fixture(autouse=True)
+def unactioned():
+    """Keep the pre-notification re-check off the network; no sheriff acted."""
+    with patch.object(
+        worker.treeherder, "recheck_skip_reason", return_value=None
+    ) as recheck:
+        yield recheck
+
+
 def test_terminal_run_notifies_once():
     run_doc = {"status": "succeeded", "summary": {}}
     with (
@@ -22,7 +32,7 @@ def test_terminal_run_notifies_once():
         worker.poll_and_notify(CTX)
 
     get_run.assert_called_once()
-    notify.send_email.assert_called_once_with(CTX, run_doc)
+    notify.send_email.assert_called_once_with(CTX, run_doc, None)
 
 
 def test_gives_up_after_max_age(monkeypatch):
@@ -37,3 +47,59 @@ def test_gives_up_after_max_age(monkeypatch):
 
     get_run.assert_called_once()
     notify.send_email.assert_not_called()
+
+
+def test_a_late_sheriff_action_marks_the_notification():
+    run_doc = {"status": "succeeded", "summary": {}}
+    with (
+        patch.object(worker.client, "get_run", return_value=run_doc),
+        patch.object(
+            worker.treeherder, "recheck_skip_reason", return_value="fixed by commit"
+        ),
+        patch.object(worker, "notify") as notify,
+    ):
+        worker.poll_and_notify(CTX)
+
+    notify.send_email.assert_called_once_with(CTX, run_doc, "fixed by commit")
+
+
+def test_an_unactioned_failure_notifies_unmarked():
+    run_doc = {"status": "succeeded", "summary": {}}
+    with (
+        patch.object(worker.client, "get_run", return_value=run_doc),
+        patch.object(worker.treeherder, "recheck_skip_reason", return_value=None),
+        patch.object(worker, "notify") as notify,
+    ):
+        worker.poll_and_notify(CTX)
+
+    notify.send_email.assert_called_once_with(CTX, run_doc, None)
+
+
+def test_the_analysis_is_still_sent_after_a_sheriff_acted():
+    run_doc = {"status": "succeeded", "summary": {}}
+    with (
+        patch.object(worker.client, "get_run", return_value=run_doc),
+        patch.object(
+            worker.treeherder, "recheck_skip_reason", return_value="fixed by commit"
+        ),
+        patch.object(worker, "notify") as notify,
+    ):
+        worker.poll_and_notify(CTX)
+
+    notify.send_email.assert_called_once()
+
+
+def test_a_failed_recheck_does_not_block_the_notification():
+    run_doc = {"status": "succeeded", "summary": {}}
+    with (
+        patch.object(worker.client, "get_run", return_value=run_doc),
+        patch.object(
+            worker.treeherder,
+            "recheck_skip_reason",
+            side_effect=RuntimeError("treeherder down"),
+        ),
+        patch.object(worker, "notify") as notify,
+    ):
+        worker.poll_and_notify(CTX)
+
+    notify.send_email.assert_called_once_with(CTX, run_doc, None)

--- a/uv.lock
+++ b/uv.lock
@@ -2695,6 +2695,7 @@ dependencies = [
     { name = "sendgrid" },
     { name = "sentry-sdk" },
     { name = "taskcluster" },
+    { name = "tenacity" },
     { name = "zstandard" },
 ]
 
@@ -2715,6 +2716,7 @@ requires-dist = [
     { name = "sendgrid", specifier = ">=6.12.5" },
     { name = "sentry-sdk", specifier = ">=2.51.0" },
     { name = "taskcluster", specifier = ">=97.1,<102.1" },
+    { name = "tenacity", specifier = "~=9.1.4" },
     { name = "zstandard", specifier = "~=0.25.0" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
This addresses various feedback from @Archaeopteryx, @marco-c, and Firefox developers. Some of it touches the agents, as the listener's code depends on them. Two main themes are to filter intermittent issues better and to clarify the output messages.

Commits are reviewable
