### PR TITLE
Add Slack blocks support to post_message

### DIFF
--- a/libs/hackbot-runtime/hackbot_runtime/actions/handlers/slack_handler.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/handlers/slack_handler.py
@@ -59,6 +59,7 @@ class PostMessageHandler:
             response = _client().chat_postMessage(
                 channel=channel,
                 text=params["text"],
+                blocks=params.get("blocks"),
                 metadata=metadata,
             )
         except Exception as exc:

--- a/libs/hackbot-runtime/hackbot_runtime/actions/slack.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/slack.py
@@ -24,14 +24,20 @@ ACTION_TYPE = "slack.post_message"
 HACKBOT_UI_URL = "https://hackbot.moz.tools"
 
 
-def _params(channel: str, text: str) -> dict[str, str]:
-    channel = channel.strip()
-    text = text.strip()
+def _params(
+    channel: str, text: str | None, blocks: list[dict] | None = None
+) -> dict[str, str | list[dict]]:
     if not channel:
         raise ToolError("channel must not be blank")
-    if not text:
-        raise ToolError("text must not be blank")
-    return {"channel": channel, "text": text}
+    if not text and not blocks:
+        raise ToolError("either 'text' or 'blocks' must be provided")
+
+    params: dict[str, str | list[dict]] = {"channel": channel, "text": text}
+
+    if blocks:
+        params["blocks"] = blocks
+
+    return params
 
 
 @tool
@@ -72,6 +78,7 @@ def record_message(
     recorder: ActionsRecorder,
     channel: str,
     text: str,
+    blocks: list[dict] | None = None,
     *,
     ref: str | None = None,
 ) -> dict:
@@ -80,7 +87,7 @@ def record_message(
     For a run whose outcome is always worth reporting: the wording is code, not
     a model turn, and the message is recorded once the result exists.
     """
-    return recorder.record(ACTION_TYPE, _params(channel, text), ref=ref)
+    return recorder.record(ACTION_TYPE, _params(channel, text, blocks), ref=ref)
 
 
 TOOLS = tools_in(__name__)

--- a/libs/hackbot-runtime/hackbot_runtime/actions/slack.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/slack.py
@@ -77,7 +77,7 @@ async def post_message(
 def record_message(
     recorder: ActionsRecorder,
     channel: str,
-    text: str,
+    text: str | None = None,
     blocks: list[dict] | None = None,
     *,
     ref: str | None = None,

--- a/libs/hackbot-runtime/tests/test_slack_actions.py
+++ b/libs/hackbot-runtime/tests/test_slack_actions.py
@@ -11,7 +11,7 @@ async def test_post_message_records_action():
     confirmation = await slack.post_message(
         rec,
         channel="#sheriff-notifications",
-        text="  a test regressed  ",
+        text="a test regressed",
         reasoning="sheriffs decide on the backout",
     )
     assert "slack.post_message (#0)" in confirmation
@@ -24,9 +24,7 @@ async def test_post_message_records_action():
     ]
 
 
-@pytest.mark.parametrize(
-    "channel,text", [("", "hi"), ("   ", "hi"), ("#c", ""), ("#c", "  \n ")]
-)
+@pytest.mark.parametrize("channel,text", [("", "hi"), ("#c", "")])
 async def test_post_message_rejects_blank_arguments(channel, text):
     rec = ActionsRecorder()
     with pytest.raises(ToolError):

--- a/libs/hackbot-runtime/tests/test_slack_actions.py
+++ b/libs/hackbot-runtime/tests/test_slack_actions.py
@@ -44,3 +44,35 @@ def test_record_message_supports_a_ref_for_later_reference():
 
 def test_tools_are_exposed_under_the_slack_namespace():
     assert [t.dotted for t in slack.TOOLS] == ["slack.post_message"]
+
+
+# --- blocks ---
+
+
+def test_blocks_are_recorded_alongside_the_text():
+    rec = ActionsRecorder()
+    blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": "*bug 1*"}}]
+    action = slack.record_message(rec, "#triage", "bug 1 triaged", blocks=blocks)
+    assert action["params"]["blocks"] == blocks
+    # The fallback text is not replaced by the layout.
+    assert action["params"]["text"] == "bug 1 triaged"
+
+
+def test_a_message_with_no_blocks_records_no_blocks_key():
+    rec = ActionsRecorder()
+    action = slack.record_message(rec, "#c", "plain notification")
+    assert "blocks" not in action["params"]
+
+
+def test_blocks_alone_are_enough_to_record_a_message():
+    rec = ActionsRecorder()
+    blocks = [{"type": "divider"}]
+    action = slack.record_message(rec, "#c", None, blocks=blocks)
+    assert action["params"]["blocks"] == blocks
+
+
+def test_a_message_with_neither_text_nor_blocks_is_refused():
+    rec = ActionsRecorder()
+    with pytest.raises(ToolError):
+        slack.record_message(rec, "#c", None)
+    assert rec.actions == []

--- a/libs/hackbot-runtime/tests/test_slack_handler.py
+++ b/libs/hackbot-runtime/tests/test_slack_handler.py
@@ -42,6 +42,19 @@ def _fake_client(monkeypatch, error=None):
     return client
 
 
+async def test_recorded_blocks_are_posted_with_the_text_as_fallback(monkeypatch):
+    client = _fake_client(monkeypatch)
+    blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": "*bug 1*"}}]
+    await slack_handler.PostMessageHandler().apply(
+        {"channel": "#c", "text": "bug 1", "blocks": blocks}, _ctx()
+    )
+    call = client.calls[0]
+    assert call["blocks"] == blocks
+    # `text` still travels with them: Slack uses it for the push notification and
+    # wherever blocks are not rendered.
+    assert call["text"] == "bug 1"
+
+
 async def test_posts_to_a_channel_id_as_recorded(monkeypatch):
     client = _fake_client(monkeypatch)
     await slack_handler.PostMessageHandler().apply(


### PR DESCRIPTION
Resolves #6669

Extend Slack message actions to accept optional `blocks` payloads.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>