### PR TITLE
Install ffmpeg into a few hackbot agent definition

### DIFF
--- a/agents/autowebcompat-diagnosis/Dockerfile
+++ b/agents/autowebcompat-diagnosis/Dockerfile
@@ -47,6 +47,8 @@ RUN apt-get update \
         libcups2t64 libdbus-1-3 libgbm1 libxcomposite1 libxdamage1 libxfixes3 \
         libxrandr2 libxkbcommon0 libasound2t64 libpango-1.0-0 libcairo2 \
         fonts-liberation \
+        # Codecs and audio/video related dependencies
+        ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # Install the DevTools MCP servers and Puppeteer from the pinned

--- a/agents/autowebcompat-repro/Dockerfile
+++ b/agents/autowebcompat-repro/Dockerfile
@@ -45,6 +45,8 @@ RUN apt-get update \
         libcups2t64 libdbus-1-3 libgbm1 libxcomposite1 libxdamage1 libxfixes3 \
         libxrandr2 libxkbcommon0 libasound2t64 libpango-1.0-0 libcairo2 \
         fonts-liberation \
+        # Codecs and audio/video related dependencies
+        ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # Install the DevTools MCP servers and Puppeteer from the pinned

--- a/agents/bug-fix/Dockerfile
+++ b/agents/bug-fix/Dockerfile
@@ -28,6 +28,11 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 FROM base AS agent
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
 # hackbot.toml lives at the agent root (not inside the package), so copy it into
 # the working dir; the runtime discovers it there (cwd) at startup.
 COPY agents/bug-fix/hackbot.toml /app/hackbot.toml

--- a/agents/build-repair/Dockerfile
+++ b/agents/build-repair/Dockerfile
@@ -28,6 +28,11 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 FROM base AS agent
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
 # hackbot.toml lives at the agent root (not inside the package), so copy it into
 # the working dir; the runtime discovers it there (cwd) at startup.
 COPY agents/build-repair/hackbot.toml /app/hackbot.toml

--- a/agents/test-plan-generator/Dockerfile
+++ b/agents/test-plan-generator/Dockerfile
@@ -35,6 +35,8 @@ RUN apt-get update \
         ca-certificates \
         libgtk-3-0 libdbus-glib-1-2 libx11-xcb1 libxtst6 libxt6 \
         libasound2 libpci3 \
+        # Codecs and audio/video related dependencies
+        ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # hackbot.toml lives at the agent root (not inside the package), so copy it into

--- a/agents/test-repair/Dockerfile
+++ b/agents/test-repair/Dockerfile
@@ -41,6 +41,8 @@ RUN apt-get update \
         libcairo2 libatk1.0-0t64 libatk-bridge2.0-0t64 libcups2t64 \
         libatspi2.0-0t64 \
         zip unzip bzip2 \
+        # Codecs and audio/video related dependencies
+        ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # hackbot.toml lives at the agent root (not inside the package), so copy it into


### PR DESCRIPTION
This adds two related things in a few agent dockerfiles:
- the Firefox/Chrome in the docker will be able to play h264 and AAC, those are very popular codecs and important for e.g. web compat or just authoring patches
- `ffprobe` and `ffmpeg` will be available as CLI programs. Those are the industry standard tools to poke at and generate media files, for diagnosis and/or test case authoring, testcase reduction, etc.

tested by booting the image and playing an h264/aac file in a real firefox there