### PR TITLE
Make autowebcompat repro script easier to use with mozregression

### DIFF
--- a/agents/autowebcompat-repro/Dockerfile
+++ b/agents/autowebcompat-repro/Dockerfile
@@ -50,14 +50,12 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install the DevTools MCP servers and Puppeteer from the pinned
-# package.json/lockfile. PUPPETEER_SKIP_DOWNLOAD stops Puppeteer's install
-# script from fetching its own bundled Chrome: the browsers this agent drives
-# are downloaded at startup instead (see browser.py).
+# package.json/lockfile.
 COPY agents/autowebcompat-repro/package.json \
      agents/autowebcompat-repro/package-lock.json \
      agents/autowebcompat-repro/repro_reference.mjs \
      /app/repro/
-RUN cd /app/repro && PUPPETEER_SKIP_DOWNLOAD=1 npm ci --omit=dev
+RUN cd /app/repro && npm ci --omit=dev
 
 # hackbot.toml lives at the agent root (not inside the package), so copy it into
 # the working dir; the runtime discovers it there (cwd) at startup.

--- a/agents/autowebcompat-repro/package-lock.json
+++ b/agents/autowebcompat-repro/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@mozilla/firefox-devtools-mcp-moz": "0.9.12",
         "chrome-devtools-mcp": "1.5.0",
-        "puppeteer": "25.4.0"
+        "puppeteer-core": "25.4.0"
       }
     },
     "node_modules/@bazel/runfiles": {
@@ -1194,18 +1194,6 @@
         "immediate": "~3.0.5"
       }
     },
-    "node_modules/lilconfig": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antonk52"
-      }
-    },
     "node_modules/loglevel": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
@@ -1412,27 +1400,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/puppeteer": {
-      "version": "25.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.4.0.tgz",
-      "integrity": "sha512-xfQp8dFBcGaLc1hEMaVr7s+oW4ZkAurr8Y9H81ilKhu6QoLfSTkZjU7IavnyJ/VWpB9ni3KNJUQHUatslLWyGw==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@puppeteer/browsers": "3.0.6",
-        "chromium-bidi": "17.0.2",
-        "devtools-protocol": "0.0.1653615",
-        "lilconfig": "^3.1.3",
-        "puppeteer-core": "25.4.0",
-        "typed-query-selector": "^2.12.2"
-      },
-      "bin": {
-        "puppeteer": "lib/puppeteer/node/cli.js"
-      },
-      "engines": {
-        "node": ">=22.12.0"
       }
     },
     "node_modules/puppeteer-core": {

--- a/agents/autowebcompat-repro/package.json
+++ b/agents/autowebcompat-repro/package.json
@@ -6,6 +6,6 @@
   "dependencies": {
     "@mozilla/firefox-devtools-mcp-moz": "0.9.12",
     "chrome-devtools-mcp": "1.5.0",
-    "puppeteer": "25.4.0"
+    "puppeteer-core": "25.4.0"
   }
 }

--- a/agents/autowebcompat-repro/repro_reference.mjs
+++ b/agents/autowebcompat-repro/repro_reference.mjs
@@ -1,3 +1,14 @@
+// For gecko engineers:
+// This script is designed to be used with mozregression.
+//
+// You will need to install node and npm. Once these are available,
+// install puppeteer-core:
+//   npm i puppeteer-core
+//
+// Then run mozregression like:
+//   mach mozregression --command="node <script.js>"
+
+
 // REFERENCE — use this structure, but replace this comment.
 //
 // This script checks whether one browser behaves as expected. Implement `probe`
@@ -18,13 +29,14 @@
 //   1 = the reported functionality did not work (breakage reproduced in this browser)
 //   2 = no verdict because the browser or script failed
 
-import puppeteer from "puppeteer";
+import puppeteer from "puppeteer-core";
 
-const { BROWSER, BROWSER_BIN } = process.env;
+const BROWSER = process.env.BROWSER ?? process.env.MOZREGRESSION_APP_NAME;
 if (BROWSER !== "firefox" && BROWSER !== "chrome") {
   console.error("set BROWSER to firefox or chrome");
   process.exit(2);
 }
+const BROWSER_BIN = process.env.BROWSER_BIN ?? process.env.MOZREGRESSION_BINARY;
 if (!BROWSER_BIN) {
   console.error("set BROWSER_BIN to the browser binary");
   process.exit(2);

--- a/agents/autowebcompat-repro/repro_reference.mjs
+++ b/agents/autowebcompat-repro/repro_reference.mjs
@@ -8,7 +8,6 @@
 // Then run mozregression like:
 //   mach mozregression --command="node <script.js>"
 
-
 // REFERENCE — use this structure, but replace this comment.
 //
 // This script checks whether one browser behaves as expected. Implement `probe`


### PR DESCRIPTION
Switch to puppeteer-core since we aren't using the browser download functionality anyway.

Use MOZREGRESSION_ environment variables to determine the browser name/path.

Together this means that one can investigate a regression locally using:

```
npm i puppeteer-core
./mach mozregression --command="node test.mjs"
```