### PR TITLE
Add ai-triage-wrong-fix and ai-triage-shallow-fix to the frontend-triage feedback tags

### DIFF
--- a/agents/frontend-triage/README.md
+++ b/agents/frontend-triage/README.md
@@ -204,9 +204,13 @@ Two further hooks shape the comment text as it is recorded:
   checkout.
 - `feedback_tags_hook` (`agent.py`) appends the triage-specific tags a reader can
   add to categorize a problem: `ai-triage-wrong-file`, `ai-triage-wrong-cause`,
-  `ai-triage-hallucination`, `ai-triage-out-of-scope`.
+  `ai-triage-hallucination`, `ai-triage-out-of-scope`, `ai-triage-wrong-fix`,
+  `ai-triage-shallow-fix`. The last two are about the fix plan rather than the
+  diagnosis: one for a fix that would not work, one for a fix that patches the
+  symptom instead of the cause the comment just named.
 
-Below both sits the runtime's shared footer inviting a 👍 or 👎 reaction. Those
+The tags go under the runtime's shared footer inviting a 👍 or 👎 reaction, which
+`bugzilla.add_comment` has already appended by the time the hook runs. Those
 reactions and tags are the feedback channel — the agent does not request needinfo.
 
 ## Slack notification

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
@@ -73,7 +73,7 @@ _JSON_BLOCK = re.compile(r"```json\s*(\{.*?\})\s*```", re.DOTALL)
 _FEEDBACK_TAGS = (
     "If you want to categorize your feedback you can add one of the following "
     "tags: ai-triage-wrong-file, ai-triage-wrong-cause, ai-triage-hallucination, "
-    "ai-triage-out-of-scope."
+    "ai-triage-out-of-scope, ai-triage-wrong-fix, ai-triage-shallow-fix."
 )
 
 


### PR DESCRIPTION
All four tags the triage comment offers, from `ai-triage-wrong-file` to `ai-triage-out-of-scope`, describe the diagnosis, so a reader who thinks the fix plan itself is wrong, or that it only patches the symptom, has nothing but an uncategorized thumbs-down. `ai-triage-wrong-fix` and `ai-triage-shallow-fix` give those two failure modes a name; the README change is incidental, correcting a claim that the 👍/👎 footer sits below the tags when `bugzilla.add_comment` appends it before the hook runs.