### PR TITLE
frontend-triage: do not triage a bug that already has a patch

### DIFF
--- a/agents/frontend-triage/README.md
+++ b/agents/frontend-triage/README.md
@@ -58,6 +58,16 @@ The `scoping.md` ruleset runs first and filters out non-defects, tracking/`meta`
 bugs and intermittent test failures with a short note instead of an invented fix
 plan.
 
+Before any of that, a bug that already has a fix is stopped in Python.
+`preflight.py` reads the bug's attachments in one `get_bugs` call and ends the run
+if a non-obsolete Phabricator revision is attached — no checkout, no model turn, no
+comment. The developer who posted the patch is on it, and a fix plan arriving
+afterwards is noise in their review queue. `scoping.md` has always said so, but it
+is prose: on bug 2066504 the agent named the revision and investigated anyway,
+which is what this gate exists to prevent. A raw `is_patch` attachment deliberately
+does **not** count — that flag is set by whoever attaches the file, so a reporter's
+speculative diff would suppress triage on a bug nobody is working.
+
 ## Running it locally
 
 Needs Docker running, an Anthropic API key with billing enabled, and a Bugzilla
@@ -82,11 +92,12 @@ minutes and a large download. Later runs reuse the volume.
 
 Three bugs that exercise the classes this agent handles:
 
-| Bug       | Class       | Notes                                           |
-| --------- | ----------- | ----------------------------------------------- |
-| `2014702` | Behavioral  | New Tab weather widget vanishing                |
-| `2014629` | Pure visual | Split View group-line CSS gap                   |
-| `2004297` | Regression  | Print Preview shift; traces the named regressor |
+| Bug       | Class         | Notes                                                        |
+| --------- | ------------- | ------------------------------------------------------------ |
+| `2014702` | Behavioral    | New Tab weather widget vanishing                             |
+| `2014629` | Pure visual   | Split View group-line CSS gap                                |
+| `2004297` | Regression    | Print Preview shift; traces the named regressor              |
+| `2066504` | Already fixed | Phabricator revision attached; stops before the model starts |
 
 ## Inputs
 
@@ -118,6 +129,8 @@ Each run writes to `~/hackbot/artifacts/<run_id>/`:
 - **`logs/agent.log`** — the streamed reasoning and every tool call, and the only
   record of which model actually ran.
 - **No `changes/` directory.** Its absence confirms the run stayed read-only.
+- **A skipped run** (see above) is `status: "ok"` with `num_turns: 0`, an empty
+  `actions`, the reason in `result`, and no `logs/agent.log` — nothing ran.
 
 Two caveats before acting on a plan:
 
@@ -157,7 +170,7 @@ That is the whole list, because a comment is the only thing this agent can write
 It has no tool that changes a bug's fields: `severity` was the one field a ruleset
 directed it to set, and that is now a suggestion at the end of the comment for a
 human to apply, so `bugzilla.update_bug` left `ENABLED_ACTION_TYPES` rather than
-staying on with no caller. `tests/test_config.py` guards that.
+staying on with no caller.
 
 A refusal reaches the agent as a tool error it can correct in the same run, and the
 action never lands in `summary.json`. The action _type_ needs no check:
@@ -252,8 +265,8 @@ Registered with `hackbot-api` as `FrontendTriageInputs` in
 need the API.
 
 `tests/` covers what an unattended run's reach depends on: the record-time hooks
-(`test_hooks.py`), the plan parsing and `may_apply_unattended` (`test_plan.py`), and
-the Slack message and its routing (`test_notify.py`). Run them with
+(`test_hooks.py`), the plan parsing and `may_apply_unattended` (`test_plan.py`), the
+Slack message and its routing (`test_notify.py`), and the pre-flight gate (`test_preflight.py`). Run them with
 `uv run --package hackbot-agent-frontend-triage pytest agents/frontend-triage/tests`.
 CI covers the shared machinery this builds on via the `libs/agent-tools` and
 `libs/hackbot-runtime` suites.

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/__main__.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/__main__.py
@@ -1,8 +1,11 @@
+import sys
+
 from hackbot_runtime import HackbotContext, run_async
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from .agent import FrontendTriageResult, run_frontend_triage
 from .notify import record_notification
+from .preflight import attached_fix, fetch_bug
 
 TRIAGE_TASK = (
     "Triage this user-facing Firefox bug. Investigate the source tree "
@@ -33,15 +36,34 @@ class AgentInputs(BaseSettings):
 
 async def main(ctx: HackbotContext) -> FrontendTriageResult:
     inputs = AgentInputs()
+    bugzilla_mcp_server = {"type": "http", "url": inputs.bugzilla_mcp_url}
+
+    # Ahead of `prepare_repo`: a bug already being worked on should cost neither
+    # the mozilla-central checkout nor a model turn.
+    bug_fields = await fetch_bug(bugzilla_mcp_server, inputs.bug_id)
+    reason = attached_fix(bug_fields)
+    if reason:
+        print(
+            f"[frontend_triage] skipping bug {inputs.bug_id}: {reason}",
+            file=sys.stderr,
+        )
+        # Returned, not raised: `_finish` turns an exception into
+        # `status: "error"`, and this run did what it should have.
+        return FrontendTriageResult(
+            bug_id=inputs.bug_id,
+            num_turns=0,
+            total_cost_usd=0.0,
+            product=bug_fields.get("product"),
+            component=bug_fields.get("component"),
+            actionable=False,
+            result=f"Skipped bug {inputs.bug_id}: {reason}. No triage was run.",
+        )
 
     await ctx.prepare_repo()
 
     result = await run_frontend_triage(
         task=TRIAGE_TASK,
-        bugzilla_mcp_server={
-            "type": "http",
-            "url": inputs.bugzilla_mcp_url,
-        },
+        bugzilla_mcp_server=bugzilla_mcp_server,
         source_repo=ctx.repo_path,
         bug=inputs.bug_id,
         model=inputs.model,

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/preflight.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/preflight.py
@@ -1,0 +1,85 @@
+"""Stop a run before it triages a bug whose fix is already written.
+
+``rules/scoping.md`` has always said to stop on these, but a ruleset is advisory:
+on bug 2066504 the agent read the attachment, named the revision, and investigated
+anyway. This is the same rule somewhere the model cannot outrank it.
+
+The gate is one-directional -- all it can do is stop a run -- so everything it
+cannot read falls through to a triage. A needless triage costs a dollar; a wrongly
+skipped bug costs a triage nobody notices is missing.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from claude_agent_sdk import McpServerConfig
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+# `id` is required: `get_bugs` diffs requested against returned ids to report
+# inaccessible ones, and raises KeyError without it. The attachment fields are
+# dotted so Bugzilla leaves `data` out -- a bare `attachments` returns every
+# attachment's base64 body.
+BUG_FIELDS = (
+    "id,product,component,"
+    "attachments.id,attachments.content_type,attachments.is_obsolete"
+)
+
+# Matched by name rather than by `is_patch`, which is 0 on one of these: the
+# attachment is a URL, and the diff itself lives on Phabricator.
+PHABRICATOR_CONTENT_TYPE = "text/x-phabricator-request"
+
+
+def attached_fix(bug: dict) -> str | None:
+    """The revision already attached to this bug, or None to triage it."""
+    for attachment in bug.get("attachments") or ():
+        # Truthiness rather than `== 1`: Bugzilla sends these as ints.
+        if not isinstance(attachment, dict) or attachment.get("is_obsolete"):
+            continue
+        content_type = (attachment.get("content_type") or "").strip().lower()
+        if content_type == PHABRICATOR_CONTENT_TYPE:
+            return (
+                f"a Phabricator revision is attached "
+                f"(attachment {attachment.get('id')})"
+            )
+    return None
+
+
+async def fetch_bug(bugzilla_mcp_server: McpServerConfig, bug: int) -> dict:
+    """The bug's :data:`BUG_FIELDS`, read through the Bugzilla broker.
+
+    Via the broker because the agent container holds no Bugzilla credentials.
+    Never raises: ``{}`` on a missing url, a broker failure, or a bug this key
+    cannot read.
+    """
+    url = (
+        bugzilla_mcp_server.get("url")
+        if isinstance(bugzilla_mcp_server, dict)
+        else None
+    )
+    if not url:
+        return {}
+
+    try:
+        async with streamablehttp_client(url) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                res = await session.call_tool(
+                    "get_bugs",
+                    {"ids": [bug], "include_fields": BUG_FIELDS},
+                )
+                if res.isError:
+                    raise RuntimeError(
+                        "".join(getattr(c, "text", "") for c in res.content)
+                    )
+                bugs = json.loads(res.content[0].text).get("bugs") or []
+                return bugs[0] if bugs else {}
+    except Exception as e:  # - see docstring; every failure fails open
+        print(
+            f"[frontend_triage] pre-flight bug lookup failed "
+            f"({type(e).__name__}: {e}); triaging without it",
+            file=sys.stderr,
+        )
+        return {}

--- a/agents/frontend-triage/tests/test_preflight.py
+++ b/agents/frontend-triage/tests/test_preflight.py
@@ -1,0 +1,96 @@
+"""Tests for the gate that stops a run on a bug whose fix is already written.
+
+The payloads are what Bugzilla really returns -- the Phabricator stub carries
+`is_patch: 0`, so a fixture that guessed would test nothing. Refresh with the
+`curl` above each one.
+"""
+
+from hackbot_agents.frontend_triage import preflight
+from hackbot_agents.frontend_triage.preflight import (
+    BUG_FIELDS,
+    attached_fix,
+    fetch_bug,
+)
+
+# curl -s "https://bugzilla.mozilla.org/rest/bug?id=2066504&include_fields=\
+# id,product,component,attachments.id,attachments.content_type,attachments.is_obsolete"
+BUG_2066504 = {
+    "id": 2066504,
+    "product": "Firefox",
+    "component": "New Tab Page",
+    "attachments": [
+        {
+            "id": 9630702,
+            "content_type": "text/x-phabricator-request",
+            "is_obsolete": 0,
+        }
+    ],
+}
+
+# Same query for 2004297 -- an ordinary open bug, screenshot only.
+BUG_2004297 = {
+    "id": 2004297,
+    "product": "Firefox",
+    "component": "Tabbed Browser: Split View",
+    "attachments": [{"id": 9525275, "content_type": "image/gif", "is_obsolete": 0}],
+}
+
+
+def test_bug_2066504_is_skipped_on_the_payload_bugzilla_really_returns():
+    reason = attached_fix(BUG_2066504)
+    assert reason is not None
+    assert "9630702" in reason
+
+
+def test_an_ordinary_open_bug_is_triaged():
+    assert attached_fix(BUG_2004297) is None
+
+
+def test_an_obsolete_revision_is_not_a_fix():
+    superseded = {
+        "attachments": [
+            {"id": 1, "content_type": "text/x-phabricator-request", "is_obsolete": 1}
+        ]
+    }
+    assert attached_fix(superseded) is None
+
+
+def test_a_raw_patch_attachment_is_not_a_fix():
+    # Deliberate: `is_patch` is set by whoever attaches, so a reporter's
+    # speculative diff would suppress triage on a bug nobody is working.
+    diff = {
+        "attachments": [
+            {"id": 2, "content_type": "text/plain", "is_patch": 1, "is_obsolete": 0}
+        ]
+    }
+    assert attached_fix(diff) is None
+
+
+def test_a_bug_that_could_not_be_read_is_triaged_rather_than_skipped():
+    # `{}` is what `fetch_bug` returns for a broker failure or an inaccessible
+    # bug; the rest are fields the proxy could drop or garble.
+    assert attached_fix({}) is None
+    assert attached_fix({"id": 1}) is None
+    assert attached_fix({"attachments": None}) is None
+    assert attached_fix({"attachments": []}) is None
+    assert attached_fix({"attachments": [None, "not a dict", {}]}) is None
+    assert attached_fix({"attachments": [{"content_type": None}]}) is None
+
+
+def test_the_lookup_asks_for_the_id_and_for_attachments_without_their_data():
+    assert BUG_FIELDS.startswith("id,")
+    assert "attachments.content_type" in BUG_FIELDS
+    assert "attachments.is_obsolete" in BUG_FIELDS
+    assert ",attachments," not in BUG_FIELDS
+    assert not BUG_FIELDS.endswith(",attachments")
+
+
+async def test_a_broker_failure_triages_the_bug_rather_than_skipping_it(monkeypatch):
+    assert await fetch_bug({}, 1) == {}
+    assert await fetch_bug({"type": "http"}, 1) == {}
+
+    def boom(url):
+        raise ConnectionError("broker is down")
+
+    monkeypatch.setattr(preflight, "streamablehttp_client", boom)
+    assert await fetch_bug({"type": "http", "url": "http://broker/mcp"}, 1) == {}


### PR DESCRIPTION
The run https://hackbot.moz.tools/runs/ecc7138a-e8c8-4a88-8815-c3a8f9282986,  the agent saw an attached Phabricator revision, said so, and investigated anyway — 13 turns and $1.21 to conclude the work was already done.

`rules/scoping.md` says to stop on these, but the ruleset is just advisory and `TRIAGE_TASK` outranks it.

`preflight.py` reads the bug's attachments before `prepare_repo` and ends the run when a non-obsolete Phabricator revision is attached: no checkout, no model turn, no comment. Everything it can't read (broker failure, dropped field) falls
through to a triage.

Not included: raw `is_patch` attachments (that flag is set by whoever attaches, so a reporter's speculative diff would suppress triage) or closed status.

This may not capture every single case, but it catches the majority of cases the agent will encounter. 