### PR TITLE
Add agent tags to Bugzilla comments

### DIFF
--- a/libs/hackbot-runtime/hackbot_runtime/actions/handlers/base.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/handlers/base.py
@@ -18,6 +18,7 @@ class ApplyContext:
     """
 
     run_id: str
+    agent: str
     download_artifact: Callable[[str], Awaitable[bytes]]
     attachments: list[dict[str, str]] = field(default_factory=list)
 

--- a/libs/hackbot-runtime/hackbot_runtime/actions/handlers/bugzilla_handler.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/handlers/bugzilla_handler.py
@@ -79,6 +79,7 @@ class UpdateBugHandler:
         body = dict(params.get("changes", {}))
         if params.get("comment"):
             body["comment"] = params["comment"]
+            body["comment_tags"] = [ctx.agent]
         try:
             _request("PUT", f"bug/{bug_id}", body)
         except Exception as exc:
@@ -90,7 +91,8 @@ class UpdateBugHandler:
 class AddCommentHandler:
     async def apply(self, params: dict[str, Any], ctx: ApplyContext) -> ActionResult:
         bug_id = params["bug_id"]
-        body = {"comment": _comment_body(params)}
+        body: dict[str, Any] = {"comment": _comment_body(params)}
+        body["comment_tags"] = [ctx.agent]
         try:
             _request("PUT", f"bug/{bug_id}", body)
         except Exception as exc:

--- a/libs/hackbot-runtime/tests/test_bugzilla_handler.py
+++ b/libs/hackbot-runtime/tests/test_bugzilla_handler.py
@@ -10,14 +10,17 @@ import base64
 from hackbot_runtime.actions.handlers import ApplyContext, bugzilla_handler
 
 
-def _ctx(attachments=None, artifacts=None):
+def _ctx(attachments=None, artifacts=None, agent="test-agent"):
     artifacts = artifacts or {}
 
     async def download(key):
         return artifacts[key]
 
     return ApplyContext(
-        run_id="run-1", download_artifact=download, attachments=attachments or []
+        run_id="run-1",
+        download_artifact=download,
+        attachments=attachments or [],
+        agent=agent,
     )
 
 
@@ -62,8 +65,36 @@ async def test_add_comment_handler_builds_comment_body(monkeypatch):
         (
             "PUT",
             "bug/5",
-            {"comment": {"body": "hi", "is_private": True, "is_markdown": True}},
+            {
+                "comment": {
+                    "body": "hi",
+                    "is_private": True,
+                    "is_markdown": True,
+                },
+                "comment_tags": ["test-agent"],
+            },
         )
+    ]
+
+
+async def test_comment_handlers_add_acting_agent_tag(monkeypatch):
+    bodies = []
+    monkeypatch.setattr(
+        bugzilla_handler, "_request", lambda _m, _p, body: bodies.append(body)
+    )
+
+    await bugzilla_handler.AddCommentHandler().apply(
+        {"bug_id": 5, "text": "standalone"},
+        _ctx(agent="frontend-triage"),
+    )
+    await bugzilla_handler.UpdateBugHandler().apply(
+        {"bug_id": 5, "changes": {}, "comment": {"body": "coalesced"}},
+        _ctx(agent="bug-fix"),
+    )
+
+    assert [body["comment_tags"] for body in bodies] == [
+        ["frontend-triage"],
+        ["bug-fix"],
     ]
 
 
@@ -128,7 +159,11 @@ async def test_update_bug_handler_merges_changes_and_comment(monkeypatch):
         (
             "PUT",
             "bug/7",
-            {"status": "RESOLVED", "comment": {"body": "done", "is_private": False}},
+            {
+                "status": "RESOLVED",
+                "comment": {"body": "done", "is_private": False},
+                "comment_tags": ["test-agent"],
+            },
         )
     ]
     # The caller's `changes` dict must not be mutated by folding in the comment.
@@ -144,7 +179,16 @@ async def test_update_bug_handler_comment_only(monkeypatch):
         {"bug_id": 7, "changes": {}, "comment": {"body": "hi", "is_private": True}},
         _ctx(),
     )
-    assert calls == [("PUT", "bug/7", {"comment": {"body": "hi", "is_private": True}})]
+    assert calls == [
+        (
+            "PUT",
+            "bug/7",
+            {
+                "comment": {"body": "hi", "is_private": True},
+                "comment_tags": ["test-agent"],
+            },
+        )
+    ]
 
 
 def test_plan_coalesced_groups_update_plus_comment():

--- a/libs/hackbot-runtime/tests/test_phabricator_handler.py
+++ b/libs/hackbot-runtime/tests/test_phabricator_handler.py
@@ -56,7 +56,7 @@ def _ctx(diff=_DIFF_PAYLOAD, local_commits=None):
         assert key == "changes/phabricator_diff.json"
         return json.dumps(submission).encode()
 
-    return ApplyContext(run_id="run-1", download_artifact=download)
+    return ApplyContext(run_id="run-1", agent="test-agent", download_artifact=download)
 
 
 def _fake_conduit(responses):
@@ -341,7 +341,7 @@ async def test_missing_artifact_fails(handler, params):
     async def download(key):
         raise KeyError(key)
 
-    ctx = ApplyContext(run_id="run-1", download_artifact=download)
+    ctx = ApplyContext(run_id="run-1", agent="test-agent", download_artifact=download)
     result = await getattr(phabricator_handler, handler)().apply(params, ctx)
     assert result.status == "failed"
     assert "No Phabricator submission artifact" in result.error
@@ -369,7 +369,7 @@ async def test_add_comment_posts_comment_transaction(monkeypatch):
 
     result = await phabricator_handler.AddCommentHandler().apply(
         {"revision_id": 42, "text": "Answering your question."},
-        ApplyContext(run_id="run-1", download_artifact=None),
+        ApplyContext(run_id="run-1", agent="test-agent", download_artifact=None),
     )
 
     assert result.status == "applied"
@@ -392,7 +392,7 @@ async def test_add_comment_conduit_error_fails(monkeypatch):
 
     result = await phabricator_handler.AddCommentHandler().apply(
         {"revision_id": 42, "text": "x"},
-        ApplyContext(run_id="run-1", download_artifact=None),
+        ApplyContext(run_id="run-1", agent="test-agent", download_artifact=None),
     )
     assert result.status == "failed"
     assert "ERR-CONDUIT-CORE" in result.error

--- a/libs/hackbot-runtime/tests/test_slack_handler.py
+++ b/libs/hackbot-runtime/tests/test_slack_handler.py
@@ -13,7 +13,7 @@ def _ctx():
     async def download(_key):
         raise AssertionError("Slack messages do not use artifacts")
 
-    return ApplyContext(run_id="run-1", download_artifact=download)
+    return ApplyContext(run_id="run-1", agent="test-agent", download_artifact=download)
 
 
 @pytest.fixture(autouse=True)

--- a/libs/hackbot-runtime/tests/test_testrail_handler.py
+++ b/libs/hackbot-runtime/tests/test_testrail_handler.py
@@ -7,7 +7,7 @@ def _ctx():
     async def download(_key):
         raise AssertionError("TestRail submissions do not use artifacts")
 
-    return ApplyContext(run_id="run-1", download_artifact=download)
+    return ApplyContext(run_id="run-1", agent="test-agent", download_artifact=download)
 
 
 def _plan():

--- a/services/hackbot-api/app/actions_applier.py
+++ b/services/hackbot-api/app/actions_applier.py
@@ -160,6 +160,7 @@ async def _dispatch(
             gcs.download_artifact_bytes(run_id, key)
         ),
         attachments=attachments,
+        agent=run.agent,
     )
     try:
         return await handler.apply(params, ctx)


### PR DESCRIPTION

updated Hackbot to tag Bugzilla comments with the acting agent’s name. It works for both standalone comments and comments included with bug updates,

Fixes #6554
