### PR TITLE
Report an auto-applied frontend triage to the owning team's Slack channel

### DIFF
--- a/agents/frontend-triage/README.md
+++ b/agents/frontend-triage/README.md
@@ -3,7 +3,9 @@
 Triages a Firefox desktop frontend bug from Bugzilla and produces a **root-cause
 analysis plus a proposed fix plan**. It reads the source tree, navigates the
 codebase with Searchfox, and inspects regressor changesets on hg.mozilla.org. It
-does **not** build Firefox, edit source, reproduce the bug, or write to Bugzilla.
+does **not** build Firefox, edit source, or reproduce the bug. It writes to
+Bugzilla only after the run, and only when it rated itself confident — see [What
+it writes back to Bugzilla](#what-it-writes-back-to-bugzilla).
 
 It deliberately stops at a plan: visual and interaction bugs can't be verified by
 the crash-reproduction loop the [`bug-fix`](../bug-fix/) agent relies on, so a
@@ -145,6 +147,36 @@ Two further hooks shape the comment text as it is recorded:
 Below both sits the runtime's shared footer inviting a 👍 or 👎 reaction. Those
 reactions and tags are the feedback channel — the agent does not request needinfo.
 
+## Slack notification
+
+A run that applies itself reports two lines to the channel of the team that owns
+the bug's component: the bug, linked, with the run's one-line summary, and a link
+to the run. An `S1` severity assessment adds a `:red_circle:` and names the level.
+Nothing else — the analysis is on the bug, the detail is in the run, and the
+channel already says which component this is.
+
+The audience is the team whose bug was just written to by nobody, so only an
+auto-applied run notifies. A medium or low result wrote nothing to Bugzilla and
+stays silent, even if someone applies it by hand later.
+
+Routing is `SLACK_CHANNELS` in `config.py`, keyed by `"<Product> :: <Component>"`
+— today just `Firefox :: New Tab Page` → `#hnt-dev`. A component that is not
+listed notifies nobody; there is deliberately no default channel, since posting one
+team's triage into another team's channel is worse than silence. Product and
+component come from the agent's `product`/`component` plan fields, because nothing
+else carries them out of a run whose only input is a bug id, so a garbled value
+matches no team and sends nothing.
+
+`notify.py` builds and records the message; the wording is code, not a model turn,
+so `slack.post_message` is _not_ in `ENABLED_ACTION_TYPES` and the agent is never
+given the tool. Like every other action it is recorded rather than sent, so it
+shows up in the Hackbot UI before it lands and is delivered at most once. Delivery
+needs `SLACK_BOT_TOKEN` on hackbot-api and the app in the channel — see
+`libs/hackbot-runtime/hackbot_runtime/actions/handlers/slack_handler.py`. A failed
+Slack post does not affect the Bugzilla writes, and it does not go the other way
+either: the applier runs each action independently, so a rejected `PUT` still
+notifies. The run page shows the failed action.
+
 ## Tuning
 
 `rules/` and `prompts/` both live under `hackbot_agents/frontend_triage/`.
@@ -167,5 +199,9 @@ Registered with `hackbot-api` as `FrontendTriageInputs` in
 `app/agents.py` (job `hackbot-agent-frontend-triage`). Local Compose runs don't
 need the API.
 
-There are no unit tests for this agent; CI covers the shared machinery it builds
-on via the `libs/agent-tools` and `libs/hackbot-runtime` suites.
+`tests/` covers what an unattended run's reach depends on: the record-time hooks
+(`test_hooks.py`), the plan parsing and `may_apply_unattended` (`test_plan.py`), and
+the Slack message and its routing (`test_notify.py`). Run them with
+`uv run --package hackbot-agent-frontend-triage pytest agents/frontend-triage/tests`.
+CI covers the shared machinery this builds on via the `libs/agent-tools` and
+`libs/hackbot-runtime` suites.

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/__main__.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/__main__.py
@@ -2,6 +2,7 @@ from hackbot_runtime import HackbotContext, run_async
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from .agent import FrontendTriageResult, run_frontend_triage
+from .notify import record_notification
 
 TRIAGE_TASK = (
     "Triage this Firefox desktop frontend bug. Investigate the source tree "
@@ -35,7 +36,7 @@ async def main(ctx: HackbotContext) -> FrontendTriageResult:
 
     await ctx.prepare_repo()
 
-    return await run_frontend_triage(
+    result = await run_frontend_triage(
         task=TRIAGE_TASK,
         bugzilla_mcp_server={
             "type": "http",
@@ -50,6 +51,11 @@ async def main(ctx: HackbotContext) -> FrontendTriageResult:
         verbose=True,
         actions_recorder=ctx.actions,
     )
+
+    # Recorded last, so it applies after the Bugzilla writes it reports. Only an
+    # auto-applied run in a component with a channel records anything -- see notify.py.
+    record_notification(ctx.actions, result, run_id=ctx.run_id)
+    return result
 
 
 if __name__ == "__main__":

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
@@ -85,6 +85,11 @@ class SeverityAssessment(BaseModel):
 
 class FrontendTriageResult(HackbotAgentResult):
     bug_id: int
+    # Where the bug lives, as the agent read it off Bugzilla. Reported rather than
+    # derived because nothing else carries it out of the run: the inputs are just a
+    # bug id. Only `notify.py` uses it, to pick the channel that owns the component.
+    product: str | None = None
+    component: str | None = None
     # Structured plan (best-effort, parsed from the agent's final message).
     summary: str | None = None
     root_cause: str | None = None
@@ -232,6 +237,11 @@ def parse_plan(text: str | None) -> dict:
             return [value]
         return value if isinstance(value, list) else None
 
+    def _as_str(value):
+        # A non-string would fail FrontendTriageResult's validation and lose the whole
+        # run's result, and these two only route a notification.
+        return value.strip() or None if isinstance(value, str) else None
+
     def _as_model(model, value):
         if not isinstance(value, dict):
             return None
@@ -244,6 +254,8 @@ def parse_plan(text: str | None) -> dict:
     if not isinstance(actionable, bool):
         actionable = None
     return {
+        "product": _as_str(data.get("product")),
+        "component": _as_str(data.get("component")),
         "summary": data.get("summary"),
         "root_cause": data.get("root_cause"),
         "proposed_fix": data.get("proposed_fix"),

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/config.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/config.py
@@ -42,6 +42,18 @@ ENABLED_ACTION_TYPES = [
     "bugzilla.update_bug",
 ]
 
+# Where an auto-applied run reports itself, by `"<Product> :: <Component>"`. A channel
+# belongs to the team that owns the component, so the routing does too: a component
+# that is not listed sends nothing, since posting one team's triage into another team's
+# channel is worse than silence. There is deliberately no default channel.
+#
+# `slack.post_message` is left out of `ENABLED_ACTION_TYPES` on purpose. The message is
+# code (see notify.py), not a model turn, so it goes through the recorder directly and
+# the agent is never given the tool — it has no say in what is said or where.
+SLACK_CHANNELS = {
+    "Firefox :: New Tab Page": "#hnt-dev",
+}
+
 # What a `bugzilla.update_bug` from this agent may touch. Enforced at record time
 # by `hooks.update_bug_hook`, so an out-of-bounds change is refused while the agent
 # can still correct it, rather than recorded and held for a human later.

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/notify.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/notify.py
@@ -1,0 +1,109 @@
+"""The Slack message an auto-applied run sends to the owning team's channel.
+
+Only a run that applies itself reports: at `confidence: high` a comment and a
+`severity`/`keywords` change reach the bug with nobody in between, and the team that
+owns the component has no other signal that it happened. A medium or low run wrote
+nothing to the bug, so there is nothing to tell anyone.
+
+Recorded as a ``slack.post_message`` action rather than posted from the run, so it is
+visible in the hackbot UI before it lands and the apply step delivers it at most once
+(see ``hackbot_runtime.actions.slack``, and ``agents/test-repair`` for the same shape).
+
+Two lines: the bug, and the run. The channel already says which product and component
+this is, the analysis is on the bug, and the detail is in the run -- so neither is
+repeated here. Confidence is not reported either, since only a `high` run gets this
+far. An S1 is the one thing worth pulling out of the bug, as it is the level someone
+may need to act on today.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from hackbot_runtime.actions.recorder import ActionsRecorder
+from hackbot_runtime.actions.slack import HACKBOT_UI_URL, record_message
+
+from .agent import FrontendTriageResult
+from .config import SLACK_CHANNELS
+
+logger = logging.getLogger(__name__)
+
+BUG_URL = "https://bugzilla.mozilla.org/show_bug.cgi?id={bug_id}"
+RUN_URL = HACKBOT_UI_URL.rstrip("/") + "/runs/{run_id}"
+
+# The severity that gets a marker. S2-S4 are ordinary triage outcomes; an S1 is
+# somebody's afternoon.
+URGENT_SEVERITY = "S1"
+
+
+def _link(url: str, label: str) -> str:
+    return f"<{url}|{label}>"
+
+
+def channel_for(product: str | None, component: str | None) -> str | None:
+    """The channel that owns ``product :: component``, or None if none does.
+
+    Fails closed on a component that is not in :data:`~.config.SLACK_CHANNELS`, and on
+    either half being missing -- both values are the agent's report of what it read off
+    Bugzilla, so a run that garbled them sends nothing rather than posting into a
+    channel that did not ask for it.
+    """
+    if not product or not component:
+        return None
+    return SLACK_CHANNELS.get(f"{product.strip()} :: {component.strip()}")
+
+
+def build_message(result: FrontendTriageResult, *, run_id: str) -> str:
+    """Render the notification for an auto-applied run."""
+    assessment = result.severity_assessment
+    suggested = (assessment.suggested or "") if assessment else ""
+    # The severity the run *judged*, which is not always the one it wrote to the bug:
+    # `rules/severity-assessment.md` holds back the field change when the severity
+    # confidence is not high. An S1 it only suspects is still worth flagging.
+    urgent = suggested.strip().upper() == URGENT_SEVERITY
+
+    headline = _link(BUG_URL.format(bug_id=result.bug_id), f"Bug {result.bug_id}")
+    if result.summary and result.summary.strip():
+        headline += f" — {result.summary.strip()}"
+    # The level is spelled out next to the emoji, so it still reads as an S1 for anyone
+    # whose client does not render one.
+    headline = f"*{headline}*"
+    if urgent:
+        headline = f":red_circle: {headline} ({URGENT_SEVERITY})"
+
+    return "\n".join(
+        [
+            headline,
+            _link(RUN_URL.format(run_id=run_id), "frontend-triage run details"),
+        ]
+    )
+
+
+def record_notification(
+    recorder: ActionsRecorder, result: FrontendTriageResult, *, run_id: str
+) -> dict | None:
+    """Record the run's Slack message, if it has one to send.
+
+    Returns the recorded action, or None when nothing is reported -- the run did not
+    mark itself safe to apply unattended, or its component has no channel. Lives here
+    rather than in ``__main__`` so the whole decision is testable without a
+    ``HackbotContext``.
+    """
+    if not result.auto_apply:
+        logger.info(
+            "Bug %s: not auto-applied, so nothing to report to Slack", result.bug_id
+        )
+        return None
+
+    channel = channel_for(result.product, result.component)
+    if channel is None:
+        logger.info(
+            "Bug %s: no Slack channel for %r :: %r; not reporting",
+            result.bug_id,
+            result.product,
+            result.component,
+        )
+        return None
+
+    logger.info("Bug %s: reporting triage to %s", result.bug_id, channel)
+    return record_message(recorder, channel, build_message(result, run_id=run_id))

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/prompts/system.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/prompts/system.md
@@ -108,6 +108,8 @@ After recording your comment, end your final message with a fenced ```json block
 
 ```json
 {{
+  "product": "Firefox",
+  "component": "New Tab Page",
   "summary": "one-line restatement of the bug",
   "root_cause": "the likely cause, or null if undetermined",
   "proposed_fix": "the approach a developer should take",
@@ -126,6 +128,7 @@ After recording your comment, end your final message with a fenced ```json block
 
 Field guidance for the handoff:
 
+- **`product`** and **`component`** — the bug's product and component, copied **verbatim** from Bugzilla (`get_bugs`), e.g. `"Firefox"` and `"New Tab Page"`. Do not infer them from the code you read or tidy up their spelling: they route a notification to the team that owns the component, and a value that isn't Bugzilla's own matches no team and notifies nobody. If the bug moved component while you were working, report where it is now.
 - **`actionable`** — `false` when the bug is out of scope or skipped per the scoping rules (meta/tracking, intermittent/test-infra, enhancement/task), or when there is simply nothing to fix-plan; `true` when you produced a real fix plan. The executor uses this to decide whether to act.
 - **`regressor_node`** — when the bug is a regression and you identified/confirmed the introducing changeset (via the `mozilla_vcs` tools or `get_blame`), put its hg node here so the executor has a direct pointer; otherwise `null`.
 - **`relevant_tests`** — existing tests that cover the affected area (typically browser-chrome mochitests under a component's `tests/browser/` dir, or xpcshell tests). These are the executor's **verification anchor** — it can run them. Use `[]` if you searched and found none (a signal that the executor should add a test).

--- a/agents/frontend-triage/tests/test_notify.py
+++ b/agents/frontend-triage/tests/test_notify.py
@@ -1,0 +1,134 @@
+"""Tests for the Slack notification an auto-applied run records.
+
+Pure functions, no network: nothing is posted from the run, so there is nothing to
+mock. What matters is that only an auto-applied run in a component with a channel
+records anything at all, since the alternative is posting into a channel that did not
+ask for it.
+"""
+
+from hackbot_agents.frontend_triage.agent import (
+    FrontendTriageResult,
+    SeverityAssessment,
+)
+from hackbot_agents.frontend_triage.notify import (
+    build_message,
+    channel_for,
+    record_notification,
+)
+from hackbot_runtime.actions import ActionsRecorder
+
+BUG_ID = 1968342
+RUN_ID = "1218e630-78c8"
+BUG_LINK = f"<https://bugzilla.mozilla.org/show_bug.cgi?id={BUG_ID}|Bug {BUG_ID}>"
+RUN_LINK = f"<https://hackbot.moz.tools/runs/{RUN_ID}|frontend-triage run details>"
+SUMMARY = "Weather widget shows the previous city after changing location"
+
+
+def _result(**overrides) -> FrontendTriageResult:
+    fields = {
+        "bug_id": BUG_ID,
+        "num_turns": 14,
+        "product": "Firefox",
+        "component": "New Tab Page",
+        "summary": SUMMARY,
+        "confidence": "high",
+        "actionable": True,
+        "auto_apply": True,
+        "severity_assessment": SeverityAssessment(
+            suggested="S3", confidence="high", rationale="visible but recoverable"
+        ),
+    }
+    return FrontendTriageResult(**{**fields, **overrides})
+
+
+def _message(**overrides) -> str:
+    return build_message(_result(**overrides), run_id=RUN_ID)
+
+
+def test_reports_the_bug_and_the_run_in_two_lines():
+    assert _message().splitlines() == [
+        f"*{BUG_LINK} — {SUMMARY}*",
+        RUN_LINK,
+    ]
+
+
+def test_an_s1_is_marked_and_named():
+    # The level is spelled out next to the emoji so it still reads as an S1 where the
+    # emoji doesn't render.
+    line = _message(
+        severity_assessment=SeverityAssessment(suggested="S1")
+    ).splitlines()[0]
+    assert line == f":red_circle: *{BUG_LINK} — {SUMMARY}* (S1)"
+
+
+def test_every_other_severity_is_unmarked():
+    for suggested in ("S2", "S3", "S4", None, "", "  "):
+        line = _message(
+            severity_assessment=SeverityAssessment(suggested=suggested)
+        ).splitlines()[0]
+        assert line == f"*{BUG_LINK} — {SUMMARY}*", suggested
+    # A run that could not assess severity reports none at all.
+    line = _message(severity_assessment=None).splitlines()[0]
+    assert line == f"*{BUG_LINK} — {SUMMARY}*"
+
+
+def test_a_lowercase_s1_is_still_an_s1():
+    # `suggested` is read out of the agent's free-form JSON block, so "s1" must not
+    # quietly read as an ordinary severity.
+    line = _message(
+        severity_assessment=SeverityAssessment(suggested=" s1 ")
+    ).splitlines()[0]
+    assert line.startswith(":red_circle: ")
+
+
+def test_a_missing_summary_leaves_the_bug_link_alone():
+    for summary in (None, "", "   "):
+        assert _message(summary=summary).splitlines() == [f"*{BUG_LINK}*", RUN_LINK]
+
+
+def test_the_channel_belongs_to_the_component():
+    assert channel_for("Firefox", "New Tab Page") == "#hnt-dev"
+    # Surrounding whitespace is the agent's, not Bugzilla's.
+    assert channel_for(" Firefox ", " New Tab Page ") == "#hnt-dev"
+
+
+def test_an_unowned_component_has_no_channel():
+    # Fails closed rather than falling back to a default: another team's channel is a
+    # worse outcome than silence.
+    assert channel_for("Firefox", "Address Bar") is None
+    assert channel_for("Core", "New Tab Page") is None
+    assert channel_for("Firefox", None) is None
+    assert channel_for(None, "New Tab Page") is None
+    assert channel_for("", "") is None
+
+
+def test_an_auto_applied_run_records_one_slack_action():
+    recorder = ActionsRecorder()
+    action = record_notification(recorder, _result(), run_id=RUN_ID)
+
+    assert action is not None
+    assert [a["type"] for a in recorder.actions] == ["slack.post_message"]
+    assert action["params"]["channel"] == "#hnt-dev"
+    assert action["params"]["text"] == build_message(_result(), run_id=RUN_ID)
+
+
+def test_a_run_that_was_not_auto_applied_reports_nothing():
+    # Medium and low results wrote nothing to the bug, so there is nothing to report.
+    recorder = ActionsRecorder()
+    assert (
+        record_notification(
+            recorder, _result(auto_apply=False, confidence="medium"), run_id=RUN_ID
+        )
+        is None
+    )
+    assert recorder.actions == []
+
+
+def test_a_run_in_an_unowned_component_reports_nothing():
+    recorder = ActionsRecorder()
+    assert (
+        record_notification(recorder, _result(component="Address Bar"), run_id=RUN_ID)
+        is None
+    )
+    assert record_notification(recorder, _result(component=None), run_id=RUN_ID) is None
+    assert recorder.actions == []

--- a/agents/frontend-triage/tests/test_plan.py
+++ b/agents/frontend-triage/tests/test_plan.py
@@ -41,6 +41,25 @@ def test_an_unusable_confidence_is_none():
         assert parse_confidence(raw) is None
 
 
+def test_parse_plan_carries_the_product_and_component():
+    # They route the Slack notification (see notify.py) and come from nowhere else --
+    # the run's inputs are just a bug id.
+    plan = parse_plan(_block('{"product": " Firefox ", "component": "New Tab Page"}'))
+    assert plan["product"] == "Firefox"
+    assert plan["component"] == "New Tab Page"
+
+
+def test_parse_plan_drops_an_unusable_product_or_component():
+    # A non-string would fail FrontendTriageResult's validation and lose the whole
+    # run's result over a field that only picks a channel.
+    plan = parse_plan(_block('{"product": 42, "component": ["New Tab Page"]}'))
+    assert plan["product"] is None
+    assert plan["component"] is None
+    plan = parse_plan(_block('{"summary": "s"}'))
+    assert plan["product"] is None
+    assert plan["component"] is None
+
+
 def test_parse_plan_normalizes_confidence():
     plan = parse_plan(_block('{"summary": "s", "confidence": "High"}'))
     assert plan["confidence"] == "high"


### PR DESCRIPTION
`5cf03b94` made frontend-triage apply its own results at `confidence: high`, so a triage comment and a `severity`/`keywords` change now reach a real bug with nobody in between. Nothing tells the team that owns the component it happened. Bugmail says the bug changed; it does not say an unreviewed agent is what changed it, which is the case worth watching while auto-apply is new.

## Change

An auto-applied run reports two lines to the channel of the team that owns the bug's component:

```
*<https://bugzilla.mozilla.org/show_bug.cgi?id=1968342|Bug 1968342> — Weather widget shows the previous city after changing location*
<https://hackbot.moz.tools/runs/abc123|frontend-triage run details>
```

An `S1` assessment adds a `:red_circle:` and names the level next to it, so it still reads as S1 in a client that does not render the emoji:

```
:red_circle: *<…|Bug 1971004> — New Tab crashes on startup when a pinned tile has no favicon* (S1)
<…|frontend-triage run details>
```

Nothing else is in the message. The channel already says which product and component this is, the analysis is on the bug, and the detail is in the run. Confidence is left out too, since only a `high` run gets this far. The severity reported is the one the run *judged*, which is not always the one it wrote to the bug — `rules/severity-assessment.md` holds the field change back when severity confidence is not high, and an S1 the agent only suspects is still worth flagging.

Only an auto-applied run reports. A medium or low result wrote nothing to Bugzilla, so there is nothing to tell anyone; it stays recorded and visible in the Hackbot UI as before.

## Reuse

Recorded as a `slack.post_message` action rather than posted from the run, so this reuses everything #6523 built for test-repair: visible in the UI before it lands, delivered at most once even though Pub/Sub is at-least-once, and no new secret or service code. **Nothing outside `agents/frontend-triage/` changes** — no `libs/`, no `services/`, no `pyproject.toml` (`slack-sdk` is already a `hackbot-runtime` dependency and the recording side does not import it).

`slack.post_message` is deliberately left out of `ENABLED_ACTION_TYPES`. The wording is code, in `notify.py`, so the agent is never given the tool and has no say in what is said or where. `record_message` goes through the recorder directly.

The existing `hooks.py` limits need no change: hooks are registered per action type, so `_check_only_one` cannot see a Slack action.

## Routing

`SLACK_CHANNELS` in `config.py` maps `"<Product> :: <Component>"` to a channel — today only `Firefox :: New Tab Page` → `#hnt-dev`. A component that is not listed sends nothing, and there is deliberately no default: posting one team's triage into another team's channel is worse than silence. Other frontend components stay silent until someone adds a line, which is an opt-in rather than a rollout to teams that have not asked for it.

Product and component come from the agent's plan block, because nothing else carries them out of a run whose only input is a bug id — `FrontendTriageInputs` is just `bug_id`, and the auto-apply decision point sees neither. `system.md` tells the agent to copy both verbatim from Bugzilla, and `parse_plan` drops a non-string rather than failing the whole result over a field that only picks a channel. A garbled value therefore matches no team and notifies nobody.

## Ordering

The Slack action is recorded last, so it has the highest `idx` and applies after the Bugzilla writes it reports. Its type differs from theirs, so `plan_coalesced_groups` will not pull it into the single `PUT /bug/{id}` that merges the comment with the field change — the one-bugmail behavior is unaffected.

No `{{actions.<ref>.<field>}}` placeholder is used. `AddCommentHandler` returns only `{bug_id, url}` where `url` is the plain `show_bug.cgi?id=<id>` page, which the message already builds itself, so a `ref` would buy nothing — and `_apply_pending_rows` drops a coalescing group whose rows carry a `ref`, so it would cost the merged PUT.

## Also fixed

Two stale README claims that predate this, fixed because the new section lands next to them: the summary said the agent never writes to Bugzilla, which the section 100 lines below it contradicts, and Registration said there are no unit tests, which stopped being true when `test_hooks.py` and `test_plan.py` landed.

## Testing

39 pass in `agents/frontend-triage/tests`, up from 28. New `tests/test_notify.py` has 11: the two message shapes line by line, a lowercase `s1` still marked (the value comes out of the agent's free-form JSON block), S2/S3/S4 and a null assessment unmarked, a missing summary degrading to the bug link alone, the channel lookup including whitespace and each half being absent, and the three cases that must record nothing — not auto-applied, unowned component, null component. `tests/test_plan.py` gains 2 for `product`/`component` round-tripping and for a non-string being dropped.

```sh
uv run --package hackbot-agent-frontend-triage pytest agents/frontend-triage/tests -q   # 39 passed
uv run --package hackbot-runtime pytest libs/hackbot-runtime/tests/test_slack_actions.py \
                                       libs/hackbot-runtime/tests/test_slack_handler.py -q   # 11 passed
```

`services/hackbot-api/tests/test_actions_applier.py` has 3 failures — `test_coalesces_update_and_comment_into_one_put`, `test_extra_comments_applied_separately`, `test_backward_placeholder_resolves_in_coalesced_comment`. They fail identically with this branch's changes stashed, so they are pre-existing on master and nothing here touches `services/`.

I have not yet confirmed a live post to `#hnt-dev`. The app has been invited to the channel, which settles `chat:write.public` and `not_in_channel`; what is untested is whether the channel restricts who may post.

## Tradeoffs worth a reviewer's attention

A rejected Bugzilla `PUT` still notifies. `_apply_pending_rows` applies each action independently, so if the write is refused — lost `editbugs`, a bug that went security-restricted mid-run — the message still goes out and reads as though triage landed. A reader clicking through sees no comment, and the run page shows the failed action. Making one action conditional on an earlier one's result is not something the applier can express today, and I did not think it worth building for this.

A manual apply posts too. Only a `high`-confidence run records the action, but if such a run's actions were held (auto-apply switched off for the agent) or retried by hand, the post happens then. The message says what was triaged, not that nobody reviewed it, so it stays accurate.

`SLACK_BOT_TOKEN` is not configured anywhere in this repo; it is attached to the hackbot-api Cloud Run service out of band and test-repair already depends on it. If it is unset the Slack row fails, visibly, without touching the Bugzilla rows.

`test-repair` and `bug-fix` are untouched. So is the severity-confidence gap noted in `rules/severity-assessment.md` — it predates this and belongs with the hooks, not the notification.
