### PR TITLE
Route Toolkit :: Data Sanitization bugs to #privacy-team-automation, and derive its docs from the tree that registers them rather than the tree its code is in

### DIFF
--- a/agents/frontend-triage/README.md
+++ b/agents/frontend-triage/README.md
@@ -27,6 +27,7 @@ and the channel each reports to:
 | --------------------------------- | -------------------------------- |
 | `Firefox :: New Tab Page`         | `#hnt-dev-triage`                |
 | `Firefox :: Site Permissions`     | `#privacy-team-automation`       |
+| `Toolkit :: Data Sanitization`    | `#privacy-team-automation`       |
 | `Firefox :: Sharing`              | `#content-sharing-automation`    |
 | `Firefox :: IP Protection`        | `#team-eng-ip-protection-triage` |
 | `Firefox :: Messaging System`     | `#omc-triage`                    |
@@ -36,9 +37,12 @@ and the channel each reports to:
 | `Toolkit :: Application Update`   | `#installer-updater-bug-triage`  |
 | `Firefox :: Installer`            | `#installer-updater-bug-triage`  |
 
-Where a component's code is documented is **not** listed anywhere here. mozilla-central
-already records it in `SPHINX_TREES` declarations, so `docs.py` runs one `git grep` over
-the checkout and matches those declarations against each entry's `trees`. That is what
+No doc path or URL is listed anywhere here. mozilla-central already records where a
+component is documented in its `SPHINX_TREES` declarations, so `docs.py` runs one
+`git grep` over the checkout and matches those declarations against each entry's `trees`.
+`Toolkit :: Data Sanitization` is the one entry that also says which directory to search,
+via `doc_trees`, because its article is registered by another component's `moz.build`; the
+registration there is still read from the tree. That is what
 replaced the `rules/areas/` directory: eight hand-written files restating structure that
 `toolkit/mozapps/update/docs/`, `browser/installer/windows/docs/`,
 `extensions/permissions/docs/`, `toolkit/components/ipprotection/docs/` and the rest
@@ -220,13 +224,14 @@ stays silent, even if someone applies it by hand later.
 
 Routing is the `channel` on each `TRIAGE_SCOPE` entry in `config.py`, looked up by
 `"<Product> :: <Component>"` through the derived `SLACK_CHANNELS` — so
-`ScopedComponent("Firefox", "New Tab Page", "Desktop frontend", "#hnt-dev-triage")`
+`ScopedComponent("Firefox", "New Tab Page", "#hnt-dev-triage", trees=(...))`
 sends a New Tab Page run to `#hnt-dev-triage`.
 
 Four things about that which are not obvious from reading the registry:
 
 - **The key is the component, not the team**, so two components may share a channel, as
-  the installer and the updater do, without either knowing about the other.
+  the installer and the updater do and as site permissions and data sanitization do,
+  without either knowing about the other.
 - **There is deliberately no default channel**, since posting one team's triage into
   another team's channel is worse than silence.
 - **`TRIAGE_SCOPE` is narrower than what the agent will triage.** It is the routing
@@ -269,7 +274,7 @@ notifies. The run page shows the failed action.
 
 ## Adding a triage component
 
-One `ScopedComponent` entry in `config.py`, and nothing else:
+One `ScopedComponent` entry in `config.py`, and a row in the table above:
 
 ```python
 ScopedComponent(
@@ -284,6 +289,13 @@ ScopedComponent(
 
 - **`trees`** is descriptive and may overlap another component. It drives the prompt's
   index and the docs lookup, so it is what makes the component triageable.
+- **`doc_trees`** is for the one case where a component's docs are not under its code,
+  and it **replaces** `trees` for the docs lookup rather than adding to it. Only
+  `Toolkit :: Data Sanitization` needs it: its article is registered by
+  `toolkit/components/antitracking/moz.build`, and its own
+  `browser/base/content/sanitize*` files otherwise resolve to `browser/base/`'s
+  tabbrowser and sslerrorreport trees. Leave it empty unless `docs_for` returns a
+  sibling component's documentation, which is the symptom it treats.
 - **`owns`** is the narrower claim that "no other component could mean this file", and it
   is what `component_guidance_hook` refuses comments on. Leave it empty rather than
   widening it to a tree that contains other components: `browser/` as an `owns` value
@@ -307,7 +319,10 @@ need the API.
 
 `tests/` covers what an unattended run's reach depends on: the record-time hooks
 (`test_hooks.py`), the plan parsing and `may_apply_unattended` (`test_plan.py`), the
-Slack message and its routing (`test_notify.py`), and the pre-flight gate (`test_preflight.py`). Run them with
+Slack message and its routing (`test_notify.py`), the docs derivation
+(`test_docs.py`, whose real-checkout test needs `SOURCE_REPO`), the
+`load_component_guidance` tool (`test_guidance.py`), and the pre-flight gate
+(`test_preflight.py`). Run them with
 `uv run --package hackbot-agent-frontend-triage pytest agents/frontend-triage/tests`.
 CI covers the shared machinery this builds on via the `libs/agent-tools` and
 `libs/hackbot-runtime` suites.

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/config.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/config.py
@@ -60,9 +60,21 @@ class ScopedComponent(NamedTuple):
     # triage with nobody told -- which is what `channel_for` failing closed produces,
     # and not something to be able to express by accident.
     channel: str
-    # Where this component's code lives, for the prompt's index and for `docs.docs_for`.
-    # Descriptive, so it may be broad and overlap another component.
+    # Where this component's code lives, for the prompt's index and, unless `doc_trees`
+    # below overrides it, for `docs.docs_for`. Descriptive, so it may be broad and
+    # overlap another component.
     trees: tuple[str, ...]
+    # Where this component's documentation is registered, when that is not under `trees`.
+    # Overrides `trees` for `docs.docs_for` and for nothing else: the prompt's index still
+    # renders `trees`, because a docs directory is not where the code is.
+    #
+    # Data Sanitization is the only entry that needs it, and it needs it twice over. The
+    # article is registered by `toolkit/components/antitracking/moz.build`, which is
+    # `Core :: Privacy: Anti-Tracking` and not a tree this component may claim; and its own
+    # `browser/base/content/sanitize*` files resolve to `browser/base/moz.build`'s
+    # tabbrowser and sslerrorreport trees, so leaving the lookup on `trees` gave it two
+    # unrelated components' documentation and none of its own.
+    doc_trees: tuple[str, ...] = ()
     # Paths whose bugs belong to this component, for `owners_for_path` and so for
     # `hooks.component_guidance_hook`. Deliberately narrower than `trees`: a tree like
     # `browser/` would refuse comments the guidance itself asked for -- IP Protection
@@ -76,7 +88,7 @@ class ScopedComponent(NamedTuple):
     owns: tuple[str, ...] = ()
     # Triage guidance that no source doc carries: which of two similar things this bug is
     # about, what a symptom in one layer usually means about another, whether the area is
-    # tested. Everything structural belongs in the docs `trees` resolves to, not here --
+    # tested. Everything structural belongs in the docs the trees resolve to, not here --
     # if a sentence restates a doc page, delete it rather than paraphrase it.
     notes: str = ""
     # Components sent alongside this one, for bugs that routinely turn out to be somewhere
@@ -157,6 +169,77 @@ TRIAGE_SCOPE = (
             'not stick", "it came back after a restart" and wrong-expiry bugs localize '
             "there and are **not** out of scope for being non-JS."
         ),
+    ),
+    # Site Permissions and Data Sanitization are triaged by the same team, so they share a
+    # channel, the way the installer and the updater do below.
+    ScopedComponent(
+        "Toolkit",
+        "Data Sanitization",
+        "#privacy-team-automation",
+        trees=(
+            "toolkit/components/cleardata/",
+            "toolkit/components/forgetaboutsite/",
+            "toolkit/components/clearsitedata/",
+            "browser/modules/Sanitizer.sys.mjs",
+            "browser/base/content/sanitizeDialog.js",
+            "browser/base/content/sanitize_v2.xhtml",
+        ),
+        # The one entry in the registry whose documentation is not under its code: the
+        # article is `toolkit/components/antitracking/docs/data-sanitization/`, registered
+        # by the anti-tracking `moz.build`. See `doc_trees` on `ScopedComponent`.
+        doc_trees=("toolkit/components/antitracking/docs/",),
+        # The paths `moz.build` gives `BUG_COMPONENT = ("Toolkit", "Data Sanitization")`,
+        # plus the test directory. Both parents are shared, so neither is claimed:
+        # `browser/base/content/` holds `browser.js` and `browser/modules/` holds site
+        # permissions' two modules.
+        owns=(
+            "toolkit/components/cleardata/",
+            "toolkit/components/forgetaboutsite/",
+            "toolkit/components/clearsitedata/",
+            "browser/modules/Sanitizer.sys.mjs",
+            "browser/base/content/sanitizeDialog.js",
+            "browser/base/content/sanitize_v2.xhtml",
+            "browser/base/content/test/sanitize/",
+        ),
+        notes=(
+            "**Four pref families, and the doc above names a retired one.** Its table "
+            "says `privacy.clearOnShutdown.*`; the live shutdown branch is "
+            "`Sanitizer.sys.mjs`'s `PREF_SHUTDOWN_BRANCH`, which is "
+            "`privacy.clearOnShutdown_v2.`, and the pre-v2 names survive only for "
+            "`maybeMigratePrefs` and its "
+            "`privacy.sanitize.<context>.hasMigratedToNewPrefs3` flag. The four live "
+            "branches are `privacy.clearOnShutdown_v2.`, `privacy.cpd.`, "
+            "`privacy.clearHistory.` and `privacy.clearSiteData.`, all declared in "
+            "`browser/app/profile/firefox.js` and chosen by which entry point the user "
+            "came through. So establish the entry point before reading a pref, and do "
+            "not take a pref name from the doc.\n\n"
+            "**Two of the five clearing entry points are not this component.** The "
+            '"Manage Data" list and the identity panel\'s clear button run '
+            "through `browser/modules/SiteDataManager.sys.mjs`, "
+            "`browser/components/preferences/dialogs/siteDataSettings.js` and "
+            "`browser/base/content/browser-siteIdentity.js`, which `moz.build` gives to "
+            "`Firefox :: Settings UI`, and they reach the service without touching "
+            "`Sanitizer.sys.mjs` at all. The doc lists all five together, which is what "
+            "makes this worth saying: a bug about the site list or the button is not "
+            "localized in the sanitizer.\n\n"
+            "**A shutdown hang can be a data-clearing bug.** Clearing runs mostly on the "
+            "main thread while the browser is shutting down, so a large profile can "
+            "outlast the shutdown watchdog and the parent process is killed. A "
+            "shutdownhang from a reporter who has clear-on-shutdown enabled localizes "
+            "here rather than in the crash reporter.\n\n"
+            "**Coverage is good, so an empty `relevant_tests` is almost always wrong "
+            "here** -- the opposite of Installer. 23 files in "
+            "`browser/base/content/test/sanitize/`, 39 under "
+            "`toolkit/components/cleardata/tests/` across xpcshell, browser and "
+            "marionette, and `browser/modules/test/unit/test_Sanitizer_interrupted_v2.js` "
+            "for the interrupted-shutdown path. The one exception is "
+            "`toolkit/components/clearsitedata/`, whose C++ header handler has no tests "
+            "directory of its own because it is covered by web-platform-tests under "
+            "`testing/web-platform/tests/`; say that rather than reporting no coverage."
+        ),
+        # Cookie permissions decide who is exempt from clear-on-shutdown and who is always
+        # cleared, and site permissions owns `extensions/permissions/` where they live.
+        related=("Firefox :: Site Permissions",),
     ),
     ScopedComponent(
         "Firefox",

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/docs.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/docs.py
@@ -1,8 +1,11 @@
 """Which Firefox Source Docs cover a triaged component, worked out from the checkout.
 
-Nothing here is written down in `config.py`. mozilla-central already records the mapping
-in `SPHINX_TREES` declarations, and restating it would be one more list to keep in step
-with a tree we do not control -- the thing this module exists to stop.
+No doc path or URL is written down in `config.py`. mozilla-central already records the
+mapping in `SPHINX_TREES` declarations, and restating it would be one more list to keep
+in step with a tree we do not control -- the thing this module exists to stop. The one
+thing an entry may say for itself is `doc_trees`, which names the directory to search
+when a component's docs are not under its code; the registration there is still read
+from the tree.
 """
 
 from __future__ import annotations
@@ -169,6 +172,13 @@ def registrations(repo: Path) -> tuple[DocRef, ...]:
 def docs_for(entry: ScopedComponent, known: tuple[DocRef, ...]) -> tuple[DocRef, ...]:
     """The registrations whose source directory sits under one of ``entry.trees``.
 
+    An entry that sets `doc_trees` is searched under that instead, because its docs are
+    not under its code. The override **replaces** `trees` rather than adding to it, and
+    that is the point rather than an economy: Data Sanitization's
+    `browser/base/content/sanitize*` files resolve to `browser/base/moz.build`'s
+    tabbrowser and sslerrorreport trees, so a union would keep both of those alongside
+    the article it is reaching for.
+
     A `trees` entry may name a file rather than a directory
     (`browser/modules/SitePermissions.sys.mjs`), and the trailing slash is what says
     which. That is a convention `test_plan.py` enforces rather than a guess: sniffing for
@@ -182,7 +192,7 @@ def docs_for(entry: ScopedComponent, known: tuple[DocRef, ...]) -> tuple[DocRef,
     claim about where its code is.
     """
     prefixes = []
-    for tree in entry.trees:
+    for tree in entry.doc_trees or entry.trees:
         if not tree.endswith("/"):
             tree = str(Path(tree).parent)
         prefixes.append(tree.rstrip("/") + "/")

--- a/agents/frontend-triage/tests/test_docs.py
+++ b/agents/frontend-triage/tests/test_docs.py
@@ -144,6 +144,36 @@ def test_a_component_whose_trees_hold_no_docs_gets_none():
     assert docs_for(entry, known) == ()
 
 
+def test_doc_trees_replaces_the_search_rather_than_widening_it():
+    # The invariant behind Data Sanitization's entry, and the one a future reader is most
+    # likely to "fix" into a union. Its docs are registered by the anti-tracking
+    # `moz.build`, while its own `browser/base/content/sanitize*` files sit under
+    # `browser/base/moz.build`'s tabbrowser tree -- so a union hands the prompt an
+    # unrelated component's documentation alongside the right article, and a comment
+    # citing that is worse than one citing nothing.
+    known = (
+        DocRef(
+            tree="toolkit/components/antitracking/docs",
+            path="toolkit/components/antitracking/anti-tracking/",
+        ),
+        DocRef(
+            tree="browser/base/content/docs/tabbrowser", path="browser/base/tabbrowser/"
+        ),
+    )
+    entry = ScopedComponent(
+        "Toolkit",
+        "Data Sanitization",
+        "#chan",
+        trees=("browser/base/content/sanitizeDialog.js",),
+        doc_trees=("toolkit/components/antitracking/docs/",),
+    )
+    assert docs_for(entry, known) == (known[0],)
+
+    # And without the override the same entry gets the wrong one, which is what the
+    # override exists for. Asserting it keeps the test honest about the alternative.
+    assert docs_for(entry._replace(doc_trees=()), known) == (known[1],)
+
+
 def test_a_gitconfig_that_adds_line_numbers_does_not_break_parsing(tmp_path):
     # `grep.lineNumber = true` is an ordinary convenience setting, and it changes
     # `git grep` output to `path:lineno:content`. Splitting on the first colon then hands
@@ -225,7 +255,7 @@ _REPO = os.environ.get("SOURCE_REPO")
     reason="needs a mozilla-central checkout; set SOURCE_REPO",
 )
 def test_the_derivation_agrees_with_a_real_checkout():
-    # Two spot checks against the real tree, both of which I confirmed load. The point is
+    # Three spot checks against the real tree, all of which I confirmed load. The point is
     # that the rule is right, not that any particular component has docs -- a component
     # legitimately has none, and a stale checkout legitimately has neither.
     known = registrations(Path(_REPO))
@@ -245,8 +275,21 @@ def test_the_derivation_agrees_with_a_real_checkout():
             ScopedComponent(
                 "Firefox", "Installer", "#c", trees=("browser/installer/",)
             ),
+            # The `doc_trees` case, and the reason the field exists: this article is
+            # registered by `toolkit/components/antitracking/moz.build`, so it resolves
+            # only because the entry names that directory rather than its own code.
+            ScopedComponent(
+                "Toolkit",
+                "Data Sanitization",
+                "#c",
+                trees=("toolkit/components/cleardata/",),
+                doc_trees=("toolkit/components/antitracking/docs/",),
+            ),
         )
         for d in docs_for(entry, known)
     }
     assert f"{SOURCE_DOCS_BASE_URL}toolkit/ipprotection/" in urls
     assert f"{SOURCE_DOCS_BASE_URL}browser/installer/windows/installer/" in urls
+    assert (
+        f"{SOURCE_DOCS_BASE_URL}toolkit/components/antitracking/anti-tracking/" in urls
+    )

--- a/agents/frontend-triage/tests/test_plan.py
+++ b/agents/frontend-triage/tests/test_plan.py
@@ -418,7 +418,7 @@ def test_a_directory_is_spelled_with_a_trailing_slash_and_a_file_without():
     # a trailing slash turns an exact-match claim into a prefix claim that matches
     # nothing, so the component silently stops owning the file it named.
     for entry in TRIAGE_SCOPE:
-        for value in (*entry.trees, *entry.owns):
+        for value in (*entry.trees, *entry.doc_trees, *entry.owns):
             basename = value.rstrip("/").rsplit("/", 1)[-1]
             assert basename, f"{entry.key}: {value!r} has no final segment"
             if "." in basename:


### PR DESCRIPTION
**This should land and deploy before mozilla/bugbot#3002.**