### PR TITLE
Sanitize Phabricator summary headers

### DIFF
--- a/libs/hackbot-runtime/hackbot_runtime/actions/handlers/phabricator_handler.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/handlers/phabricator_handler.py
@@ -93,9 +93,23 @@ Bug #: {bug_id}
 # in the visible title only adds cleanup work when promoting to review.
 _WIP_PREFIX_RE = re.compile(r"^(?:WIP[: ]|WIP$)", re.IGNORECASE)
 
+# Phabricator reparses summaries as commit messages. Test Plan aliases at the
+# start of a line are interpreted as fields, making the summary ambiguous.
+_PHABRICATOR_TEST_PLAN_HEADER_RE = re.compile(
+    r"^(?=(?:Test Plan|Testplan|Tested|Tests):)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
 
 def _revision_title(title: str) -> str:
     return _WIP_PREFIX_RE.sub("", title).strip()
+
+
+def _sanitize_summary(summary: str | None) -> str | None:
+    """Indent lines Phabricator would parse as Test Plan field headers."""
+    if not summary:
+        return summary
+    return _PHABRICATOR_TEST_PLAN_HEADER_RE.sub(" ", summary)
 
 
 async def _revision_fields(revision_id: int) -> dict:
@@ -152,7 +166,7 @@ def _arc_commit_message(title: str, summary: str | None, bug_id: Any, url: str) 
     reconstructed commit reads identically to a moz-phab submission. Reviewers
     are always empty: hackbot never assigns them (draft submissions omit them).
     """
-    body = summary or ""
+    body = _sanitize_summary(summary) or ""
     if body:
         body += "\n"
     body += f"\nDifferential Revision: {url}"
@@ -219,7 +233,7 @@ class SubmitPatchHandler:
 
     async def apply(self, params: dict[str, Any], ctx: ApplyContext) -> ActionResult:
         bug_id = params["bug_id"]
-        summary = params.get("summary")
+        summary = _sanitize_summary(params.get("summary"))
 
         try:
             raw = await ctx.download_artifact(_DIFF_ARTIFACT_KEY)

--- a/libs/hackbot-runtime/hackbot_runtime/actions/handlers/phabricator_handler.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/handlers/phabricator_handler.py
@@ -93,23 +93,9 @@ Bug #: {bug_id}
 # in the visible title only adds cleanup work when promoting to review.
 _WIP_PREFIX_RE = re.compile(r"^(?:WIP[: ]|WIP$)", re.IGNORECASE)
 
-# Phabricator reparses summaries as commit messages. Test Plan aliases at the
-# start of a line are interpreted as fields, making the summary ambiguous.
-_PHABRICATOR_TEST_PLAN_HEADER_RE = re.compile(
-    r"^(?=(?:Test Plan|Testplan|Tested|Tests):)",
-    re.IGNORECASE | re.MULTILINE,
-)
-
 
 def _revision_title(title: str) -> str:
     return _WIP_PREFIX_RE.sub("", title).strip()
-
-
-def _sanitize_summary(summary: str | None) -> str | None:
-    """Indent lines Phabricator would parse as Test Plan field headers."""
-    if not summary:
-        return summary
-    return _PHABRICATOR_TEST_PLAN_HEADER_RE.sub(" ", summary)
 
 
 async def _revision_fields(revision_id: int) -> dict:
@@ -166,7 +152,7 @@ def _arc_commit_message(title: str, summary: str | None, bug_id: Any, url: str) 
     reconstructed commit reads identically to a moz-phab submission. Reviewers
     are always empty: hackbot never assigns them (draft submissions omit them).
     """
-    body = _sanitize_summary(summary) or ""
+    body = summary or ""
     if body:
         body += "\n"
     body += f"\nDifferential Revision: {url}"
@@ -233,7 +219,7 @@ class SubmitPatchHandler:
 
     async def apply(self, params: dict[str, Any], ctx: ApplyContext) -> ActionResult:
         bug_id = params["bug_id"]
-        summary = _sanitize_summary(params.get("summary"))
+        summary = params.get("summary")
 
         try:
             raw = await ctx.download_artifact(_DIFF_ARTIFACT_KEY)

--- a/libs/hackbot-runtime/hackbot_runtime/actions/phabricator.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/phabricator.py
@@ -13,9 +13,10 @@ argument wrong.
 
 from __future__ import annotations
 
+import re
 from typing import Annotated
 
-from agent_tools.registry import tool, tools_in
+from agent_tools.registry import ToolError, tool, tools_in
 from pydantic import Field
 
 from hackbot_runtime.actions.recorder import ActionsRecorder
@@ -25,9 +26,27 @@ from hackbot_runtime.actions.recorder import ActionsRecorder
 # in ``context.publish_changes`` — has to cover both types.
 PATCH_ACTION_TYPES = frozenset({"phabricator.submit_patch", "phabricator.update_patch"})
 
+_PHABRICATOR_TEST_PLAN_HEADER_RE = re.compile(
+    r"^(?:Test Plan|Testplan|Tested|Tests):",
+    re.IGNORECASE | re.MULTILINE,
+)
+
 
 def _confirm(recorder: ActionsRecorder, action_type: str) -> str:
     return f"Recorded {action_type} (#{len(recorder.actions) - 1})."
+
+
+def _validate_summary(summary: str | None) -> None:
+    if not summary:
+        return
+
+    match = _PHABRICATOR_TEST_PLAN_HEADER_RE.search(summary)
+    if match:
+        raise ToolError(
+            f'Invalid Phabricator summary: "{match.group()}" at the beginning of '
+            "a line is interpreted as a Test Plan field. Add a leading space or "
+            "rephrase that line, then call submit_patch again."
+        )
 
 
 @tool
@@ -48,7 +67,14 @@ async def submit_patch(
     ],
     summary: Annotated[
         str | None,
-        Field(default=None, description="Revision summary/description."),
+        Field(
+            default=None,
+            description=(
+                "Revision summary/description. Do not start a line with a Test "
+                "Plan header or alias such as Tests:, Test Plan:, Testplan:, or "
+                "Tested:; indent or rephrase it."
+            ),
+        ),
     ] = None,
     ref: Annotated[
         str | None,
@@ -80,6 +106,7 @@ async def submit_patch(
     in the same run, written as `{{actions.<ref>.url}}` (for example, inside a
     bug comment).
     """
+    _validate_summary(summary)
     recorder.record(
         "phabricator.submit_patch",
         {"bug_id": bug_id, "title": title, "summary": summary},

--- a/libs/hackbot-runtime/hackbot_runtime/actions/phabricator.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/phabricator.py
@@ -44,8 +44,8 @@ def _validate_summary(summary: str | None) -> None:
     if match:
         raise ToolError(
             f'Invalid Phabricator summary: "{match.group()}" at the beginning of '
-            "a line is interpreted as a Test Plan field. Add a leading space or "
-            "rephrase that line, then call submit_patch again."
+            "a line is interpreted as a Test Plan field. Call submit_patch again "
+            "with that fixed."
         )
 
 
@@ -67,14 +67,7 @@ async def submit_patch(
     ],
     summary: Annotated[
         str | None,
-        Field(
-            default=None,
-            description=(
-                "Revision summary/description. Do not start a line with a Test "
-                "Plan header or alias such as Tests:, Test Plan:, Testplan:, or "
-                "Tested:; indent or rephrase it."
-            ),
-        ),
+        Field(default=None, description="Revision summary/description."),
     ] = None,
     ref: Annotated[
         str | None,

--- a/libs/hackbot-runtime/tests/test_phabricator_actions.py
+++ b/libs/hackbot-runtime/tests/test_phabricator_actions.py
@@ -37,7 +37,7 @@ async def test_submit_rejects_test_plan_headers(header):
         )
 
     assert header in str(exc.value)
-    assert "Add a leading space or rephrase that line" in str(exc.value)
+    assert "Call submit_patch again with that fixed" in str(exc.value)
     assert rec.actions == []
 
 

--- a/libs/hackbot-runtime/tests/test_phabricator_actions.py
+++ b/libs/hackbot-runtime/tests/test_phabricator_actions.py
@@ -1,6 +1,7 @@
 """Tests for the phabricator recording tools (submit/update patch, comment)."""
 
 import pytest
+from agent_tools.registry import ToolError
 from hackbot_runtime.actions import ActionsRecorder, phabricator
 
 
@@ -17,6 +18,47 @@ async def test_submit_records_create_params_only():
         "summary": "Details",
     }
     assert "ref" not in action
+
+
+@pytest.mark.parametrize(
+    "header",
+    ["Tests", "tests", "Test Plan", "Testplan", "Tested"],
+)
+async def test_submit_rejects_test_plan_headers(header):
+    rec = ActionsRecorder()
+
+    with pytest.raises(ToolError) as exc:
+        await phabricator.submit_patch(
+            rec,
+            bug_id=1,
+            title="Fix",
+            reasoning="r",
+            summary=f"Explanation\n\n{header}: details",
+        )
+
+    assert header in str(exc.value)
+    assert "Add a leading space or rephrase that line" in str(exc.value)
+    assert rec.actions == []
+
+
+@pytest.mark.parametrize(
+    "summary",
+    [
+        None,
+        "",
+        "Testing: details",
+        "Some Tests: details",
+        " Tests: already indented",
+    ],
+)
+async def test_submit_accepts_safe_summary(summary):
+    rec = ActionsRecorder()
+
+    await phabricator.submit_patch(
+        rec, bug_id=1, title="Fix", reasoning="r", summary=summary
+    )
+
+    assert rec.actions[0]["params"]["summary"] == summary
 
 
 async def test_submit_requires_title():

--- a/libs/hackbot-runtime/tests/test_phabricator_handler.py
+++ b/libs/hackbot-runtime/tests/test_phabricator_handler.py
@@ -86,31 +86,6 @@ def test_revision_title_strips_wip_prefix():
     assert rt("WIP: Fix bug") == "Fix bug"
 
 
-@pytest.mark.parametrize(
-    "header",
-    ["Tests", "tests", "Test Plan", "Testplan", "Tested"],
-)
-def test_sanitize_summary_indents_test_plan_headers(header):
-    summary = f"Explanation\n\n{header}: details"
-    assert phabricator_handler._sanitize_summary(summary) == (
-        f"Explanation\n\n {header}: details"
-    )
-
-
-@pytest.mark.parametrize(
-    "summary",
-    [
-        None,
-        "",
-        "Testing: details",
-        "Some Tests: details",
-        " Tests: already indented",
-    ],
-)
-def test_sanitize_summary_leaves_safe_text_unchanged(summary):
-    assert phabricator_handler._sanitize_summary(summary) == summary
-
-
 async def test_submit_patch_creates_planned_changes_revision(monkeypatch):
     fake, calls = _fake_conduit(
         {
@@ -123,12 +98,8 @@ async def test_submit_patch_creates_planned_changes_revision(monkeypatch):
         phabricator_handler, "_repository_phid", AsyncMock(return_value="PHID-REPO-1")
     )
 
-    summary = (
-        "The migration picker now defaults to Documents.\n\n"
-        "Tests: `browser_file_migration.js` passes."
-    )
     result = await phabricator_handler.SubmitPatchHandler().apply(
-        {"bug_id": 1, "title": "Fix", "summary": summary},
+        {"bug_id": 1, "title": "Fix", "summary": "s"},
         _ctx(),
     )
 
@@ -152,7 +123,7 @@ async def test_submit_patch_creates_planned_changes_revision(monkeypatch):
     assert transactions["plan-changes"] is True
     assert "reviewers.add" not in transactions
     assert transactions["bugzilla.bug-id"] == "1"
-    assert transactions["summary"] == summary.replace("\nTests:", "\n Tests:")
+    assert transactions["summary"] == "s"
 
 
 async def test_submit_patch_sets_local_commits_property(monkeypatch):

--- a/libs/hackbot-runtime/tests/test_phabricator_handler.py
+++ b/libs/hackbot-runtime/tests/test_phabricator_handler.py
@@ -86,6 +86,31 @@ def test_revision_title_strips_wip_prefix():
     assert rt("WIP: Fix bug") == "Fix bug"
 
 
+@pytest.mark.parametrize(
+    "header",
+    ["Tests", "tests", "Test Plan", "Testplan", "Tested"],
+)
+def test_sanitize_summary_indents_test_plan_headers(header):
+    summary = f"Explanation\n\n{header}: details"
+    assert phabricator_handler._sanitize_summary(summary) == (
+        f"Explanation\n\n {header}: details"
+    )
+
+
+@pytest.mark.parametrize(
+    "summary",
+    [
+        None,
+        "",
+        "Testing: details",
+        "Some Tests: details",
+        " Tests: already indented",
+    ],
+)
+def test_sanitize_summary_leaves_safe_text_unchanged(summary):
+    assert phabricator_handler._sanitize_summary(summary) == summary
+
+
 async def test_submit_patch_creates_planned_changes_revision(monkeypatch):
     fake, calls = _fake_conduit(
         {
@@ -98,8 +123,12 @@ async def test_submit_patch_creates_planned_changes_revision(monkeypatch):
         phabricator_handler, "_repository_phid", AsyncMock(return_value="PHID-REPO-1")
     )
 
+    summary = (
+        "The migration picker now defaults to Documents.\n\n"
+        "Tests: `browser_file_migration.js` passes."
+    )
     result = await phabricator_handler.SubmitPatchHandler().apply(
-        {"bug_id": 1, "title": "Fix", "summary": "s"},
+        {"bug_id": 1, "title": "Fix", "summary": summary},
         _ctx(),
     )
 
@@ -123,6 +152,7 @@ async def test_submit_patch_creates_planned_changes_revision(monkeypatch):
     assert transactions["plan-changes"] is True
     assert "reviewers.add" not in transactions
     assert transactions["bugzilla.bug-id"] == "1"
+    assert transactions["summary"] == summary.replace("\nTests:", "\n Tests:")
 
 
 async def test_submit_patch_sets_local_commits_property(monkeypatch):


### PR DESCRIPTION
## Bug

Hackbot fails to submit a patch when the summary contains a line starting with `Tests:`. Phabricator treats `Tests` as an alias for the `Test Plan` field, so the summary is parsed ambiguously and rejected.

## Reproduction

Reproduced on `phabricator-dev.allizom.org`:

- `Tests: ...` is rejected with `ERR-CONDUIT-CORE ...`.
- ` Tests: ...` is accepted.

## Solution

Add one leading space to lines starting with a Test Plan alias, such as Tests:. This prevents Phabricator from parsing them as fields. Apply it to revision summaries and generated commit metadata.

Fixes #6547

