### PR TITLE
Route Android, installer, and updater bugs to their own channels and widen the frontend-triage prompt past the desktop frontend

### DIFF
--- a/agents/frontend-triage/README.md
+++ b/agents/frontend-triage/README.md
@@ -177,7 +177,7 @@ Routing is `SLACK_CHANNELS` in `config.py`, keyed by `"<Product> :: <Component>"
 
 | Product :: Component             | Channel                         |
 | -------------------------------- | ------------------------------- |
-| `Firefox :: New Tab Page`        | `#hnt-dev`                      |
+| `Firefox :: New Tab Page`        | `#hnt-dev-triage`               |
 | `Firefox for Android :: History` | `#android-core-dev`             |
 | `Toolkit :: Application Update`  | `#installer-updater-bug-triage` |
 | `Firefox :: Installer`           | `#installer-updater-bug-triage` |

--- a/agents/frontend-triage/README.md
+++ b/agents/frontend-triage/README.md
@@ -1,6 +1,6 @@
 # frontend-triage agent
 
-Triages a Firefox desktop frontend bug from Bugzilla and produces a **root-cause
+Triages a user-facing Firefox bug from Bugzilla and produces a **root-cause
 analysis plus a proposed fix plan**. It reads the source tree, navigates the
 codebase with Searchfox, and inspects regressor changesets on hg.mozilla.org. It
 does **not** build Firefox, edit source, or reproduce the bug. It writes to
@@ -13,14 +13,28 @@ human (or a downstream execution agent) takes it from there.
 
 ## What it triages
 
-Firefox desktop **frontend defects** — the kind documented with a screenshot or
-steps to reproduce rather than a stack trace: Tabbed Browser (incl. Split View
-and Tab Groups), New Tab Page, Address Bar, Menus, Toolbars and Customization,
-Sidebar, Theme.
+**Defects in user-facing Firefox** — the kind documented with a screenshot, steps
+to reproduce, or a log rather than a stack trace:
+
+- **Desktop frontend**, under `Firefox`: Tabbed Browser (incl. Split View and Tab
+  Groups), New Tab Page, Address Bar, Menus, Toolbars and Customization, Sidebar,
+  Theme.
+- **Firefox for Android**: History. Kotlin under `mobile/android/fenix/`.
+- **Install and update**: `Firefox :: Installer` (NSIS) and
+  `Toolkit :: Application Update` (`.sys.mjs`, IDL, C++).
+
+Install and update bugs are the odd ones out: they arrive as a failure with an
+error code and an `update.log` or installer log, usually with no steps to
+reproduce and no screenshot. That is the normal shape of a bug in that area, so
+`frontend-triage.md` says so explicitly — otherwise the ruleset's papercut
+framing reads as a reason to skip them. `severity-assessment.md` starts them at
+S2 rather than the S3 a papercut would get, since a user who cannot update is
+left on an unpatched build with no in-product workaround.
 
 Poor fits: crashes, hangs, assertions and sanitizer reports (those belong to
-[`bug-fix`](../bug-fix/)), anything with no frontend component, and bugs whose
-fix can only be judged by _seeing_ the rendered result.
+[`bug-fix`](../bug-fix/)) — note that "the installer failed" is not a crash
+report — anything outside user-facing Firefox, and bugs whose fix can only be
+judged by _seeing_ the rendered result.
 
 The `scoping.md` ruleset runs first and filters out non-defects, tracking/`meta`
 bugs and intermittent test failures with a short note instead of an invented fix
@@ -159,13 +173,21 @@ The audience is the team whose bug was just written to by nobody, so only an
 auto-applied run notifies. A medium or low result wrote nothing to Bugzilla and
 stays silent, even if someone applies it by hand later.
 
-Routing is `SLACK_CHANNELS` in `config.py`, keyed by `"<Product> :: <Component>"`
-— today just `Firefox :: New Tab Page` → `#hnt-dev`. A component that is not
-listed notifies nobody; there is deliberately no default channel, since posting one
-team's triage into another team's channel is worse than silence. Product and
-component come from the agent's `product`/`component` plan fields, because nothing
-else carries them out of a run whose only input is a bug id, so a garbled value
-matches no team and sends nothing.
+Routing is `SLACK_CHANNELS` in `config.py`, keyed by `"<Product> :: <Component>"`:
+
+| Product :: Component             | Channel                         |
+| -------------------------------- | ------------------------------- |
+| `Firefox :: New Tab Page`        | `#hnt-dev`                      |
+| `Firefox for Android :: History` | `#android-core-dev`             |
+| `Toolkit :: Application Update`  | `#installer-updater-bug-triage` |
+| `Firefox :: Installer`           | `#installer-updater-bug-triage` |
+
+Two components may share a channel, as the installer and the updater do; the key is
+the component, not the team. A component that is not listed notifies nobody; there is
+deliberately no default channel, since posting one team's triage into another team's
+channel is worse than silence. Product and component come from the agent's
+`product`/`component` plan fields, because nothing else carries them out of a run
+whose only input is a bug id, so a garbled value matches no team and sends nothing.
 
 `notify.py` builds and records the message; the wording is code, not a model turn,
 so `slack.post_message` is _not_ in `ENABLED_ACTION_TYPES` and the agent is never

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
@@ -1,6 +1,7 @@
 """Frontend triage tool -- a read-only Bugzilla triage + fix-planning agent.
 
-Orchestrates a Claude agent that triages Firefox desktop *frontend* bugs
+Orchestrates a Claude agent that triages user-facing Firefox bugs -- the desktop
+frontend, Firefox for Android, and the Windows installer and application updater --
 according to rulesets in the rules/ directory. The agent investigates the
 source repository READ-ONLY (no build, no source edits, no reproduction) and
 produces a root-cause analysis plus a proposed fix plan, which it records as a

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/config.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/config.py
@@ -51,7 +51,7 @@ ENABLED_ACTION_TYPES = [
 # code (see notify.py), not a model turn, so it goes through the recorder directly and
 # the agent is never given the tool — it has no say in what is said or where.
 SLACK_CHANNELS = {
-    "Firefox :: New Tab Page": "#hnt-dev",
+    "Firefox :: New Tab Page": "#hnt-dev-triage",
     "Firefox for Android :: History": "#android-core-dev",
     # The installer and the updater are triaged by the same team, so two components
     # share a channel. Keying by product-and-component rather than by channel is what

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/config.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/config.py
@@ -52,6 +52,12 @@ ENABLED_ACTION_TYPES = [
 # the agent is never given the tool — it has no say in what is said or where.
 SLACK_CHANNELS = {
     "Firefox :: New Tab Page": "#hnt-dev",
+    "Firefox for Android :: History": "#android-core-dev",
+    # The installer and the updater are triaged by the same team, so two components
+    # share a channel. Keying by product-and-component rather than by channel is what
+    # lets them, without either one having to know about the other.
+    "Toolkit :: Application Update": "#installer-updater-bug-triage",
+    "Firefox :: Installer": "#installer-updater-bug-triage",
 }
 
 # What a `bugzilla.update_bug` from this agent may touch. Enforced at record time

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/prompts/system.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/prompts/system.md
@@ -1,4 +1,4 @@
-You are an autonomous triage agent for Firefox **desktop frontend** bugs, operating against a Bugzilla instance.
+You are an autonomous triage agent for **user-facing Firefox** bugs, operating against a Bugzilla instance. That is the desktop frontend, Firefox for Android, and the Windows installer and the application updater. The shape of the work is the same in all of them — localize a defect in the source and propose a fix — but the language and the layout of the code are not, so read the per-component guidance below rather than assuming a JS/CSS frontend.
 
 # Your job
 
@@ -29,9 +29,23 @@ Use **only** these tools for accessing Bugzilla, nothing else.
 
 # Source repository
 
-Your working directory is the Firefox source repository. You have Read, Grep, Glob, and Bash (read-only — do not modify files) to inspect it. Use this to localize the bug: find the components, JS/JSM modules, CSS, and XUL/HTML involved, the relevant prefs (often under `modules/libpref/init/all.js`), and any existing tests that cover the area. Frontend code mostly lives under `browser/`, `toolkit/`, and `devtools/`.
+Your working directory is the Firefox source repository — the whole tree, desktop and Android in one checkout. You have Read, Grep, Glob, and Bash (read-only — do not modify files) to inspect it. Use this to localize the bug: find the modules, markup, styling, and prefs (often under `modules/libpref/init/all.js`) that govern the behaviour, and any existing tests that cover the area.
 
-**Always look for an existing test that exercises the affected area** (browser-chrome mochitests usually live in a component's `tests/browser/` directory; also check `tests/`/`test/` and xpcshell tests). Record what you find in the `relevant_tests` field — it is the downstream executor's verification anchor. If you searched and there is no covering test, say so (empty `relevant_tests`).
+Where to look, and what you will find there, depends on the bug's component:
+
+- **Desktop frontend** — `browser/`, `toolkit/`, and `devtools/`. JS/JSM modules (`.js`, `.mjs`, `.sys.mjs`), CSS, and XUL/HTML.
+- **Firefox for Android** — `mobile/android/`, with the Fenix app under `mobile/android/fenix/app/src/main/java/org/mozilla/fenix/` and the reusable components under `mobile/android/android-components/`. This is **Kotlin**, and it is structured as Fragment / Store / Middleware / View rather than as chrome markup plus a script: a `…Fragment.kt` owns the screen, a `…FragmentStore.kt` holds its state and actions, a `…View.kt` or a Compose function renders it, and a `…Middleware.kt` performs side effects. Layouts are Android XML under `mobile/android/fenix/app/src/main/res/layout/`, strings under `res/values/strings.xml`.
+- **Application updater** — `toolkit/mozapps/update/`. `.sys.mjs` modules (`AppUpdater.sys.mjs`, `UpdateService.sys.mjs`, `BackgroundUpdate.sys.mjs`), the XPCOM interfaces in `nsIUpdateService.idl`, and the C++ updater binary under `toolkit/mozapps/update/updater/`. Update behaviour is heavily driven by prefs under `app.update.*` and by the state written to the update directory, so read `common/` for the shared constants and status codes.
+- **Windows installer** — `browser/installer/windows/nsis/`. This is **NSIS**: `installer.nsi` (the full installer), `stub.nsi` (the small downloader stub), `uninstaller.nsi`, `maintenanceservice_installer.nsi`, and the `.nsh` include files that hold most of the logic. Localized strings live in the `.nsi`/`.properties` files alongside. The packaging manifests are `browser/installer/package-manifest.in` and `browser/installer/allowed-dupes.mn`, and the MSI and MSIX wrappers are in the sibling `msi/` and `msix/` directories. There is no JS here at all. Note which installer the bug is about: the stub and the full installer are separate programs with separate code.
+
+**Always look for an existing test that exercises the affected area**, and record what you find in the `relevant_tests` field — it is the downstream executor's verification anchor. Where to look depends on the component:
+
+- Desktop: browser-chrome mochitests usually live in a component's `tests/browser/` directory; also check `tests/`/`test/` and xpcshell tests.
+- Android: Kotlin unit tests under `mobile/android/fenix/app/src/test/java/org/mozilla/fenix/`, and instrumented UI tests under `app/src/androidTest/`.
+- Updater: `toolkit/mozapps/update/tests/` — xpcshell under `unit_aus_update/`, `unit_background_update/`, and `unit_update_binary/`, browser-chrome under `browser/`, plus `marionette/` and C++ `gtest/`.
+- Installer: coverage is thin and specific. `browser/installer/windows/nsis/test/xpcshell/test_stub_installer.js` drives `test_stub.nsi` and covers the **stub** installer only; nothing exercises `installer.nsi` or the uninstaller. So for most Installer bugs an empty `relevant_tests` is the correct answer — say that the area is uncovered rather than leaving the reader to wonder whether you looked.
+
+If you searched and there is genuinely no covering test, say so (empty `relevant_tests`).
 
 When you reference a cause or a fix target, cite concrete paths (and ideally functions/selectors), e.g. `browser/components/tabbrowser/content/tabgroup.js`. In your Bugzilla comment those paths must be Searchfox permalinks — see **Linking source files** below.
 

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/rules/frontend-triage.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/rules/frontend-triage.md
@@ -1,21 +1,44 @@
-# Frontend papercut triage
+# User-facing Firefox defect triage
 
-These rules apply to **Firefox desktop frontend defects** — UI/UX papercuts in
-the browser chrome and built-in pages. Typical components: `Firefox :: Tabbed
-Browser`, `Firefox :: Tabbed Browser: Split View`, `Firefox :: New Tab Page`,
-`Firefox :: Address Bar`, `Firefox :: Menus`, `Firefox :: Toolbars and
-Customization`, `Firefox :: Sidebar`, `Firefox :: Theme`. These are usually
-documented with a **video or screenshot** and steps to reproduce, and are
-**not** crashes, hangs, or sanitizer reports.
+These rules apply to **defects in user-facing Firefox** — the desktop frontend,
+Firefox for Android, and the Windows installer and application updater. Typical
+components:
 
-If the bug is a crash/assertion/sanitizer report, or is not a frontend bug, this
-ruleset does not apply — note that and stop.
+- Desktop frontend, all under `Firefox`: `Tabbed Browser`,
+  `Tabbed Browser: Split View`, `New Tab Page`, `Address Bar`, `Menus`,
+  `Toolbars and Customization`, `Sidebar`, `Theme`.
+- Android: `Firefox for Android :: History`.
+- Install and update: `Firefox :: Installer`, `Toolkit :: Application Update`.
+
+Desktop and Android bugs here are usually UI/UX papercuts, documented with a
+**video or screenshot** and steps to reproduce.
+
+**Install and update bugs look different, and that is not a reason to skip them.**
+An installer or updater bug is normally a _failure_ rather than a papercut: an update
+that did not apply, an install that rolled back, a version that stayed where it was,
+a wrong or unhelpful error dialog — reported with an error or status code, an
+`update.log` or installer log excerpt, and an OS and channel rather than a
+screenshot. Triage those normally: read the log the reporter pasted, map the status
+code to its definition in `toolkit/mozapps/update/common/` or to the NSIS `.nsh` that
+emits it, and localize from there. Missing steps to reproduce is the norm in this area
+and is not by itself grounds to call a bug unactionable — say what you would need
+instead.
+
+If the bug is a crash, assertion failure, or sanitizer report, this ruleset does not
+apply — note that and stop. "The installer failed" and "the update did not apply" are
+**not** crash reports. Also stop if the bug is not in user-facing Firefox at all — a
+Core, DevTools-internals, or build-system bug — and say which area it looks like.
 
 ## What to produce
 
-1. **Localize the cause in the source.** Frontend code lives mostly under
-   `browser/`, `toolkit/`, and `devtools/`. Find the JS/JSM module, the CSS, the
-   XUL/HTML, and any relevant pref (often `modules/libpref/init/all.js`) that
+1. **Localize the cause in the source.** Where to look and what language to expect
+   depend on the component — see **Source repository** in the system prompt for the
+   per-area layout. In short: desktop frontend under `browser/`, `toolkit/`, and
+   `devtools/` (JS/JSM, CSS, XUL/HTML); Android under `mobile/android/` (Kotlin,
+   Fragment/Store/Middleware/View); the updater under `toolkit/mozapps/update/`
+   (`.sys.mjs`, IDL, C++); the installer under `browser/installer/windows/nsis/`
+   (NSIS `.nsi`/`.nsh`). Find the module, the markup or layout, and any relevant pref
+   (often `modules/libpref/init/all.js`, or `app.update.*` for the updater) that
    governs the behaviour. Use the `investigator` subagent for deep searches.
 2. **Confirm the area is still live.** Check the referenced code/strings still
    exist and aren't already changed by a recent commit. If the bug looks already

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/rules/scoping.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/rules/scoping.md
@@ -27,9 +27,16 @@ output's `actionable` to `false`, `confidence` to `low`, and `root_cause` to nul
 
 ## Proceed normally
 
-Everything else — a `defect` in a frontend component (Bookmarks & History, New Tab Page,
+Everything else — a `defect` in a user-facing Firefox component without the skip signals
+above — is in scope. That covers the desktop frontend (Bookmarks & History, New Tab Page,
 Session Restore, Sidebar, Tabbed Browser: Split View / Tab Groups, Toolbars and
-Customization, …) without the skip signals above — is in scope. Continue to the
+Customization, …), Firefox for Android (History, …), and install and update
+(`Firefox :: Installer`, `Toolkit :: Application Update`). Continue to the
 `frontend-triage` ruleset.
+
+An install or update failure reported as an error code and a log, with no steps to
+reproduce and no screenshot, is an in-scope defect — it is the usual shape of a bug in
+that area, not a sign the report is too thin to work with. See the install-and-update
+paragraph in the `frontend-triage` ruleset.
 
 When in doubt about scope, prefer a short clarifying comment over a speculative fix plan.

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/rules/severity-assessment.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/rules/severity-assessment.md
@@ -21,6 +21,13 @@ user is affected, how many users hit it, and whether a workaround exists.
 - Frontend UI/UX papercuts are usually **S3** (or **S4** when purely cosmetic). Reserve
   **S1 / S2** for genuine breakage: crashes, data/state loss, or a broken core workflow
   with no easy workaround.
+- **Install and update failures do not default to S3.** "Papercut usually means S3" is a
+  desktop-frontend heuristic and does not carry over: a user whose update does not apply
+  is left on an older, unpatched build, and a user whose install fails does not have
+  Firefox at all. Neither has a workaround inside the product. Judge these on reach — a
+  failure specific to one antivirus product or one locale is narrower than one that hits
+  a whole channel or OS version — but start from **S2** and move up or down from there,
+  rather than starting from S3.
 - Weigh: is it functional vs cosmetic? Is there a workaround? How frequently and how
   broadly is it hit (mainline path vs rare configuration)?
 - Do **not downgrade** an existing higher severity unless you have strong evidence the

--- a/agents/frontend-triage/tests/test_notify.py
+++ b/agents/frontend-triage/tests/test_notify.py
@@ -87,10 +87,10 @@ def test_a_missing_summary_leaves_the_bug_link_alone():
 
 
 def test_the_channel_belongs_to_the_component():
-    assert channel_for("Firefox", "New Tab Page") == "#hnt-dev"
+    assert channel_for("Firefox", "New Tab Page") == "#hnt-dev-triage"
     assert channel_for("Firefox for Android", "History") == "#android-core-dev"
     # Surrounding whitespace is the agent's, not Bugzilla's.
-    assert channel_for(" Firefox ", " New Tab Page ") == "#hnt-dev"
+    assert channel_for(" Firefox ", " New Tab Page ") == "#hnt-dev-triage"
 
 
 def test_the_installer_and_the_updater_share_a_channel():
@@ -120,7 +120,7 @@ def test_an_auto_applied_run_records_one_slack_action():
 
     assert action is not None
     assert [a["type"] for a in recorder.actions] == ["slack.post_message"]
-    assert action["params"]["channel"] == "#hnt-dev"
+    assert action["params"]["channel"] == "#hnt-dev-triage"
     assert action["params"]["text"] == build_message(_result(), run_id=RUN_ID)
 
 

--- a/agents/frontend-triage/tests/test_notify.py
+++ b/agents/frontend-triage/tests/test_notify.py
@@ -88,8 +88,17 @@ def test_a_missing_summary_leaves_the_bug_link_alone():
 
 def test_the_channel_belongs_to_the_component():
     assert channel_for("Firefox", "New Tab Page") == "#hnt-dev"
+    assert channel_for("Firefox for Android", "History") == "#android-core-dev"
     # Surrounding whitespace is the agent's, not Bugzilla's.
     assert channel_for(" Firefox ", " New Tab Page ") == "#hnt-dev"
+
+
+def test_the_installer_and_the_updater_share_a_channel():
+    # One team triages both, and a key that is off by a character notifies nobody
+    # rather than failing, so each one is asserted rather than assumed from the other.
+    triage = "#installer-updater-bug-triage"
+    assert channel_for("Toolkit", "Application Update") == triage
+    assert channel_for("Firefox", "Installer") == triage
 
 
 def test_an_unowned_component_has_no_channel():
@@ -97,6 +106,9 @@ def test_an_unowned_component_has_no_channel():
     # worse outcome than silence.
     assert channel_for("Firefox", "Address Bar") is None
     assert channel_for("Core", "New Tab Page") is None
+    # A component name is only owned within its own product: `History` routes to
+    # #android-core-dev under Firefox for Android and nowhere at all under Firefox.
+    assert channel_for("Firefox", "History") is None
     assert channel_for("Firefox", None) is None
     assert channel_for(None, "New Tab Page") is None
     assert channel_for("", "") is None


### PR DESCRIPTION
## Problem

bugbot is about to start sending `Firefox for Android :: History`, `Toolkit :: Application Update`, and `Firefox :: Installer` bugs to this agent (bugbot PR to follow — **this should land and deploy first**). Neither half of the agent was ready for them.

`SLACK_CHANNELS` held only `Firefox :: New Tab Page`, and `channel_for` fails closed on an unlisted component. That silences the notification but not the run: `record_notification` returns `None` while the Bugzilla comment and the severity/keyword change still apply. So the three new components would have got unattended triage on their bugs with nobody told.

The bigger gap is that none of the three is the JS/CSS frontend the prompt and rulesets describe:

| Component | Language | Where |
| --- | --- | --- |
| `Firefox for Android :: History` | Kotlin, Fragment/Store/Middleware/View | `mobile/android/fenix/app/src/main/java/org/mozilla/fenix/library/history/` |
| `Firefox :: Installer` | NSIS | `browser/installer/windows/nsis/` |
| `Toolkit :: Application Update` | `.sys.mjs`, IDL, C++ | `toolkit/mozapps/update/` |

`prompts/system.md` named only `browser/`, `toolkit/`, and `devtools/` and called the agent's remit "Firefox desktop frontend bugs", while `rules/frontend-triage.md` told it to stop when the bug "is not a frontend bug". A Fenix or NSIS bug would likely have been declared out of scope rather than triaged.

## Change

- `config.py` — three `SLACK_CHANNELS` entries. `#android-core-dev` for Android History; `#installer-updater-bug-triage` for both Application Update and Installer, which the product-and-component key already allows without either entry knowing about the other.
- `prompts/system.md` — remit restated as user-facing Firefox, and the single source-roots sentence replaced with a per-area layout of where the code lives and what language to expect. Test-discovery guidance now names the real harness per area rather than only browser-chrome mochitests.
- `rules/frontend-triage.md`, `rules/scoping.md` — the three components added to the in-scope lists, and the "not a frontend bug → stop" instruction narrowed so it no longer catches them.

All three areas are already in the checkout `hackbot.toml` clones, so nothing needed widening on the source side.

## Two calibration changes worth a reviewer's attention

These matter more than they look, because this agent writes to bugs unattended at high confidence.

1. `rules/frontend-triage.md` asserted that in-scope bugs are "usually documented with a video or screenshot" and are "not crashes, hangs". An update that did not apply arrives as an error code and an `update.log` excerpt with no steps to reproduce — the normal shape of a bug in that area, which must not read as grounds to skip it. Now spelled out, with "the installer failed" called out as not being a crash report.
2. `rules/severity-assessment.md` said papercuts default to S3. Applied to a user whose update does not install, that understates it: they are left on an unpatched build with no in-product workaround. Install and update failures now start from **S2** and are judged on reach from there.

## Testing

`pytest tests/` in `agents/frontend-triage`: 40 passed. New cases in `tests/test_notify.py` cover a mapping per new component, both installer/updater keys resolving to the same channel, and `channel_for("Firefox", "History") is None` — pinning that a component name is only owned within its own product. A key that is off by a character notifies nobody rather than failing, so each mapping is asserted rather than assumed from its neighbour.

Every path named in the prompt was checked against a mozilla-firefox checkout. That caught two errors in my first draft: the uninstaller is `uninstaller.nsi`, not `uninstall.nsi`, and the updater's xpcshell directories are `unit_aus_update`/`unit_background_update`/`unit_update_binary`, not the `unit_base_updater`/`unit_service_updater` I had guessed.

The prompt and ruleset changes are prose, so the tests do not cover them. They are unverified against a real run.

## Residual risk

**The prompt widening for Kotlin and NSIS is a guess until a run is observed, and feedback will be slow.** Those three components saw 11 staff-filed defects in the last 90 days combined (Installer 6, Application Update 4, Android History 1), against 191 for New Tab Page — roughly one Fenix History bug per quarter. Worth reading the first Fenix and Installer comments by hand before trusting them.

**Installer coverage is thin, by construction.** The only automated test is `browser/installer/windows/nsis/test/xpcshell/test_stub_installer.js`, which drives `test_stub.nsi` and covers the stub installer only; nothing exercises `installer.nsi` or the uninstaller. The prompt says so plainly rather than implying a search failure, so an empty `relevant_tests` on an Installer bug reads as the correct answer instead of a lazy one.

**Cheap lever if it goes badly:** drop a component's `SLACK_CHANNELS` entry to silence it, or drop it from bugbot's `TRIAGED_COMPONENTS` to stop the runs at the source.