### PR TITLE
Fix login callback redirect path

### DIFF
--- a/services/hackbot-ui/middleware.ts
+++ b/services/hackbot-ui/middleware.ts
@@ -18,7 +18,10 @@ export function middleware(req: NextRequest) {
 
   // Remember the requested URL so the login page can send the user back here
   const loginUrl = new URL("/login", req.url);
-  loginUrl.searchParams.set("callbackURL", req.nextUrl.toString());
+  loginUrl.searchParams.set(
+    "callbackURL",
+    `${req.nextUrl.pathname}${req.nextUrl.search}`
+  );
   return NextResponse.redirect(loginUrl);
 }
 


### PR DESCRIPTION
Fix #6702 

The login middleware was storing the full request URL in the `callbackURL` query parameter. That included the absolute origin and could break the redirect back flow after authentication. This change stores only the requested path and query string so users return to the correct page after login.