### PR TITLE
Frontend triage severity as comment suggestion

### DIFF
--- a/agents/frontend-triage/README.md
+++ b/agents/frontend-triage/README.md
@@ -132,9 +132,8 @@ Two caveats before acting on a plan:
 ## What it writes back to Bugzilla
 
 **Nothing, during a run.** `ENABLED_ACTION_TYPES` in `config.py` allows
-`bugzilla.add_comment` and `bugzilla.update_bug`, but those come from an
-in-process actions server that appends to `summary.json` and makes no network
-calls. The only Bugzilla access the agent has is through the broker sidecar,
+`bugzilla.add_comment` and nothing else, and that tool comes from an in-process
+actions server that appends to `summary.json` and makes no network calls. The only Bugzilla access the agent has is through the broker sidecar,
 which exposes five read tools and holds the API key.
 
 **Afterwards, though, a confident run posts itself.** When the run reports
@@ -152,10 +151,12 @@ hackbot-api applies whatever it finds in `summary.json`, dispatching it against 
 handler registry far wider than the tools this agent was given.
 
 - `add_comment_hook` — one comment, public, on the bug being triaged.
-- `update_bug_hook` — one field change, add-only, on the bug being triaged, and
-  only `keywords`/`severity` with values from `TRIAGE_SEVERITIES` /
-  `TRIAGE_KEYWORDS` in `config.py`. Widen those sets alongside the rule that needs
-  the new value.
+
+That is the whole list, because a comment is the only thing this agent can write.
+It has no tool that changes a bug's fields: `severity` was the one field a ruleset
+directed it to set, and that is now a suggestion at the end of the comment for a
+human to apply, so `bugzilla.update_bug` left `ENABLED_ACTION_TYPES` rather than
+staying on with no caller. `tests/test_config.py` guards that.
 
 A refusal reaches the agent as a tool error it can correct in the same run, and the
 action never lands in `summary.json`. The action _type_ needs no check:
@@ -182,9 +183,12 @@ reactions and tags are the feedback channel — the agent does not request needi
 
 A run that applies itself reports two lines to the channel of the team that owns
 the bug's component: the bug, linked, with the run's one-line summary, and a link
-to the run. An `S1` severity assessment adds a `:red_circle:` and names the level.
-Nothing else — the analysis is on the bug, the detail is in the run, and the
-channel already says which component this is.
+to the run. An `S1` the run is confident about adds a `:red_circle:` and names the
+level as `(suggested S1)` — suggested, because nothing was written to the field.
+Below `REPORTABLE_SEVERITY_CONFIDENCES` there is no marker, matching the comment,
+which omits its severity block on the same threshold. Nothing else — the analysis
+is on the bug, the detail is in the run, and the channel already says which
+component this is.
 
 The audience is the team whose bug was just written to by nobody, so only an
 auto-applied run notifies. A medium or low result wrote nothing to Bugzilla and

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
@@ -41,7 +41,7 @@ from hackbot_runtime.searchfox import (
     permalink_prefix,
     resolve_index_revision,
 )
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 from searchfox import AsyncSearchfoxClient
 
 from .config import (
@@ -50,9 +50,10 @@ from .config import (
     MOZILLA_VCS_TOOLS,
     SEARCHFOX_TOOLS,
     TRIAGE_SCOPE,
+    TRIAGE_SEVERITIES,
     ScopedComponent,
 )
-from .hooks import add_comment_hook, update_bug_hook
+from .hooks import add_comment_hook
 
 HERE = Path(__file__).resolve().parent
 
@@ -237,6 +238,35 @@ def parse_confidence(value: object) -> str | None:
     return normalized if normalized in CONFIDENCE_LEVELS else None
 
 
+def parse_severity(value: object) -> str | None:
+    """One of :data:`~.config.TRIAGE_SEVERITIES`, or None if ``value`` isn't one.
+
+    Same contract as :func:`parse_confidence`, for the same reason: the level comes out
+    of the agent's free-form JSON block, and it is the only severity signal reaching a
+    human now that the field is no longer written.
+    """
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().upper()
+    return normalized if normalized in TRIAGE_SEVERITIES else None
+
+
+def parse_severity_assessment(value: object) -> SeverityAssessment | None:
+    """A :class:`SeverityAssessment` with its level and confidence normalized.
+
+    Fields degrade independently: an unreadable level or confidence becomes None, which
+    drops the comment's severity block, rather than discarding the rationale with it.
+    """
+    if not isinstance(value, dict):
+        return None
+    rationale = value.get("rationale")
+    return SeverityAssessment(
+        suggested=parse_severity(value.get("suggested")),
+        confidence=parse_confidence(value.get("confidence")),
+        rationale=rationale if isinstance(rationale, str) else None,
+    )
+
+
 def may_apply_unattended(plan: dict) -> bool:
     """Whether this run's recorded actions may reach the bug without a human.
 
@@ -284,14 +314,6 @@ def parse_plan(text: str | None) -> dict:
         # run's result, and these two only route a notification.
         return value.strip() or None if isinstance(value, str) else None
 
-    def _as_model(model, value):
-        if not isinstance(value, dict):
-            return None
-        try:
-            return model.model_validate(value)
-        except ValidationError:
-            return None
-
     actionable = data.get("actionable")
     if not isinstance(actionable, bool):
         actionable = None
@@ -306,8 +328,8 @@ def parse_plan(text: str | None) -> dict:
         "actionable": actionable,
         "regressor_node": data.get("regressor_node"),
         "relevant_tests": _as_list(data.get("relevant_tests")),
-        "severity_assessment": _as_model(
-            SeverityAssessment, data.get("severity_assessment")
+        "severity_assessment": parse_severity_assessment(
+            data.get("severity_assessment")
         ),
     }
 
@@ -368,9 +390,6 @@ async def run_frontend_triage(
     # rewritten.
     actions_recorder.add_hook(
         "bugzilla.add_comment", add_comment_hook(actions_recorder, bug)
-    )
-    actions_recorder.add_hook(
-        "bugzilla.update_bug", update_bug_hook(actions_recorder, bug)
     )
 
     actions_recorder.add_hook(

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
@@ -53,7 +53,7 @@ from .config import (
     TRIAGE_SEVERITIES,
     ScopedComponent,
 )
-from .hooks import add_comment_hook
+from .hooks import add_comment_hook, severity_block_hook
 
 HERE = Path(__file__).resolve().parent
 
@@ -391,6 +391,7 @@ async def run_frontend_triage(
     actions_recorder.add_hook(
         "bugzilla.add_comment", add_comment_hook(actions_recorder, bug)
     )
+    actions_recorder.add_hook("bugzilla.add_comment", severity_block_hook)
 
     actions_recorder.add_hook(
         "bugzilla.add_comment",

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/config.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/config.py
@@ -31,17 +31,15 @@ MOZILLA_VCS_TOOLS = [
 ]
 
 
-# Recordable action types the agent may take, by dotted id. This agent triages
-# and plans only: it records a comment with its findings/plan and, at high
-# confidence, may propose field updates (e.g. keyword/severity). It never
-# creates bugs or attaches files.
+# Recordable action types the agent may take, by dotted id. A comment is the only one:
+# `bugzilla.update_bug` was here for `severity`, which is now a suggestion in the comment
+# instead, leaving the tool with no caller.
 #
-# `bugzilla.update_bug` needs `editbugs` on the apply account. The apply step coalesces
-# a same-bug field change with the nearest comment into one PUT, so losing that
-# privilege would take the analysis comment down with the rejected field change.
+# Dropping it also drops the `editbugs` requirement on the apply account, which mattered:
+# the apply step coalesces a same-bug field change with the nearest comment into one PUT,
+# so a rejected field change used to take the analysis comment down with it.
 ENABLED_ACTION_TYPES = [
     "bugzilla.add_comment",
-    "bugzilla.update_bug",
 ]
 
 
@@ -125,32 +123,21 @@ TRIAGE_SCOPE = (
 # that `notify.py` keeps one flat mapping to look up.
 SLACK_CHANNELS = {c.key: c.channel for c in TRIAGE_SCOPE}
 
-# What a `bugzilla.update_bug` from this agent may touch. Enforced at record time
-# by `hooks.update_bug_hook`, so an out-of-bounds change is refused while the agent
-# can still correct it, rather than recorded and held for a human later.
-
-TRIAGE_FIELDS = frozenset({"keywords", "severity"})
-
 # Bugzilla's `bug_severity` legal values are `--`, `blocker`, `S1`, `critical`,
 # `S2`, `major`, `normal`, `S3`, `minor`, `S4`, `trivial`, `N/A`, `enhancement`
 # (https://bugzilla.mozilla.org/rest/field/bug/bug_severity). Narrowed to the four
 # `rules/severity-assessment.md` actually defines: the word forms are legacy, kept
 # for old bugs, and `--`/`N/A` mean unset or not-applicable, which is a metadata
 # regression rather than a triage judgment.
+#
+# The agent no longer writes the field; `agent.parse_severity` validates the level it
+# suggests against this set.
 TRIAGE_SEVERITIES = frozenset({"S1", "S2", "S3", "S4"})
 
-# Bugzilla defines ~340 keywords (https://bugzilla.mozilla.org/rest/field/bug/keywords,
-# or https://bugzilla.mozilla.org/describekeywords.cgi for the annotated list), several
-# of which drive automation. These six are the ones a frontend triage pass can add
-# without side effects. No ruleset in `rules/` directs a keyword addition today, so
-# widen this set alongside the rule that needs it rather than ahead of one.
-TRIAGE_KEYWORDS = frozenset(
-    {
-        "access",
-        "dataloss",
-        "good-first-bug",
-        "papercut",
-        "perf",
-        "regression",
-    }
-)
+# Which `severity_assessment.confidence` values are worth reporting. Below this the agent
+# says nothing about severity at all, since a level it is unsure of still reads as a
+# judgment an engineer may act on.
+#
+# `notify.py` reads this for the S1 marker; `rules/severity-assessment.md` repeats the
+# threshold for the comment block, because the model cannot import it. Change both.
+REPORTABLE_SEVERITY_CONFIDENCES = frozenset({"high", "medium"})

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/hooks.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/hooks.py
@@ -2,8 +2,7 @@
 
 Once a run marks itself high-confidence its actions are applied to Bugzilla with no
 human in between, and an action's params are model output. These hooks bound that:
-one public comment and one add-only ``keywords``/``severity`` change, both on the
-bug being triaged.
+one public comment on the bug being triaged, and nothing else.
 
 They run at record time rather than at apply time for two reasons. The refusal
 reaches the agent as a tool error it can correct in the same run, and the
@@ -11,28 +10,26 @@ out-of-bounds action never reaches ``summary.json``. ``ActionsRecorder`` runs ho
 before appending, so raising here aborts the recording (see
 :data:`hackbot_runtime.actions.ActionHook`).
 
-The action **type** needs no check. ``ENABLED_ACTION_TYPES`` filters the tools the
-actions server exposes, so this agent has no way to record a
-``bugzilla.create_bug`` or a Phabricator action in the first place.
+The action **type** needs no check, and there is no field-change hook.
+``ENABLED_ACTION_TYPES`` filters the tools the actions server exposes, so this agent
+has no way to record a ``bugzilla.update_bug``, a ``bugzilla.create_bug`` or a
+Phabricator action in the first place -- ``severity`` is a suggestion in the comment
+now, which is what left that tool with no caller.
 """
 
 from __future__ import annotations
 
-from typing import Any
-
 from agent_tools.registry import ToolError
 from hackbot_runtime.actions import ActionHook, ActionsRecorder
 
-from .config import TRIAGE_FIELDS, TRIAGE_KEYWORDS, TRIAGE_SEVERITIES
 
-
-def _check_only_one(recorder: ActionsRecorder, action_type: str) -> None:
-    # The rules ask for a single comment and at most one field change, but nothing
-    # else caps the count, and the agent reads every comment on the bug as untrusted
-    # input. A run told to write "a single brief comment" could record fifty.
-    if any(action["type"] == action_type for action in recorder.actions):
+def _check_no_comment_yet(recorder: ActionsRecorder) -> None:
+    # The rules ask for a single comment, but nothing else caps the count, and the
+    # agent reads every comment on the bug as untrusted input. A run told to write
+    # "a single brief comment" could record fifty.
+    if any(action["type"] == "bugzilla.add_comment" for action in recorder.actions):
         raise ToolError(
-            f"you have already recorded a {action_type}; record one per run, "
+            "you have already recorded a comment; record one per run, "
             "revising it rather than adding another"
         )
 
@@ -45,74 +42,6 @@ def _check_target_bug(params: dict, bug_id: int) -> None:
         )
 
 
-def _check_severity(value: Any) -> None:
-    # Single-valued, so a scalar is the only way to set it — there is no additive
-    # form to insist on the way there is for keywords. `isinstance` before the
-    # membership test, because a list or dict is unhashable and `in` would raise
-    # rather than reject.
-    if not isinstance(value, str) or value not in TRIAGE_SEVERITIES:
-        raise ToolError(
-            f"severity {value!r} is not one you may set; "
-            f"use one of {', '.join(sorted(TRIAGE_SEVERITIES))}"
-        )
-
-
-def _check_keywords(value: Any) -> None:
-    # A bare list *replaces* every keyword already on the bug; `{"add": [...]}` is
-    # the only form that adds one.
-    if not isinstance(value, dict) or set(value) != {"add"}:
-        raise ToolError(
-            'keywords must be added, not set: pass {"add": ["…"]} rather than '
-            f"{value!r}, which would replace the keywords already on the bug"
-        )
-    additions = value["add"]
-    if not isinstance(additions, list) or not additions:
-        raise ToolError("keywords' add must be a non-empty list")
-    # `isinstance` first: an unhashable entry would make `in` raise rather than reject.
-    unknown = [
-        k for k in additions if not isinstance(k, str) or k not in TRIAGE_KEYWORDS
-    ]
-    if unknown:
-        raise ToolError(
-            f"keyword(s) {', '.join(repr(k) for k in unknown)} are not ones you may "
-            f"add; use one of {', '.join(sorted(TRIAGE_KEYWORDS))}"
-        )
-
-
-def update_bug_hook(recorder: ActionsRecorder, bug_id: int) -> ActionHook:
-    """Refuse a ``bugzilla.update_bug`` outside what this agent is trusted with.
-
-    Mirrors what ``rules/frontend-triage.md`` and ``rules/severity-assessment.md``
-    sanction: one add-only change to fields in :data:`~.config.TRIAGE_FIELDS`, with
-    values from Bugzilla's own vocabulary, on ``bug_id`` — the bug the run was asked
-    about.
-    """
-
-    def hook(action: dict) -> None:
-        params = action.get("params") or {}
-        _check_only_one(recorder, "bugzilla.update_bug")
-        _check_target_bug(params, bug_id)
-
-        changes = params.get("changes")
-        if not isinstance(changes, dict) or not changes:
-            raise ToolError("changes must be a non-empty mapping of field to value")
-
-        disallowed = sorted(set(changes) - TRIAGE_FIELDS)
-        if disallowed:
-            raise ToolError(
-                f"you may not change {', '.join(disallowed)}; this agent changes only "
-                f"{', '.join(sorted(TRIAGE_FIELDS))}"
-            )
-
-        for field, value in changes.items():
-            if field == "severity":
-                _check_severity(value)
-            else:
-                _check_keywords(value)
-
-    return hook
-
-
 def add_comment_hook(recorder: ActionsRecorder, bug_id: int) -> ActionHook:
     """Refuse a ``bugzilla.add_comment`` this agent may not post.
 
@@ -123,7 +52,7 @@ def add_comment_hook(recorder: ActionsRecorder, bug_id: int) -> ActionHook:
 
     def hook(action: dict) -> None:
         params = action.get("params") or {}
-        _check_only_one(recorder, "bugzilla.add_comment")
+        _check_no_comment_yet(recorder)
         _check_target_bug(params, bug_id)
 
         if params.get("is_private"):

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/hooks.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/hooks.py
@@ -19,8 +19,31 @@ now, which is what left that tool with no caller.
 
 from __future__ import annotations
 
+import re
+
 from agent_tools.registry import ToolError
 from hackbot_runtime.actions import ActionHook, ActionsRecorder
+
+# A line the model writes to declare its severity. Anchored to the line start so an
+# ordinary mention -- quoting a reporter, or arguing why something is not S1 -- does
+# not count as a second declaration.
+_SEVERITY_DECLARATION = re.compile(r"^Severity assessment:", re.MULTILINE)
+
+
+def severity_block_hook(action: dict) -> None:
+    """Refuse a comment that declares its severity more than once.
+
+    The prompt asks for one block at the end. Nothing stops the model from also
+    writing the level into its analysis, and the reader would then have two
+    declarations that can disagree. Absence is fine and deliberate -- a run with low
+    severity confidence omits the block -- so this only fires on a second one.
+    """
+    text = (action.get("params") or {}).get("text")
+    if isinstance(text, str) and len(_SEVERITY_DECLARATION.findall(text)) > 1:
+        raise ToolError(
+            "your comment declares a severity more than once; keep the single "
+            "`Severity assessment:` block at the end and drop the other"
+        )
 
 
 def _check_no_comment_yet(recorder: ActionsRecorder) -> None:

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/hooks.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/hooks.py
@@ -27,7 +27,7 @@ from hackbot_runtime.actions import ActionHook, ActionsRecorder
 # A line the model writes to declare its severity. Anchored to the line start so an
 # ordinary mention -- quoting a reporter, or arguing why something is not S1 -- does
 # not count as a second declaration.
-_SEVERITY_DECLARATION = re.compile(r"^Severity assessment:", re.MULTILINE)
+_SEVERITY_DECLARATION = re.compile(r"^Suggested severity:", re.MULTILINE)
 
 
 def severity_block_hook(action: dict) -> None:
@@ -42,7 +42,7 @@ def severity_block_hook(action: dict) -> None:
     if isinstance(text, str) and len(_SEVERITY_DECLARATION.findall(text)) > 1:
         raise ToolError(
             "your comment declares a severity more than once; keep the single "
-            "`Severity assessment:` block at the end and drop the other"
+            "`Suggested severity:` block at the end and drop the other"
         )
 
 

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/notify.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/notify.py
@@ -1,9 +1,9 @@
 """The Slack message an auto-applied run sends to the owning team's channel.
 
-Only a run that applies itself reports: at `confidence: high` a comment and a
-`severity`/`keywords` change reach the bug with nobody in between, and the team that
-owns the component has no other signal that it happened. A medium or low run wrote
-nothing to the bug, so there is nothing to tell anyone.
+Only a run that applies itself reports: at `confidence: high` its comment reaches the
+bug with nobody in between, and the team that owns the component has no other signal
+that it happened. A medium or low run wrote nothing to the bug, so there is nothing to
+tell anyone.
 
 Recorded as a ``slack.post_message`` action rather than posted from the run, so it is
 visible in the hackbot UI before it lands and the apply step delivers it at most once
@@ -13,7 +13,8 @@ Two lines: the bug, and the run. The channel already says which product and comp
 this is, the analysis is on the bug, and the detail is in the run -- so neither is
 repeated here. Confidence is not reported either, since only a `high` run gets this
 far. An S1 is the one thing worth pulling out of the bug, as it is the level someone
-may need to act on today.
+may need to act on today -- but only one the run is confident about, on the same
+threshold that decides whether the comment mentions severity at all.
 """
 
 from __future__ import annotations
@@ -24,7 +25,7 @@ from hackbot_runtime.actions.recorder import ActionsRecorder
 from hackbot_runtime.actions.slack import HACKBOT_UI_URL, record_message
 
 from .agent import FrontendTriageResult
-from .config import SLACK_CHANNELS
+from .config import REPORTABLE_SEVERITY_CONFIDENCES, SLACK_CHANNELS
 
 logger = logging.getLogger(__name__)
 
@@ -56,20 +57,27 @@ def channel_for(product: str | None, component: str | None) -> str | None:
 def build_message(result: FrontendTriageResult, *, run_id: str) -> str:
     """Render the notification for an auto-applied run."""
     assessment = result.severity_assessment
-    suggested = (assessment.suggested or "") if assessment else ""
-    # The severity the run *judged*, which is not always the one it wrote to the bug:
-    # `rules/severity-assessment.md` holds back the field change when the severity
-    # confidence is not high. An S1 it only suspects is still worth flagging.
-    urgent = suggested.strip().upper() == URGENT_SEVERITY
+    # Gated on the severity's own confidence, not the run's -- the two are independent,
+    # and a run that localized the cause precisely can still be unsure how bad the bug
+    # is. The comment drops its severity block on the same threshold, so without this
+    # Slack could shout S1 while the bug says nothing about severity at all.
+    #
+    # Both values arrive normalized from `parse_plan`.
+    urgent = bool(
+        assessment
+        and assessment.suggested == URGENT_SEVERITY
+        and assessment.confidence in REPORTABLE_SEVERITY_CONFIDENCES
+    )
 
     headline = _link(BUG_URL.format(bug_id=result.bug_id), f"Bug {result.bug_id}")
     if result.summary and result.summary.strip():
         headline += f" — {result.summary.strip()}"
     # The level is spelled out next to the emoji, so it still reads as an S1 for anyone
-    # whose client does not render one.
+    # whose client does not render one. "suggested", because a bare "(S1)" would read as
+    # the bug having been marked S1, and nothing was written to the field.
     headline = f"*{headline}*"
     if urgent:
-        headline = f":red_circle: {headline} ({URGENT_SEVERITY})"
+        headline = f":red_circle: {headline} (suggested {URGENT_SEVERITY})"
 
     return "\n".join(
         [

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/prompts/system.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/prompts/system.md
@@ -136,15 +136,17 @@ End your comment with this block, exactly this shape, after the fix plan and sep
 ```
 ---
 
-Severity assessment: S2 (currently S4)
+Suggested severity: S4
 
-Rationale: <one or two sentences on the user impact that decided the level>
+<one or two sentences on the user impact that decided the level>
 ```
 
-- Add `(currently …)` **only when your level differs from the bug's current `severity`** — `(currently unset)` if the bug has none. If they match, write just `Severity assessment: S3`. This is what tells a reader the two disagree, so do not leave it out when they do. You already have the current value: `get_bugs` returns `severity` by default, so ask for it explicitly if you narrow `include_fields`.
-- Keep the blank line between the two lines. Without it they render as one run-on paragraph.
+- **Do not state the bug's current severity.** A reader has the field on screen, and a comment is permanent while the field is not — "currently S4" is wrong the moment somebody changes it.
+- Keep the blank line after the level, or the two run together into one paragraph.
+- No `Rationale:` label — just the sentences.
 - Do **not** put your confidence in the comment. It belongs in `severity_assessment` in the structured output.
 - **Omit the whole block, horizontal rule included, when your severity confidence is low or you could not assess severity at all** — an out-of-scope or unlocalized bug included. A level you are unsure of still reads as a judgment someone may act on, and a stray rule with nothing under it renders as an empty section.
+- Declare the severity **once**. Naming the level again in your analysis gives the reader two claims that can disagree, and a comment that does is refused.
 
 Always be **brief** and to the point. Developers have limited time. Do **not** record private comments — all developers on the bug need to see them, and a private one is refused.
 

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/prompts/system.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/prompts/system.md
@@ -137,13 +137,12 @@ End your comment with this block, exactly this shape, after the fix plan and sep
 ---
 
 Suggested severity: S4
-
 <one or two sentences on the user impact that decided the level>
 ```
 
 - **Do not state the bug's current severity.** A reader has the field on screen, and a comment is permanent while the field is not — "currently S4" is wrong the moment somebody changes it.
-- Keep the blank line after the level, or the two run together into one paragraph.
-- No `Rationale:` label — just the sentences.
+- The reasoning goes on the line directly below the level, with no blank line and no `Rationale:` label.
+- Keep the blank line _before_ the `---`. Without it the line above becomes a heading.
 - Do **not** put your confidence in the comment. It belongs in `severity_assessment` in the structured output.
 - **Omit the whole block, horizontal rule included, when your severity confidence is low or you could not assess severity at all** — an out-of-scope or unlocalized bug included. A level you are unsure of still reads as a judgment someone may act on, and a stray rule with nothing under it renders as an empty section.
 - Declare the severity **once**. Naming the level again in your analysis gives the reader two claims that can disagree, and a comment that does is refused.

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/prompts/system.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/prompts/system.md
@@ -8,7 +8,7 @@ You are given a bug ID. Your job is to triage it and produce a **proposed fix pl
 2. **Read the relevant triage rules** from `{rules_dir}` — Glob the directory and Read only the rulesets that apply to this bug. Do not assume all rules apply to all bugs.
 3. **Assess** what the rules say should happen, and whether the bug has open questions in its comments.
 4. **Investigate** the source tree (read-only) to localize the cause — delegate deep searches to the `investigator` subagent (see below).
-5. **Assess severity** — determine an appropriate Mozilla severity (S1–S4) from the user impact (see the `severity-assessment` rules).
+5. **Assess severity** — determine an appropriate Mozilla severity (S1–S4) from the user impact (see the `severity-assessment` rules). You do **not** set it on the bug; it goes at the end of your comment as a suggestion.
 6. **Produce a fix plan**: the likely root cause, the specific files to change, and the approach. Record it as a brief Bugzilla comment.
 
 # This agent is READ-ONLY
@@ -111,7 +111,7 @@ When you spawn an investigator via the Task tool, write a complete, self-contain
 
 # Recording actions
 
-The `actions` MCP tools (`bugzilla_add_comment`, `bugzilla_update_bug`) do **not** mutate Bugzilla directly. They record an intended action into the run's `summary.json` for a downstream apply step. Treat each recorded action as a final, irrevocable proposal.
+The `actions` MCP tool `bugzilla_add_comment` does **not** mutate Bugzilla directly. It records an intended comment into the run's `summary.json` for a downstream apply step. Treat a recorded comment as a final, irrevocable proposal.
 
 **Recording is not posting, but it is not always reviewed either.** When you report `confidence: high`, this run's recorded actions are applied to the real bug automatically, with no human in between. At `medium` or `low` they are held for a person to apply by hand. So reserve `high` for when you have actually localized the cause in specific code — not for a plausible-sounding hypothesis — and write every action as if it will be read on the bug unreviewed, because at `high` it will be.
 
@@ -120,16 +120,31 @@ Before calling any action tool, state in your response:
 - **What** action you are recording and **why** (cite the specific rule)
 - **Your confidence**: high / medium / low
 
-Record exactly one `bugzilla_add_comment` with your fix plan (which should also state the severity conclusion). Only record a `bugzilla_update_bug` when confidence is **high** and a specific triage rule directs it — e.g. a `severity` (per the `severity-assessment` rules) or an obvious keyword. You may combine several such fields into one `bugzilla_update_bug`, each justified in the `reasoning`. At medium/low confidence, state the assessment in the comment and structured output but do **not** record a field change. Never record `status: RESOLVED`.
+Record exactly one `bugzilla_add_comment` with your fix plan, ending with the severity block described below. That comment is the **only** thing you can write to a bug — you have no tool that changes a field, so a severity, keyword, status or resolution can only be _suggested_ in the comment for a human to apply.
 
-Both action tools are deliberately narrow, and a call outside what they accept is refused with the reason (fix it and retry — a refused call records nothing, so it costs you nothing but the turn):
+The tool is deliberately narrow, and a call outside what it accepts is refused with the reason (fix it and retry — a refused call records nothing, so it costs you nothing but the turn):
 
-- At most one comment and one field change per run, both on the bug you were asked to triage.
-- `bugzilla_update_bug` may change only `keywords` and `severity`.
-- `keywords` must be `{{"add": ["…"]}}`. A bare list **replaces** every keyword already on the bug.
-- `severity` must be one of `S1`, `S2`, `S3`, `S4` — the levels `severity-assessment` defines.
+- At most one comment per run, on the bug you were asked to triage.
+- The comment must be public. A private one is invisible to the reporter and to everyone else on the bug.
 
-The `reasoning` parameter on every action tool is required and stored alongside the recorded action. Fill it properly.
+The `reasoning` parameter is required and stored alongside the recorded comment. Fill it properly.
+
+# Severity in the comment
+
+End your comment with this block, exactly this shape, after the fix plan and separated from it by a horizontal rule:
+
+```
+---
+
+Severity assessment: S2 (currently S4)
+
+Rationale: <one or two sentences on the user impact that decided the level>
+```
+
+- Add `(currently …)` **only when your level differs from the bug's current `severity`** — `(currently unset)` if the bug has none. If they match, write just `Severity assessment: S3`. This is what tells a reader the two disagree, so do not leave it out when they do. You already have the current value: `get_bugs` returns `severity` by default, so ask for it explicitly if you narrow `include_fields`.
+- Keep the blank line between the two lines. Without it they render as one run-on paragraph.
+- Do **not** put your confidence in the comment. It belongs in `severity_assessment` in the structured output.
+- **Omit the whole block, horizontal rule included, when your severity confidence is low or you could not assess severity at all** — an out-of-scope or unlocalized bug included. A level you are unsure of still reads as a judgment someone may act on, and a stray rule with nothing under it renders as an empty section.
 
 Always be **brief** and to the point. Developers have limited time. Do **not** record private comments — all developers on the bug need to see them, and a private one is refused.
 
@@ -163,7 +178,7 @@ Field guidance for the handoff:
 - **`actionable`** — `false` when the bug is out of scope or skipped per the scoping rules (meta/tracking, intermittent/test-infra, enhancement/task), or when there is simply nothing to fix-plan; `true` when you produced a real fix plan. The executor uses this to decide whether to act.
 - **`regressor_node`** — when the bug is a regression and you identified/confirmed the introducing changeset (via the `mozilla_vcs` tools or `get_blame`), put its hg node here so the executor has a direct pointer; otherwise `null`.
 - **`relevant_tests`** — existing tests that cover the affected area (typically browser-chrome mochitests under a component's `tests/browser/` dir, or xpcshell tests). These are the executor's **verification anchor** — it can run them. Use `[]` if you searched and found none (a signal that the executor should add a test).
-- **`severity_assessment`** — the severity you judged appropriate (per the `severity-assessment` rules), with `confidence` and a `rationale`. Set to null only if you could not assess it.
+- **`severity_assessment`** — the severity you judged appropriate (per the `severity-assessment` rules), with `confidence` and a `rationale`. `suggested` and `rationale` must match what your comment says. `confidence` is what decides whether the comment carries the block at all, so rate it honestly rather than defaulting to high. Set the whole object to null only if you could not assess severity.
 
 If you could not localize a root cause, set `root_cause` to null, keep `confidence` low, set `actionable` accordingly, and have your comment ask the specific open questions that block triage.
 

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/rules/README.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/rules/README.md
@@ -12,5 +12,6 @@ frontend defects with a video or steps-to-reproduce but no crash.").
 Rules are free-form prose. Be explicit about:
 
 - **When** the rule applies (which products/components/keywords/states)
-- **What** field changes or comments the agent should make
+- **What** the comment should say. A comment is the only thing the agent can write
+  to a bug, so a rule that directs a field change directs something impossible.
 - **What confidence threshold** is needed before acting

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/rules/frontend-triage.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/rules/frontend-triage.md
@@ -46,8 +46,9 @@ Core, DevTools-internals, or build-system bug — and say which area it looks li
    change, and the approach. Prefer a comprehensive fix at the right level over a
    spot fix.
 4. **Assess severity.** Apply the `severity-assessment` rules to judge the bug's
-   severity from its user impact. It belongs in your comment and structured
-   output.
+   severity from its user impact. It goes in the severity block at the end of your
+   comment and in the structured output — never on the bug's `severity` field,
+   which you cannot set.
 
 ## Comment
 
@@ -57,18 +58,20 @@ inline Markdown link to its Searchfox permalink (with a line anchor where you
 know the line) per the **Linking source files** section of the system prompt. Do
 not restate the whole bug. Do not claim the fix is verified — you did not run it.
 
-## Confidence and field changes
+Close with the severity block — a horizontal rule, `Severity assessment: <level>`,
+then `Rationale:` — unless your severity confidence is low or you could not assess
+it, in which case leave the block out entirely. Exact shape and the `(currently …)`
+rule are in **Severity in the comment** in the system prompt.
 
-Your `confidence` decides whether your actions reach the bug unreviewed — see
-**Recording actions** in the system prompt before you pick a level.
+## Confidence
+
+Your `confidence` decides whether your comment reaches the bug unreviewed — see
+**Recording actions** in the system prompt before you pick a level. This is the
+run's confidence in the _localization_; the severity block has its own, separate
+confidence (see `severity-assessment`).
 
 - **High** (you found the specific code and the cause is clear): record the
-  plan comment. If a rule or convention clearly applies, you may also record a
-  `bugzilla_update_bug` for an obviously-correct field — e.g. adding a relevant
-  keyword, or a `severity` (per `severity-assessment`). Do not change
-  `status`/`resolution`. Record a keyword addition as
-  `{"keywords": {"add": ["…"]}}` — a bare list replaces every keyword already on
-  the bug.
+  plan comment.
 - **Medium** (plausible area, cause not pinned down): record the comment with
   your best hypothesis and the open questions that would confirm it.
 - **Low** (could not localize): record a comment stating what you checked and

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/rules/frontend-triage.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/rules/frontend-triage.md
@@ -58,10 +58,10 @@ inline Markdown link to its Searchfox permalink (with a line anchor where you
 know the line) per the **Linking source files** section of the system prompt. Do
 not restate the whole bug. Do not claim the fix is verified — you did not run it.
 
-Close with the severity block — a horizontal rule, `Severity assessment: <level>`,
-then `Rationale:` — unless your severity confidence is low or you could not assess
-it, in which case leave the block out entirely. Exact shape and the `(currently …)`
-rule are in **Severity in the comment** in the system prompt.
+Close with the severity block — a horizontal rule, `Suggested severity: <level>`,
+then the reasoning — unless your severity confidence is low or you could not assess
+it, in which case leave the block out entirely. Exact shape is in **Severity in the
+comment** in the system prompt.
 
 ## Confidence
 

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/rules/severity-assessment.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/rules/severity-assessment.md
@@ -1,9 +1,12 @@
 # Severity assessment
 
-Assess an appropriate Mozilla severity for the bug and record it in the
-`severity_assessment` structured-output object. Base the judgment on **user impact and
-reach** as evidenced by the bug report and the code you investigated — how badly the
-user is affected, how many users hit it, and whether a workaround exists.
+Assess an appropriate Mozilla severity for the bug. Record it in **both** the
+`severity_assessment` structured-output object and the severity block at the end of your
+comment (see **Severity in the comment** in the system prompt). Base the judgment on
+**user impact and reach** as evidenced by the bug report and the code you investigated —
+how badly the user is affected, how many users hit it, and whether a workaround exists.
+
+You cannot set the `severity` field. The comment is a suggestion for a human to apply.
 
 ## Severity definitions
 
@@ -41,13 +44,28 @@ user is affected, how many users hit it, and whether a workaround exists.
 - Weigh: is it functional vs cosmetic? Is there a workaround? How frequently and how
   broadly is it hit (mainline path vs rare configuration)?
 - Do **not downgrade** an existing higher severity unless you have strong evidence the
-  impact is lower than currently recorded.
+  impact is lower than currently recorded. The `(currently …)` parenthetical is what
+  asserts the recorded value is wrong, so that bar applies to writing it: when your level
+  is below the bug's, say what evidence puts it lower.
 
-## Confidence and field changes
+## Confidence
 
-- **High** — impact is clear-cut (clearly cosmetic, or clearly a crash/data-loss). Only
-  then may you record a `bugzilla_update_bug` proposing the `severity` (see the system
-  prompt's recording rules), with a `reasoning` citing the impact evidence. Prefer not to
-  propose a change when the bug already carries a reasonable severity.
-- **Medium / low** — suggest a severity in the comment and structured output, but do
-  **not** record a field change.
+This is your confidence in the **impact judgment** — how sure you are the bug is an S2
+rather than an S3. It is not the run's top-level `confidence`, which is about whether you
+localized the cause in code. The two are independent: a bug can be obviously cosmetic
+while you have no idea which file is at fault, and that case still deserves a severity.
+
+It decides whether the comment mentions severity at all:
+
+- **High** — impact is clear-cut (clearly cosmetic, or clearly a crash/data-loss).
+- **Medium** — the level is a reasonable read but the impact or reach is arguable.
+- **Low, or you could not assess it** — **omit the severity block from the comment
+  entirely**, horizontal rule included, and set `confidence` accordingly (or the whole
+  `severity_assessment` object to null). Say nothing rather than guess: a level you are
+  unsure of still reads as a judgment an engineer may act on, and being wrong there costs
+  trust in the rest of your comment.
+
+High and medium are the reportable levels. `notify.py` uses the same threshold to decide
+whether a suspected S1 gets a marker in Slack, so the bug and the channel say the same
+thing — keep the two in step if you change this
+(`REPORTABLE_SEVERITY_CONFIDENCES` in `config.py`).

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/rules/severity-assessment.md
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/rules/severity-assessment.md
@@ -44,9 +44,9 @@ You cannot set the `severity` field. The comment is a suggestion for a human to 
 - Weigh: is it functional vs cosmetic? Is there a workaround? How frequently and how
   broadly is it hit (mainline path vs rare configuration)?
 - Do **not downgrade** an existing higher severity unless you have strong evidence the
-  impact is lower than currently recorded. The `(currently …)` parenthetical is what
-  asserts the recorded value is wrong, so that bar applies to writing it: when your level
-  is below the bug's, say what evidence puts it lower.
+  impact is lower than currently recorded. Suggesting a level below the bug's asserts
+  the recorded value is wrong, so that bar applies to it: say what evidence puts the
+  impact lower.
 
 ## Confidence
 

--- a/agents/frontend-triage/tests/test_hooks.py
+++ b/agents/frontend-triage/tests/test_hooks.py
@@ -80,7 +80,7 @@ def test_a_refused_comment_does_not_use_up_the_allowance():
 
 def test_a_comment_may_declare_its_severity_only_once():
     plan = "Root cause is a stale selector in content-area.css."
-    block = "\n\n---\n\nSeverity assessment: S4\n\nRationale: cosmetic only."
+    block = "\n\n---\n\nSuggested severity: S4\n\nCosmetic only, no functional impact."
 
     # Absent is deliberate — a run with low severity confidence omits the block.
     severity_block_hook({"params": {"text": plan}})

--- a/agents/frontend-triage/tests/test_hooks.py
+++ b/agents/frontend-triage/tests/test_hooks.py
@@ -7,25 +7,18 @@ hackbot_agents/frontend_triage/hooks.py.
 
 import pytest
 from agent_tools.registry import ToolError
-from hackbot_agents.frontend_triage.hooks import add_comment_hook, update_bug_hook
+from hackbot_agents.frontend_triage.config import ENABLED_ACTION_TYPES
+from hackbot_agents.frontend_triage.hooks import add_comment_hook
 from hackbot_runtime.actions import ActionsRecorder
+from hackbot_runtime.actions.claude_sdk import actions_to_tool_names
 
 BUG = 2014702
 
 
 def _recorder():
     rec = ActionsRecorder()
-    rec.add_hook("bugzilla.update_bug", update_bug_hook(rec, BUG))
     rec.add_hook("bugzilla.add_comment", add_comment_hook(rec, BUG))
     return rec
-
-
-def _update(rec, changes, bug_id=BUG):
-    return rec.record(
-        "bugzilla.update_bug",
-        {"bug_id": bug_id, "changes": changes},
-        reasoning="rule X",
-    )
 
 
 def _comment(rec, bug_id=BUG, **params):
@@ -36,107 +29,12 @@ def _comment(rec, bug_id=BUG, **params):
     )
 
 
-def _rejects(changes, bug_id=BUG):
-    """Assert the change is refused and nothing is left behind."""
-    rec = _recorder()
-    with pytest.raises(ToolError):
-        _update(rec, changes, bug_id=bug_id)
-    assert rec.actions == []
-
-
-def test_adding_an_allowed_keyword_is_recorded():
-    rec = _recorder()
-    _update(rec, {"keywords": {"add": ["perf"]}})
-    assert rec.actions[0]["params"]["changes"] == {"keywords": {"add": ["perf"]}}
-
-
-def test_setting_a_current_severity_is_recorded():
-    rec = _recorder()
-    _update(rec, {"severity": "S2"})
-    assert rec.actions[0]["params"]["changes"] == {"severity": "S2"}
-
-
-def test_an_unknown_severity_is_refused():
-    # Anything `rules/severity-assessment.md` doesn't define, including the legacy
-    # words Bugzilla still accepts for old bugs and the unset `--`/`N/A`.
-    for value in (
-        "S5",
-        "critical",
-        "normal",
-        "enhancement",
-        "--",
-        "N/A",
-        "",
-        "s2",
-        "S2 ",
-    ):
-        _rejects({"severity": value})
-
-
-def test_a_severity_that_is_not_a_string_is_refused():
-    for value in (None, True, 2, ["S2"], {"set": "S2"}):
-        _rejects({"severity": value})
-
-
-def test_an_unknown_keyword_is_refused():
-    # `keywords` being an allowed field does not open up all ~340 keywords Bugzilla
-    # defines, several of which drive automation.
-    for keyword in ("checkin-needed", "sec-high", "leave-open", "meta", ""):
-        _rejects({"keywords": {"add": [keyword]}})
-
-
-def test_one_bad_keyword_in_a_batch_is_enough():
-    _rejects({"keywords": {"add": ["perf", "leave-open"]}})
-
-
-def test_a_keyword_that_is_not_a_string_is_refused():
-    # Unhashable entries included: a bare `in` against a frozenset would raise
-    # TypeError here rather than returning a refusal the agent can read.
-    for keyword in (None, 7, True, ["perf"], {"name": "perf"}):
-        _rejects({"keywords": {"add": [keyword]}})
-
-
-def test_a_destructive_keyword_edit_is_refused():
-    # A bare list replaces every keyword already on the bug, and the recording tool
-    # advertises add/remove/set to the model, so name-only checking is not enough.
-    for value in (
-        ["perf"],
-        "perf",
-        {"set": ["perf"]},
-        {"set": []},
-        {"remove": ["regression"]},
-        {"add": ["perf"], "remove": ["regression"]},
-        {"add": "perf"},
-        {"add": []},
-        {},
-    ):
-        _rejects({"keywords": value})
-
-
-def test_a_field_outside_the_allowlist_is_refused():
-    # `bugzilla.update_bug` accepts any field the REST endpoint does, so the
-    # allowlist is what keeps triage from resolving or reassigning the bug.
-    for changes in (
-        {"status": "RESOLVED"},
-        {"resolution": "DUPLICATE"},
-        {"assigned_to": "someone@mozilla.com"},
-        {"component": "General"},
-        {"comment": "hi"},  # a third route to posting a comment
-        {"keywords": {"add": ["perf"]}, "status": "RESOLVED"},  # one bad key is enough
-    ):
-        _rejects(changes)
-
-
-def test_changes_must_be_a_non_empty_mapping():
-    for changes in ([], "", 0, {}, None, "keywords=perf"):
-        _rejects(changes)
-
-
-def test_a_change_against_another_bug_is_refused():
-    # The bug being triaged can name any other bug in its comments, and the agent
-    # reads all of them.
-    for bug_id in (999, "2014702", None, f"{BUG} "):
-        _rejects({"severity": "S2"}, bug_id=bug_id)
+def test_the_agent_is_given_no_tool_that_changes_a_bug_field():
+    # What makes dropping `severity` structural rather than something the prompt asks
+    # for: `ENABLED_ACTION_TYPES` decides which tools the actions server exposes at all.
+    assert ENABLED_ACTION_TYPES == ["bugzilla.add_comment"]
+    tools = actions_to_tool_names(ENABLED_ACTION_TYPES)
+    assert not [t for t in tools if "update_bug" in t], tools
 
 
 def test_a_private_comment_is_refused():
@@ -170,31 +68,11 @@ def test_only_one_comment_may_be_recorded():
     assert len(rec.actions) == 1
 
 
-def test_only_one_field_change_may_be_recorded():
-    rec = _recorder()
-    _update(rec, {"severity": "S2"})
-    with pytest.raises(ToolError):
-        _update(rec, {"severity": "S3"})
-    assert len(rec.actions) == 1
-
-
-def test_a_comment_and_a_field_change_coexist():
-    # One plan comment plus one field change is the pair the rules sanction, and the
-    # apply step coalesces it into a single Bugzilla PUT.
-    rec = _recorder()
-    _comment(rec)
-    _update(rec, {"keywords": {"add": ["perf"]}})
-    assert [a["type"] for a in rec.actions] == [
-        "bugzilla.add_comment",
-        "bugzilla.update_bug",
-    ]
-
-
-def test_a_refused_action_does_not_use_up_the_allowance():
+def test_a_refused_comment_does_not_use_up_the_allowance():
     # The count is taken from what was actually recorded, so a rejected attempt
     # leaves the agent free to retry with a corrected call.
     rec = _recorder()
     with pytest.raises(ToolError):
-        _update(rec, {"severity": "critical"})
-    _update(rec, {"severity": "S2"})
+        _comment(rec, is_private=True)
+    _comment(rec)
     assert len(rec.actions) == 1

--- a/agents/frontend-triage/tests/test_hooks.py
+++ b/agents/frontend-triage/tests/test_hooks.py
@@ -80,7 +80,7 @@ def test_a_refused_comment_does_not_use_up_the_allowance():
 
 def test_a_comment_may_declare_its_severity_only_once():
     plan = "Root cause is a stale selector in content-area.css."
-    block = "\n\n---\n\nSuggested severity: S4\n\nCosmetic only, no functional impact."
+    block = "\n\n---\n\nSuggested severity: S4\nCosmetic only, no functional impact."
 
     # Absent is deliberate — a run with low severity confidence omits the block.
     severity_block_hook({"params": {"text": plan}})

--- a/agents/frontend-triage/tests/test_hooks.py
+++ b/agents/frontend-triage/tests/test_hooks.py
@@ -8,7 +8,7 @@ hackbot_agents/frontend_triage/hooks.py.
 import pytest
 from agent_tools.registry import ToolError
 from hackbot_agents.frontend_triage.config import ENABLED_ACTION_TYPES
-from hackbot_agents.frontend_triage.hooks import add_comment_hook
+from hackbot_agents.frontend_triage.hooks import add_comment_hook, severity_block_hook
 from hackbot_runtime.actions import ActionsRecorder
 from hackbot_runtime.actions.claude_sdk import actions_to_tool_names
 
@@ -76,3 +76,21 @@ def test_a_refused_comment_does_not_use_up_the_allowance():
         _comment(rec, is_private=True)
     _comment(rec)
     assert len(rec.actions) == 1
+
+
+def test_a_comment_may_declare_its_severity_only_once():
+    plan = "Root cause is a stale selector in content-area.css."
+    block = "\n\n---\n\nSeverity assessment: S4\n\nRationale: cosmetic only."
+
+    # Absent is deliberate — a run with low severity confidence omits the block.
+    severity_block_hook({"params": {"text": plan}})
+    severity_block_hook({"params": {"text": plan + block}})
+
+    # An ordinary mention is not a declaration; the agent quotes reporters and argues
+    # about levels in its analysis, and only a line *starting* the declaration counts.
+    severity_block_hook(
+        {"params": {"text": "The reporter argues this is S1, but see below." + block}}
+    )
+
+    with pytest.raises(ToolError):
+        severity_block_hook({"params": {"text": plan + block + block}})

--- a/agents/frontend-triage/tests/test_notify.py
+++ b/agents/frontend-triage/tests/test_notify.py
@@ -57,29 +57,41 @@ def test_an_s1_is_marked_and_named():
     # The level is spelled out next to the emoji so it still reads as an S1 where the
     # emoji doesn't render.
     line = _message(
-        severity_assessment=SeverityAssessment(suggested="S1")
+        severity_assessment=SeverityAssessment(suggested="S1", confidence="high")
     ).splitlines()[0]
-    assert line == f":red_circle: *{BUG_LINK} — {SUMMARY}* (S1)"
+    assert line == f":red_circle: *{BUG_LINK} — {SUMMARY}* (suggested S1)"
+
+
+def test_a_medium_confidence_s1_is_still_marked():
+    line = _message(
+        severity_assessment=SeverityAssessment(suggested="S1", confidence="medium")
+    ).splitlines()[0]
+    assert line.startswith(":red_circle: ")
+
+
+def test_an_s1_the_run_is_unsure_of_is_unmarked():
+    # The comment drops its severity block below medium, so a marker here would have
+    # Slack shout S1 while the bug says nothing about severity at all.
+    for confidence in ("low", None):
+        line = _message(
+            severity_assessment=SeverityAssessment(
+                suggested="S1", confidence=confidence
+            )
+        ).splitlines()[0]
+        assert line == f"*{BUG_LINK} — {SUMMARY}*", confidence
 
 
 def test_every_other_severity_is_unmarked():
-    for suggested in ("S2", "S3", "S4", None, "", "  "):
+    for suggested in ("S2", "S3", "S4", None):
         line = _message(
-            severity_assessment=SeverityAssessment(suggested=suggested)
+            severity_assessment=SeverityAssessment(
+                suggested=suggested, confidence="high"
+            )
         ).splitlines()[0]
         assert line == f"*{BUG_LINK} — {SUMMARY}*", suggested
     # A run that could not assess severity reports none at all.
     line = _message(severity_assessment=None).splitlines()[0]
     assert line == f"*{BUG_LINK} — {SUMMARY}*"
-
-
-def test_a_lowercase_s1_is_still_an_s1():
-    # `suggested` is read out of the agent's free-form JSON block, so "s1" must not
-    # quietly read as an ordinary severity.
-    line = _message(
-        severity_assessment=SeverityAssessment(suggested=" s1 ")
-    ).splitlines()[0]
-    assert line.startswith(":red_circle: ")
 
 
 def test_a_missing_summary_leaves_the_bug_link_alone():

--- a/agents/frontend-triage/tests/test_plan.py
+++ b/agents/frontend-triage/tests/test_plan.py
@@ -11,6 +11,8 @@ from hackbot_agents.frontend_triage.agent import (
     may_apply_unattended,
     parse_confidence,
     parse_plan,
+    parse_severity,
+    parse_severity_assessment,
     render_scope,
 )
 from hackbot_agents.frontend_triage.config import TRIAGE_SCOPE, ScopedComponent
@@ -22,10 +24,10 @@ def _block(body: str) -> str:
 
 def test_the_system_prompt_renders():
     # system.md goes through str.format, so a literal brace in it must be doubled or
-    # startup raises KeyError and the run never begins. The prompt now has to show
-    # JSON payloads like {"add": [...]}, which is where that would happen.
+    # startup raises KeyError and the run never begins. The structured-output block is
+    # where that happens.
     prompt = load_system_prompt(Path("rules"), "")
-    assert '{"add": ["…"]}' in prompt
+    assert '"severity_assessment": {' in prompt
     assert "{rules_dir}" not in prompt
     assert "{triaged_components}" not in prompt
     # The component list reaches the prompt as full routing keys, since a bare component
@@ -152,3 +154,61 @@ def test_an_unusable_confidence_does_not_apply_unattended():
     assert may_apply_unattended(plan)
     plan = parse_plan(_block('{"confidence": "highish", "actionable": true}'))
     assert not may_apply_unattended(plan)
+
+
+def test_severity_is_normalized():
+    for value in ("S4", "s4", " S4 ", "s4\n"):
+        assert parse_severity(value) == "S4", value
+
+
+def test_an_unusable_severity_is_none():
+    # Bugzilla's legacy word forms and the unset markers are not levels this agent
+    # deals in, so they fail closed rather than reaching a bug as a suggestion.
+    for value in ("critical", "normal", "S5", "--", "N/A", "", "   ", None, 4, ["S4"]):
+        assert parse_severity(value) is None, value
+
+
+def test_the_severity_assessment_is_normalized():
+    assessment = parse_severity_assessment(
+        {"suggested": " s2 ", "confidence": "High", "rationale": "no workaround"}
+    )
+    assert assessment.suggested == "S2"
+    # "High" would otherwise read as "not high" and silently drop both the comment
+    # block and the Slack marker.
+    assert assessment.confidence == "high"
+    assert assessment.rationale == "no workaround"
+
+
+def test_each_field_degrades_on_its_own():
+    # Discarding the rationale along with an unusable level would throw away the half a
+    # human reads, and a non-string rationale would otherwise raise after the whole
+    # expensive run and lose the entire plan.
+    unusable_level = parse_severity_assessment(
+        {"suggested": "critical", "confidence": "nope", "rationale": "cosmetic only"}
+    )
+    assert (unusable_level.suggested, unusable_level.confidence) == (None, None)
+    assert unusable_level.rationale == "cosmetic only"
+
+    unusable_rationale = parse_severity_assessment(
+        {"suggested": "S3", "rationale": {"a": 1}}
+    )
+    assert unusable_rationale.suggested == "S3"
+    assert unusable_rationale.rationale is None
+
+
+def test_an_unusable_severity_assessment_is_none():
+    for value in (None, [], "S3", 3):
+        assert parse_severity_assessment(value) is None, value
+
+
+def test_parse_plan_normalizes_the_severity_assessment():
+    plan = parse_plan(
+        _block(
+            '{"confidence": "high", "severity_assessment": '
+            '{"suggested": "s1", "confidence": "MEDIUM", "rationale": "data loss"}}'
+        )
+    )
+    assessment = plan["severity_assessment"]
+    assert assessment.suggested == "S1"
+    assert assessment.confidence == "medium"
+    assert assessment.rationale == "data loss"


### PR DESCRIPTION
The agent used to write severity straight to the bug's `severity` field. At `confidence: high` that happened with no human in between. It still works out a severity — it just suggests it at the end of the comment now, before the footer:

    ---

    Suggested severity: S4
    Purely cosmetic, no functional impact. Only visible on Nightly.


The block is left out entirely when the agent isn't confident about the impact. A level it's unsure of still reads like a judgement someone might act on so we avoid that. 

## Other relevant changes

**Which confidence decides whether the block sev appears.** The agent reports two, and they measure different things:
- `confidence` — how sure it is that it found the cause in the code
- `severity_assessment.confidence` — how sure it is about the user impact

The block is gated on the second one. They're independent: the agent can be certain a bug is cosmetic while having no idea which file is at fault, and that bug should still get a severity suggestion. The rules didn't distinguish the two before; they
do now.

`notify.py` uses the same threshold for its Slack S1 marker, so Slack can't flag an S1 on a bug whose comment says nothing about severity.

**`severity_assessment` is now normalized in `parse_plan`.** It came straight from the model's JSON before, so `"High"` instead of `"high"` would have silently dropped both the comment block and the Slack marker.