### PR TITLE
Propagate finalize_run status fetch failures

### DIFF
--- a/services/hackbot-api/app/routers/runs.py
+++ b/services/hackbot-api/app/routers/runs.py
@@ -243,8 +243,8 @@ async def finalize_run(db: AsyncSession, run: Run) -> None:
     try:
         exec_status = await jobs.get_execution_status(run.execution_name)
     except Exception:
-        log.exception("Failed to fetch execution status for run %s", run.run_id)
-        return
+        log.warning("Failed to fetch execution status for run %s", run.run_id)
+        raise
 
     if exec_status in (ExecutionStatus.pending, ExecutionStatus.running):
         if (


### PR DESCRIPTION
Fixes #6691

Remove the broad exception swallow around in `finalize_run`. This ensures the route returns 5xx on transient errors so Pub/Sub/Eventarc retries, instead of silently leaving runs unfinalized with pending actions.