### PR TITLE
Fix failure to apply bugzilla.create_bug action

### DIFF
--- a/libs/hackbot-runtime/hackbot_runtime/actions/bugzilla.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/bugzilla.py
@@ -226,7 +226,6 @@ async def create_bug(
         "summary": summary,
         "version": version,
         "description": description,
-        "is_markdown": True,
     }
     for k, v in (extra or {}).items():
         body.setdefault(k, v)

--- a/libs/hackbot-runtime/hackbot_runtime/actions/handlers/bugzilla_handler.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/handlers/bugzilla_handler.py
@@ -143,13 +143,8 @@ class AddAttachmentHandler:
 
 class CreateBugHandler:
     async def apply(self, params: dict[str, Any], ctx: ApplyContext) -> ActionResult:
-        # TEMPORARY: BMO's POST /bug rejects `is_markdown` with a 400 Bad
-        # Request. `create_bug` no longer records it, but this strip is needed
-        # to apply actions recorded before that change. Delete it once no
-        # pending/failed `bugzilla.create_bug` row still carries the flag.
-        body = {k: v for k, v in params.items() if k != "is_markdown"}
         try:
-            data = _request("POST", "bug", body)
+            data = _request("POST", "bug", params)
         except Exception as exc:
             log.exception("Failed to create bug: %s", params.get("summary"))
             return ActionResult.failed(str(exc))

--- a/libs/hackbot-runtime/hackbot_runtime/actions/handlers/bugzilla_handler.py
+++ b/libs/hackbot-runtime/hackbot_runtime/actions/handlers/bugzilla_handler.py
@@ -143,8 +143,13 @@ class AddAttachmentHandler:
 
 class CreateBugHandler:
     async def apply(self, params: dict[str, Any], ctx: ApplyContext) -> ActionResult:
+        # TEMPORARY: BMO's POST /bug rejects `is_markdown` with a 400 Bad
+        # Request. `create_bug` no longer records it, but this strip is needed
+        # to apply actions recorded before that change. Delete it once no
+        # pending/failed `bugzilla.create_bug` row still carries the flag.
+        body = {k: v for k, v in params.items() if k != "is_markdown"}
         try:
-            data = _request("POST", "bug", params)
+            data = _request("POST", "bug", body)
         except Exception as exc:
             log.exception("Failed to create bug: %s", params.get("summary"))
             return ActionResult.failed(str(exc))

--- a/libs/hackbot-runtime/tests/test_bugzilla_actions.py
+++ b/libs/hackbot-runtime/tests/test_bugzilla_actions.py
@@ -58,7 +58,8 @@ async def test_create_bug_merges_extra_top_level_wins():
     body = rec.actions[0]["params"]
     assert body["severity"] == "S3"
     assert body["product"] == "Core"  # explicit arg wins over extra
-    assert body["is_markdown"] is True
+    # BMO's POST /bug rejects `is_markdown` with a 400, so it is never recorded.
+    assert "is_markdown" not in body
 
 
 async def test_handlers_return_confirmation_string():


### PR DESCRIPTION
`create_bug` records `is_markdown: true`, but BMO's `POST /bug` endpoint rejects that parameter with a `400 Bad Request`, causing every recorded bug filing to fail when applied.

### Changes

* `create_bug` no longer records `is_markdown` in the action body.
* `CreateBugHandler` strips `is_markdown` before sending the `POST` request, allowing already-recorded actions to succeed on retry.

  * This is temporary and can be removed once no pending action rows contain the flag.

Fixes #6752
