### PR TITLE
Reduce listener delay for CI agents

### DIFF
--- a/services/hackbot-pulse-listener/README.md
+++ b/services/hackbot-pulse-listener/README.md
@@ -48,7 +48,7 @@ Failed **build** tasks go to `build-repair`; failed **test** tasks go to `test-r
    - _Both:_ a walk is abandoned as soon as another task triggers the run for that
      push. One push can emit dozens of failing tasks, and without this each one holds
      a worker for the full wait only to find the push already handed off.
-6. **Budget.** At most `MAX_TEST_REPAIRS_PER_DAY` test-repair runs (default 50) may
+6. **Budget.** At most `MAX_TEST_REPAIRS_PER_DAY` test-repair runs (default 100) may
    start in any rolling 24 hours. A slot is taken when a run is triggered and given
    back if the trigger fails, so only runs that really started count. Once the budget
    is spent, later test failures stop before any Treeherder work. Build-repair is not

--- a/services/hackbot-pulse-listener/README.md
+++ b/services/hackbot-pulse-listener/README.md
@@ -27,7 +27,11 @@ Failed **build** tasks go to `build-repair`; failed **test** tasks go to `test-r
    agent works from a single task but reads the push's other failures itself, so a
    second run for the same push would re-tread the same ground. A revision is recorded
    only once a run is actually triggered, so a task rejected as intermittent or
-   inherited leaves the push open for the next one.
+   inherited leaves the push open for the next one. A second cache spans pushes: a
+   failure already investigated on a recent push is skipped for
+   `GROUP_DEDUPE_TTL_SECONDS`, keyed by failing manifest — or, for a task compared as a
+   whole, by its label without the chunk number — since a broken manifest stays broken
+   on the pushes that follow.
 5. **Judge** whether the failure is worth a run. Every check fails open — an upstream
    error runs the agent rather than dropping a possible regression.
    - _Build:_ keep only failures this push introduced, waiting for an unsettled ancestor

--- a/services/hackbot-pulse-listener/README.md
+++ b/services/hackbot-pulse-listener/README.md
@@ -36,12 +36,15 @@ Failed **build** tasks go to `build-repair`; failed **test** tasks go to `test-r
      regression (intermittent, infra, expected-fail, fixed-by-commit). Treeherder ingests
      the job a minute or so behind us, and sheriffs classify it — mostly by hand — a
      median of ~1 minute past the end of the job, ~11 minutes at p90 (measured over 40
-     recent autoland pushes), so this gate waits for the job to appear and then up to
-     `TREEHERDER_CLASSIFICATION_WAIT_SECONDS` for its verdict. It is the cheap filter,
-     and most test failures stop here, before any group is fetched or any ancestor
-     walked. What survives goes through the ancestor walk below, then Treeherder is
-     asked once more, since a verdict can still land while that walk runs. The run
-     carries only the task id.
+     recent autoland pushes), so this gate waits for the job to appear, briefly for its
+     log to be parsed (`TREEHERDER_LOG_PARSE_WAIT_SECONDS` — the failure lines the
+     intermittent gate and history check read are not there before), and then up to
+     `TREEHERDER_CLASSIFICATION_WAIT_SECONDS` for its verdict, unless the
+     [history check](#skipping-the-classification-wait) says no verdict is coming. It is
+     the cheap filter, and most test failures stop here, before any group is fetched or
+     any ancestor walked. What survives goes through the ancestor walk below, then
+     Treeherder is asked once more, since a verdict can still land while that walk runs.
+     The run carries only the task id.
    - _Both:_ a walk is abandoned as soon as another task triggers the run for that
      push. One push can emit dozens of failing tasks, and without this each one holds
      a worker for the full wait only to find the push already handed off.

--- a/services/hackbot-pulse-listener/README.md
+++ b/services/hackbot-pulse-listener/README.md
@@ -89,8 +89,18 @@ the agent. `MAX_TEST_REPAIRS_PER_DAY` is the backstop; watch it after deploying.
 
 Both paths ask the same question — did this push introduce the failure, or inherit it
 from an ancestor? — by walking the push's ancestors (mozci resolves the chain from the
-pushlog) until one gives a verdict on the failing unit, and both wait up to ten minutes
-for an ancestor still running before failing open. What differs is the unit compared:
+pushlog) until one gives a verdict on the failing unit. An ancestor still running is
+waited for on the build path, up to ten minutes before failing open. The test path steps
+over it instead and asks the next ancestor back: one that already failed still makes the
+failure inherited, one that passed makes it new within the last few pushes, which is
+answer enough when the agent works out the culprit commit itself. On autoland the parent
+push is nearly always still running when a failure arrives, and in a dry run waiting for
+it cost the full ten minutes on almost every real regression — the same ten minutes the
+[history check](#skipping-the-classification-wait) had just saved. Only when every
+ancestor back to the depth limit is unsettled does the test path wait too. A build has no
+group dedupe, so deciding from the grandparent would run build-repair once for this push
+and again for the parent once it fails; it keeps waiting. What differs is the unit
+compared:
 
 - _Build:_ the task **label**. A build label carries no chunk number, so it means the
   same thing on every push: an ancestor whose same label passed makes the failure new,

--- a/services/hackbot-pulse-listener/README.md
+++ b/services/hackbot-pulse-listener/README.md
@@ -58,6 +58,30 @@ Failed **build** tasks go to `build-repair`; failed **test** tasks go to `test-r
 The dedupe caches, the daily budget and pending-run tracking are all in-memory, so
 a restart resets them.
 
+## Skipping the classification wait
+
+The wait costs the most on the failures worth repairing. On recent autoland jobs an
+intermittent is labelled a median of ~1.7 minutes after the job ends, 98% inside the
+wait; a genuine regression is labelled `fixed by commit` a median of ~7 minutes after,
+only 58% inside it. So a regression either sits out the whole
+`TREEHERDER_CLASSIFICATION_WAIT_SECONDS`, or a sheriff gets there first and the
+listener drops it as already classified.
+
+[`flakiness.py`](app/flakiness.py) short-circuits it with the
+[tests.firefox.dev](https://tests.firefox.dev) timings data — public Taskcluster index
+artifacts holding three weeks of every test's pass/fail record. When every test that
+failed here clears `FLAKINESS_MIN_RUNS` runs and `FLAKINESS_MAX_FAILURE_RATE`, it is no
+intermittent and no verdict is coming, so the classification already in hand is used
+as-is. The test names come from the bug suggestions the gate above already fetched, at
+no extra request. Anything the data cannot answer for — another harness, an unlisted or
+brand-new test, a failure naming no test, a read error — keeps the wait.
+
+Over 150 autoland pushes, 90% of those whose failure was eventually attributed to a
+commit skipped the wait, against 6 of 105 that turned out to be noise — and those 6
+still face the ancestor walk and the re-check after it. Expect more runs, not just
+faster ones: a regression a sheriff would have classified during the wait now reaches
+the agent. `MAX_TEST_REPAIRS_PER_DAY` is the backstop; watch it after deploying.
+
 ## The ancestor walk
 
 Both paths ask the same question — did this push introduce the failure, or inherit it

--- a/services/hackbot-pulse-listener/README.md
+++ b/services/hackbot-pulse-listener/README.md
@@ -100,12 +100,14 @@ for an ancestor still running before failing open. What differs is the unit comp
   configuration keeps a manifest already broken on another platform from masking a
   genuine new failure here. Only the manifests that come back new are kept, and the task
   is skipped if none do.
-- _Test with no manifests:_ a suite that reports no groups (gtest, talos, jittest, ...)
-  or a task-level failure (crash, timeout, harness error) has nothing finer to compare,
-  so the whole task is compared by label as on the build path — except that a chunked
-  label is reported as new rather than compared, since the chunk covers different tests
-  on each push. These cannot be reproduced by re-running a manifest, but the agent can
-  still identify the culprit commit.
+- _Test with no manifests:_ a suite that reports no groups (gtest, talos, jittest, ...),
+  a task-level failure (crash, timeout, harness error), or a job that failed while every
+  manifest passed — a debug assertion count, a leak check; in a dry run all 23 of these
+  were real regressions — has nothing finer to compare, so the whole task is compared by
+  label as on the build path — except that a chunked label is reported as new rather
+  than compared, since the chunk covers different tests on each push. These cannot be
+  reproduced by re-running a manifest, but the agent can still identify the culprit
+  commit.
 
 ## Run locally
 

--- a/services/hackbot-pulse-listener/app/config.py
+++ b/services/hackbot-pulse-listener/app/config.py
@@ -38,6 +38,13 @@ class Settings(BaseSettings):
     # at p90, so waiting much past that buys few extra rejections and delays every
     # real regression by the full wait.
     treeherder_classification_wait_seconds: int = 600
+    # The wait is skipped for a task whose every failing test looks reliable in the
+    # tests.firefox.dev timings data (see the README). 0.05% is the measured knee: a
+    # strict 0% covers only two thirds of the genuine regressions that 0.05% does,
+    # and looser rates add noise without covering more. The runs floor only rules out
+    # tests too new to judge; anything from 30 to 1000 scores the same.
+    flakiness_min_runs: int = 100
+    flakiness_max_failure_rate: float = 0.0005
 
     # Dedupe (in-memory, by hg revision)
     dedupe_ttl_seconds: int = 6 * 60 * 60

--- a/services/hackbot-pulse-listener/app/config.py
+++ b/services/hackbot-pulse-listener/app/config.py
@@ -31,6 +31,10 @@ class Settings(BaseSettings):
     # gate waits for the job to be ingested before reading that verdict.
     treeherder_ingest_poll_seconds: int = 30
     treeherder_ingest_max_wait_seconds: int = 240
+    # The log is parsed after the job is ingested; the failure lines the intermittent
+    # gate and the history check read are not there until it is. Measured on 40
+    # autoland failures: parsed by first sight in 39, within 24s in the last.
+    treeherder_log_parse_wait_seconds: int = 60
     # How long to wait for a verdict once the job is ingested. Most test failures turn
     # out to be intermittent or expected-fail, so waiting here rejects them before the
     # ancestor walk and before an agent run. Bounded by how late that makes the

--- a/services/hackbot-pulse-listener/app/config.py
+++ b/services/hackbot-pulse-listener/app/config.py
@@ -60,7 +60,9 @@ class Settings(BaseSettings):
     # builds Firefox in its own container, so a bad day on autoland -- a broken
     # manifest inherited by push after push, or a Treeherder outage that leaves every
     # gate failing open -- could otherwise cost far more than the failures are worth.
-    max_test_repairs_per_day: int = 50
+    # A cost backstop, not a quality gate: a 7-hour dry run on a busy day extrapolated
+    # to ~75 runs, so 50 would have dropped the afternoon's regressions unread.
+    max_test_repairs_per_day: int = 100
 
     # Worker pool for message processing. A regression check may block for a few
     # minutes waiting for a parent build to settle, so the pool is sized well above

--- a/services/hackbot-pulse-listener/app/consumer.py
+++ b/services/hackbot-pulse-listener/app/consumer.py
@@ -352,6 +352,26 @@ def _process_test(body: dict, tags: dict) -> str | None:
         )
         return _trigger_test_repair([], *trigger)
 
+    if not groups and not whole_task:
+        if not tests:
+            logger.info(
+                "Task %s reported no failing test groups; skipping -- %s",
+                task_id,
+                job_link,
+            )
+            return None
+        # The tests passed but the job did not -- a debug assertion count, a leak
+        # check -- so Treeherder records every manifest as green and there is no
+        # group to compare. In a dry run every such task was a genuine regression.
+        logger.info(
+            "Task %s failed %s test(s) but reports no failing group; comparing the "
+            "task as a whole -- %s",
+            task_id,
+            len(tests),
+            job_link,
+        )
+        whole_task = True
+
     try:
         if whole_task:
             if not regression.is_new_task_failure(
@@ -366,13 +386,6 @@ def _process_test(body: dict, tags: dict) -> str | None:
                 return None
             fresh: list[str] = []
         else:
-            if not groups:
-                logger.info(
-                    "Task %s reported no failing test groups; skipping -- %s",
-                    task_id,
-                    job_link,
-                )
-                return None
             fresh = _fresh_groups(
                 groups, project, hg_revision, config, claimed_elsewhere
             )

--- a/services/hackbot-pulse-listener/app/consumer.py
+++ b/services/hackbot-pulse-listener/app/consumer.py
@@ -407,9 +407,9 @@ def _process_test(body: dict, tags: dict) -> str | None:
         )
         return None
 
-    if _groups_claimed(project, fresh):
+    if _groups_claimed(project, _dedupe_units(fresh, label)):
         logger.info(
-            "Every failing group of task %s was already investigated on a recent "
+            "Everything failing in task %s was already investigated on a recent "
             "push; skipping -- %s",
             task_id,
             job_link,
@@ -491,8 +491,18 @@ def _claim_push(hg_revision: str) -> bool:
         return True
 
 
+def _dedupe_units(test_groups: list[str], label: str) -> list[str]:
+    """What a run covers, for the cross-push dedupe.
+
+    Its failing manifests, or, for a task compared as a whole, its label without the
+    chunk number: a whole-task failure stays broken on the following pushes just as a
+    manifest does, and without this each of them would get a near-identical run.
+    """
+    return test_groups or [regression.unchunked(label)]
+
+
 def _groups_claimed(project: str, groups: list[str]) -> bool:
-    """Whether a recent run already covered every one of these groups.
+    """Whether a recent run already covered every one of these groups (or the label).
 
     All, not any: a task that also broke an unanalysed manifest is still worth a run.
     """
@@ -600,7 +610,7 @@ def _trigger_test_repair(
         _release_test_run()
         return None
 
-    group_keys = _claim_groups(project, test_groups)
+    group_keys = _claim_groups(project, _dedupe_units(test_groups, label))
 
     try:
         run_id = client.trigger_run(

--- a/services/hackbot-pulse-listener/app/consumer.py
+++ b/services/hackbot-pulse-listener/app/consumer.py
@@ -300,7 +300,8 @@ def _process_test(body: dict, tags: dict) -> str | None:
     # The same record carries the configuration the regression check compares against.
     job = treeherder.job_for_task(project, task_id)
 
-    # Populated at ingestion, so this needs no wait for a sheriff to star the job.
+    # Needs no sheriff, only the parsed log, which trails ingestion by a little.
+    treeherder.await_bug_suggestions(project, job)
     intermittent = treeherder.intermittent_match(project, job)
     if intermittent.known:
         logger.info(

--- a/services/hackbot-pulse-listener/app/consumer.py
+++ b/services/hackbot-pulse-listener/app/consumer.py
@@ -9,7 +9,7 @@ from cachetools import TTLCache
 from kombu import Connection, Exchange, Queue
 from kombu.mixins import ConsumerMixin
 
-from app import client, lando, regression, taskcluster, treeherder
+from app import client, flakiness, lando, regression, taskcluster, treeherder
 from app.config import settings
 
 logger = logging.getLogger(__name__)
@@ -296,8 +296,8 @@ def _process_test(body: dict, tags: dict) -> str | None:
     # Cheapest gate first: it rules out intermittents and infra failures for every
     # harness before any group resolution or ancestor walking. Sheriffs classify a
     # minute or so after the job ends, so the verdict is waited for rather than read
-    # once. The same record carries the configuration the regression check compares
-    # against.
+    # once -- unless the failing tests' own history already rules an intermittent out.
+    # The same record carries the configuration the regression check compares against.
     job = treeherder.job_for_task(project, task_id)
 
     # Populated at ingestion, so this needs no wait for a sheriff to star the job.
@@ -312,7 +312,10 @@ def _process_test(body: dict, tags: dict) -> str | None:
         )
         return None
 
-    reason = treeherder.await_skip_reason(project, task_id, job)
+    tests = treeherder.failing_tests(project, job)
+    reason = _skip_reason(
+        project, task_id, job, tests, tags.get("test-suite") or "", label, job_link
+    )
     if reason:
         logger.info(
             "Treeherder classified task %s as %s; skipping -- %s",
@@ -414,6 +417,37 @@ def _process_test(body: dict, tags: dict) -> str | None:
         return None
 
     return _trigger_test_repair(fresh, *trigger)
+
+
+def _skip_reason(
+    project: str,
+    task_id: str,
+    job: dict | None,
+    tests: list[str] | None,
+    suite: str,
+    label: str,
+    job_link: str,
+) -> str | None:
+    """Treeherder's reason not to investigate, waiting for one unless it is moot.
+
+    The wait exists to catch an intermittent before the ancestor walk, so it is worth
+    nothing on a task whose every failing test has weeks of CI runs behind it and next
+    to no failures among them: that is not a flaky test, and no verdict is coming that
+    would say otherwise. Skipping it takes ten minutes off the report for exactly the
+    failures the agent exists to explain.
+    """
+    reason = treeherder.skip_reason(job)
+    if job is None or reason:
+        return reason
+    if tests and flakiness.has_clean_history(tests, suite, label):
+        logger.info(
+            "Every test failing in task %s has a clean run history; not waiting for "
+            "a classification -- %s",
+            task_id,
+            job_link,
+        )
+        return None
+    return treeherder.await_skip_reason(project, task_id, job)
 
 
 def _build_claimed(hg_revision: str) -> bool:

--- a/services/hackbot-pulse-listener/app/flakiness.py
+++ b/services/hackbot-pulse-listener/app/flakiness.py
@@ -1,0 +1,260 @@
+"""Historical pass/fail record of a test, from the tests.firefox.dev timings data.
+
+Used to decide that a failing test is not an intermittent, so the listener need not
+wait for a sheriff to say so. A test with three weeks of CI runs behind it and next
+to no failures among them is not flaky; when it fails, it regressed.
+
+The tests.firefox.dev dashboard (github.com/mozilla/aretestsfastyet) is static JS
+that reads pre-aggregated timings JSON from the Firefox CI Taskcluster index at
+runtime. We consume the same public artifacts (no auth). The decode logic (bucket
+hashing and per-test stats) is a direct port of the dashboard's
+``common-test-data.js``.
+
+Only ``mozilla-central`` / ``try`` datasets are published, and only for the mochitest
+and xpcshell harnesses, so this answers for a subset of failures and abstains on the
+rest.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+import httpx
+from cachetools import TTLCache
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+_INDEX_URL = (
+    "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/"
+    "gecko.v2.{repo}.latest.source.test-info-{harness}-timings/artifacts/public/{filename}"
+)
+_REPO = "mozilla-central"
+_TIMEOUT = 30
+_TOTAL_CHUNKS = 64
+
+# Decoded buckets, keyed by (harness, chunk). A raw bucket is ~17MB of JSON and the
+# index republishes at most daily, so caching the (small) decoded stats avoids
+# refetching it for every test; the cache is sized to hold every chunk of both
+# harnesses. The lock covers the fetch and decode together: the worker pool is far
+# larger than the number of buckets, and concurrent decodes would dominate the
+# memory limit.
+_BUCKET_TTL_SECONDS = 24 * 60 * 60
+_buckets: TTLCache = TTLCache(maxsize=2 * _TOTAL_CHUNKS, ttl=_BUCKET_TTL_SECONDS)
+_buckets_lock = threading.Lock()
+
+
+@dataclass(frozen=True)
+class Flakiness:
+    """Cross-push pass/fail stats for one test over the timings window."""
+
+    passes: int = 0
+    fails: int = 0
+    timeouts: int = 0
+    crashes: int = 0
+    skips: int = 0
+
+    @property
+    def runs(self) -> int:
+        """Runs that produced a verdict; skips are not evidence either way."""
+        return self.passes + self.fails + self.timeouts + self.crashes
+
+    @property
+    def failures(self) -> int:
+        return self.fails + self.timeouts + self.crashes
+
+    @property
+    def failure_rate(self) -> float:
+        return self.failures / self.runs if self.runs else 0.0
+
+
+def _harness(suite: str, label: str) -> str | None:
+    """The timings harness for a test task, or None if it publishes none.
+
+    Only the mochitest and xpcshell datasets exist, so every other harness has no
+    history to check against. The Taskcluster ``kind`` is not a harness name (it is
+    often just "test"), so both the suite tag and the label are matched -- the same
+    suite arrives tagged either way.
+    """
+    text = f"{suite or ''} {label or ''}"
+    if "xpcshell" in text:
+        return "xpcshell"
+    if "mochitest" in text or "browser-chrome" in text:
+        return "mochitest"
+    return None
+
+
+def _to_int32(n: int) -> int:
+    """Wrap to a signed 32-bit int, matching JavaScript's ``| 0``."""
+    n &= 0xFFFFFFFF
+    return n - 0x100000000 if n >= 0x80000000 else n
+
+
+def _chunk_index(full_path: str, total_chunks: int = _TOTAL_CHUNKS) -> int:
+    """Bucket a test path to 0..63; port of the dashboard's ``getChunkIndex``."""
+    h = 0
+    for ch in full_path:
+        h = _to_int32((h << 5) - h + ord(ch))
+    return ((h % total_chunks) + total_chunks) % total_chunks
+
+
+def _fetch_bucket(harness: str, chunk: int) -> dict:
+    filename = f"{harness}-{chunk:02x}.json"
+    url = _INDEX_URL.format(repo=_REPO, harness=harness, filename=filename)
+    resp = httpx.get(url, timeout=_TIMEOUT, follow_redirects=True)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _run_count(group: dict) -> int:
+    """Runs recorded in a status group; port of ``getCountAtIndex`` over all indices."""
+    if "counts" in group:
+        return sum(group["counts"])
+    for key in ("durations", "taskIdIds"):
+        if key in group:
+            return sum(len(entry) for entry in group[key])
+    return len(group.get("days") or [])
+
+
+def _classify(status: str) -> str | None:
+    """Map a status string to pass/fail/timeout/crash/skip (None = ignored)."""
+    if status == "SKIP":
+        return "skip"
+    if status == "CRASH":
+        return "crash"
+    if status.startswith("TIMEOUT"):
+        return "timeout"
+    if status == "UNKNOWN":
+        return None
+    # PASS-*, OK and EXPECTED-FAIL are all treated as green by the dashboard.
+    if status.startswith("PASS") or status in ("OK", "EXPECTED-FAIL"):
+        return "pass"
+    return "fail"
+
+
+def _test_paths(data: dict) -> dict[int, str]:
+    """Full test path per test id, from the bucket's index tables."""
+    tables = data.get("tables") or {}
+    info = data.get("testInfo") or {}
+    paths = tables.get("testPaths") or []
+    names = tables.get("testNames") or []
+    path_ids = info.get("testPathIds") or []
+    name_ids = info.get("testNameIds") or []
+    out = {}
+    for test_id in range(min(len(path_ids), len(name_ids))):
+        dir_path = paths[path_ids[test_id]]
+        name = names[name_ids[test_id]]
+        out[test_id] = f"{dir_path}/{name}" if dir_path else name
+    return out
+
+
+def _decode_bucket(data: dict) -> dict[str, Flakiness]:
+    """Per-test stats for every test in a bucket."""
+    statuses = (data.get("tables") or {}).get("statuses") or []
+    paths = _test_paths(data)
+    out: dict[str, Flakiness] = {}
+    for test_id, test_group in enumerate(data.get("testRuns") or []):
+        path = paths.get(test_id)
+        if not test_group or path is None:
+            continue
+        counts = dict.fromkeys(("pass", "fail", "timeout", "crash", "skip"), 0)
+        for status_id, group in enumerate(test_group):
+            if not group or status_id >= len(statuses):
+                continue
+            kind = _classify(statuses[status_id])
+            if kind is not None:
+                counts[kind] += _run_count(group)
+        out[path] = Flakiness(
+            passes=counts["pass"],
+            fails=counts["fail"],
+            timeouts=counts["timeout"],
+            crashes=counts["crash"],
+            skips=counts["skip"],
+        )
+    return out
+
+
+def _bucket_stats(harness: str, chunk: int) -> dict[str, Flakiness]:
+    key = (harness, chunk)
+    with _buckets_lock:
+        stats = _buckets.get(key)
+        if stats is None:
+            stats = _decode_bucket(_fetch_bucket(harness, chunk))
+            _buckets[key] = stats
+        return stats
+
+
+def get_flakiness(test_path: str, harness: str) -> Flakiness:
+    """Historical record of a test, or an empty one if the data cannot say.
+
+    Fails soft: a network or parse error, a harness with no dataset and a test the
+    dataset does not cover all return zero runs, which every caller reads as "no
+    evidence" rather than as "never failed".
+    """
+    try:
+        return _bucket_stats(harness, _chunk_index(test_path)).get(
+            test_path, Flakiness()
+        )
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 404:
+            logger.info(
+                "No tests.firefox.dev dataset for harness %s (%s)", harness, test_path
+            )
+        else:
+            logger.warning(
+                "tests.firefox.dev lookup failed for %s (%s): %s",
+                test_path,
+                harness,
+                exc,
+            )
+    except Exception:
+        logger.exception(
+            "tests.firefox.dev lookup failed for %s (%s)", test_path, harness
+        )
+    return Flakiness()
+
+
+def has_clean_history(tests: Iterable[str], suite: str, label: str) -> bool:
+    """Whether none of these tests looks like an intermittent in the timings data.
+
+    True only when the data covers every one of them with at least
+    ``flakiness_min_runs`` runs and a failure rate no higher than
+    ``flakiness_max_failure_rate``. Every unknown -- a harness that publishes no
+    dataset, a test the dataset does not list, one too new to have a record --
+    returns False, so the caller keeps whatever wait it would otherwise have done.
+    """
+    harness = _harness(suite, label)
+    if harness is None:
+        logger.info("No tests.firefox.dev dataset for %s", label)
+        return False
+
+    tests = set(tests)
+    if not tests:
+        return False
+
+    for test in tests:
+        stats = get_flakiness(test, harness)
+        if stats.runs < settings.flakiness_min_runs:
+            logger.info(
+                "Only %s recorded runs of %s (need %s); cannot rule out an "
+                "intermittent",
+                stats.runs,
+                test,
+                settings.flakiness_min_runs,
+            )
+            return False
+        if stats.failure_rate > settings.flakiness_max_failure_rate:
+            logger.info(
+                "Test %s failed %s of its last %s runs (%.3f%%); it may be an "
+                "intermittent",
+                test,
+                stats.failures,
+                stats.runs,
+                100 * stats.failure_rate,
+            )
+            return False
+    return True

--- a/services/hackbot-pulse-listener/app/regression.py
+++ b/services/hackbot-pulse-listener/app/regression.py
@@ -320,6 +320,11 @@ def is_stale_push(project: str, rev: str, max_age_seconds: float) -> bool:
 _CHUNKED_LABEL = re.compile(r"-\d+$")
 
 
+def unchunked(label: str) -> str:
+    """The task label without its chunk number, the same on every push."""
+    return _CHUNKED_LABEL.sub("", label)
+
+
 def _is_new_label_failure(
     project: str,
     rev: str,

--- a/services/hackbot-pulse-listener/app/regression.py
+++ b/services/hackbot-pulse-listener/app/regression.py
@@ -104,14 +104,30 @@ def _group_status(project: str, rev: str, config: tuple[str, str], group: str):
     return None
 
 
-def _classify(project: str, rev: str, status_fn, describe: str, first_pass=True):
+def _classify(
+    project: str,
+    rev: str,
+    status_fn,
+    describe: str,
+    first_pass=True,
+    look_past_pending=False,
+):
     """Walk ancestors of `rev`; True (new), False (inherited) or _PENDING.
 
     status_fn(ancestor_rev) reports 'passed'/'failed'/_PENDING/None for the failing
     unit (build label or test group). `first_pass` keeps the "not settled" notice to
     one line per unit rather than repeating it on every poll for up to an hour.
+
+    With ``look_past_pending`` an unsettled ancestor is stepped over rather than
+    waited for. An older ancestor that already failed still makes the failure
+    inherited; one that passed makes it new somewhere between it and ``rev``, which
+    is answer enough when the agent works out the culprit commit itself. On autoland
+    the parent push is nearly always still running when a failure arrives, so
+    waiting for it costs the whole MAX_WAIT_SECONDS on almost every real regression.
     """
     push = Push(rev, branch=project)
+    notice = logger.info if first_pass else logger.debug
+    pending_at = None
     for _ in range(MAX_DEPTH):
         try:
             push = push.parent
@@ -122,15 +138,25 @@ def _classify(project: str, rev: str, status_fn, describe: str, first_pass=True)
             continue
         ancestor_link = treeherder.push_url(project, push.rev)
         if status is _PENDING:
-            notice = logger.info if first_pass else logger.debug
-            notice(
-                "%s not settled at %s; deferring for %s -- %s",
-                describe,
-                push.rev,
-                rev,
-                ancestor_link,
-            )
-            return _PENDING
+            if not look_past_pending:
+                notice(
+                    "%s not settled at %s; deferring for %s -- %s",
+                    describe,
+                    push.rev,
+                    rev,
+                    ancestor_link,
+                )
+                return _PENDING
+            if pending_at is None:
+                pending_at = push.rev
+                notice(
+                    "%s not settled at %s; looking further back for %s -- %s",
+                    describe,
+                    push.rev,
+                    rev,
+                    ancestor_link,
+                )
+            continue
         if status == "failed":
             logger.info(
                 "%s already failing at %s; inherited at %s -- %s",
@@ -140,15 +166,35 @@ def _classify(project: str, rev: str, status_fn, describe: str, first_pass=True)
                 ancestor_link,
             )
             return False
-        logger.info(
-            "%s passed at %s; new failure at %s -- %s",
-            describe,
-            push.rev,
-            rev,
-            ancestor_link,
-        )
+        if pending_at is None:
+            logger.info(
+                "%s passed at %s; new failure at %s -- %s",
+                describe,
+                push.rev,
+                rev,
+                ancestor_link,
+            )
+        else:
+            logger.info(
+                "%s passed at %s and not yet settled at %s; new failure at %s or "
+                "just before it -- %s",
+                describe,
+                push.rev,
+                pending_at,
+                rev,
+                ancestor_link,
+            )
         return True
 
+    if pending_at is not None:
+        notice(
+            "%s not settled at %s and undecided further back; deferring for %s -- %s",
+            describe,
+            pending_at,
+            rev,
+            treeherder.push_url(project, pending_at),
+        )
+        return _PENDING
     logger.warning(
         "No ancestor within %s pushes ran %s; running agent -- %s",
         MAX_DEPTH,
@@ -159,7 +205,13 @@ def _classify(project: str, rev: str, status_fn, describe: str, first_pass=True)
 
 
 def _await_new_failures(
-    project: str, rev: str, status_fn, units, describe: str, should_abort=None
+    project: str,
+    rev: str,
+    status_fn,
+    units,
+    describe: str,
+    should_abort=None,
+    look_past_pending=False,
 ) -> set:
     """The units whose failure `rev` introduced; the rest were inherited.
 
@@ -191,6 +243,7 @@ def _await_new_failures(
                     lambda ancestor, u=unit: status_fn(ancestor, u),
                     f"{describe} {unit}",
                     first_pass=first_pass,
+                    look_past_pending=look_past_pending,
                 )
                 if state is _PENDING:
                     pending.append(unit)
@@ -268,7 +321,12 @@ _CHUNKED_LABEL = re.compile(r"-\d+$")
 
 
 def _is_new_label_failure(
-    project: str, rev: str, label: str, describe: str, should_abort=None
+    project: str,
+    rev: str,
+    label: str,
+    describe: str,
+    should_abort=None,
+    look_past_pending=False,
 ) -> bool:
     return label in _await_new_failures(
         project,
@@ -277,6 +335,7 @@ def _is_new_label_failure(
         [label],
         describe,
         should_abort,
+        look_past_pending,
     )
 
 
@@ -300,7 +359,9 @@ def is_new_task_failure(project: str, rev: str, label: str, should_abort=None) -
             rev,
         )
         return True
-    return _is_new_label_failure(project, rev, label, "task", should_abort)
+    return _is_new_label_failure(
+        project, rev, label, "task", should_abort, look_past_pending=True
+    )
 
 
 def new_test_failures(
@@ -329,4 +390,5 @@ def new_test_failures(
         groups,
         "group",
         should_abort,
+        look_past_pending=True,
     )

--- a/services/hackbot-pulse-listener/app/treeherder.py
+++ b/services/hackbot-pulse-listener/app/treeherder.py
@@ -364,9 +364,47 @@ def bug_suggestions(project: str, job_id: int) -> list[dict]:
             return _bug_suggestions_cache[key]
 
     suggestions = _get(f"{project}/jobs/{job_id}/bug_suggestions/") or []
-    with _cache_lock:
-        _bug_suggestions_cache[key] = suggestions
+    # Empty means the log is not parsed yet far more often than it means nothing
+    # failed, so only a parsed result is cached; the next reader tries again.
+    if suggestions:
+        with _cache_lock:
+            _bug_suggestions_cache[key] = suggestions
     return suggestions
+
+
+def await_bug_suggestions(project: str, job: dict | None) -> None:
+    """Wait a bounded time for Treeherder to parse the job's log.
+
+    The job is ingested before its log is parsed, and until then ``bug_suggestions``
+    is empty: the intermittent gate and the history check both read it, and both
+    fall through to the classification wait when it has nothing. Nothing is returned;
+    callers read ``bug_suggestions`` themselves, through the cache this fills.
+    """
+    job_id = (job or {}).get("id")
+    if job_id is None:
+        return
+    deadline = time.monotonic() + settings.treeherder_log_parse_wait_seconds
+    while True:
+        try:
+            if bug_suggestions(project, job_id):
+                return
+        except Exception:
+            logger.exception(
+                "Could not read the bug suggestions of job %s -- %s",
+                job_id,
+                job_url(project, None, (job or {}).get("task_id") or ""),
+            )
+            return
+        if time.monotonic() >= deadline:
+            logger.info(
+                "Treeherder has not parsed the log of job %s after %ss; judging the "
+                "task without its failure lines -- %s",
+                job_id,
+                settings.treeherder_log_parse_wait_seconds,
+                job_url(project, None, (job or {}).get("task_id") or ""),
+            )
+            return
+        time.sleep(settings.treeherder_ingest_poll_seconds)
 
 
 def _failure_line_test(search: str) -> str | None:

--- a/services/hackbot-pulse-listener/app/treeherder.py
+++ b/services/hackbot-pulse-listener/app/treeherder.py
@@ -369,6 +369,64 @@ def bug_suggestions(project: str, job_id: int) -> list[dict]:
     return suggestions
 
 
+def _failure_line_test(search: str) -> str | None:
+    """The source-relative test path a parsed failure line names, if it names one.
+
+    Lines read ``TEST-UNEXPECTED-FAIL | <test> | <message>``. The middle field is a
+    test path for a per-test failure and a label like "ShutdownLeaks" or "shutdown
+    hang" for a task-level one; xpcshell prefixes the path with its manifest.
+    """
+    fields = [field.strip() for field in search.split("|")]
+    if len(fields) < 2:
+        return None
+    candidate = fields[1].rsplit(":", 1)[-1]
+    return candidate if "/" in candidate else None
+
+
+def failing_tests(project: str, job: dict | None) -> list[str] | None:
+    """The tests a job reported as failing, or None if they cannot be enumerated.
+
+    None means some unexpected failure was not attributable to a test -- a crash, a
+    leak, a shutdown hang, or a job whose log yielded no failure lines at all -- so a
+    caller must not read the empty result as "nothing else failed". Fails soft to
+    None on any error, for the same reason.
+    """
+    job_id = (job or {}).get("id")
+    if job_id is None:
+        return None
+    try:
+        lines = [
+            line.get("search") or ""
+            for line in bug_suggestions(project, job_id)
+            if (line.get("search") or "").startswith(_FAILURE_LINE_PREFIX)
+        ]
+    except Exception:
+        logger.exception(
+            "Could not read the bug suggestions of job %s -- %s",
+            job_id,
+            job_url(project, None, (job or {}).get("task_id") or ""),
+        )
+        return None
+
+    if not lines:
+        logger.info(
+            "Job %s has no parsed failure lines; its tests cannot be judged -- %s",
+            job_id,
+            job_url(project, None, (job or {}).get("task_id") or ""),
+        )
+        return None
+    tests = [_failure_line_test(line) for line in lines]
+    if None in tests:
+        logger.info(
+            "Job %s failed outside any test (%s); its tests cannot be judged -- %s",
+            job_id,
+            lines[tests.index(None)][:120],
+            job_url(project, None, (job or {}).get("task_id") or ""),
+        )
+        return None
+    return list(dict.fromkeys(tests))
+
+
 @dataclass(frozen=True)
 class IntermittentMatch:
     """What Treeherder's bug suggestions say about a failing job.

--- a/services/hackbot-pulse-listener/tests/test_consumer.py
+++ b/services/hackbot-pulse-listener/tests/test_consumer.py
@@ -1004,6 +1004,34 @@ def test_a_group_less_task_is_not_suppressed_by_the_manifest_cache(env):
     assert consumer.process(_test_msg(task_id="B")) == "tr-1"
 
 
+def test_the_same_whole_task_failure_on_later_pushes_is_deduped(env):
+    # No manifest to dedupe on, so the label stands in for it: a debug assertion
+    # count broken by one push fails the same task on every push after it.
+    _consecutive_pushes(env, "rev-one", "rev-two", "rev-three")
+    env.failing_groups.side_effect = consumer.treeherder.GroupResultsUnavailable("none")
+    assert consumer.process(_test_msg(task_id="A")) == "tr-1"
+    assert consumer.process(_test_msg(task_id="B")) is None
+    assert consumer.process(_test_msg(task_id="C")) is None
+    env.trigger_run.assert_called_once()
+
+
+def test_whole_task_dedupe_ignores_the_chunk_number(env):
+    _consecutive_pushes(env, "rev-one", "rev-two")
+    env.failing_groups.side_effect = consumer.treeherder.GroupResultsUnavailable("none")
+    chunked = "test-linux1804-64/opt-mochitest-browser-chrome-{}"
+    assert consumer.process(_test_msg(task_id="A", label=chunked.format(1))) == "tr-1"
+    assert consumer.process(_test_msg(task_id="B", label=chunked.format(7))) is None
+
+
+def test_a_different_whole_task_failure_on_a_later_push_still_runs(env):
+    _consecutive_pushes(env, "rev-one", "rev-two")
+    env.failing_groups.side_effect = consumer.treeherder.GroupResultsUnavailable("none")
+    assert consumer.process(_test_msg(task_id="A")) == "tr-1"
+    other = "test-windows11-64/debug-mochitest-plain-3"
+    assert consumer.process(_test_msg(task_id="B", label=other)) == "tr-1"
+    assert env.trigger_run.call_count == 2
+
+
 def test_the_deduped_task_is_logged_with_a_treeherder_link(env, caplog):
     _consecutive_pushes(env, "rev-one", "hgrev")
     assert consumer.process(_test_msg(task_id="A")) == "tr-1"

--- a/services/hackbot-pulse-listener/tests/test_consumer.py
+++ b/services/hackbot-pulse-listener/tests/test_consumer.py
@@ -323,6 +323,8 @@ def env(monkeypatch):
         intermittent_match=MagicMock(
             return_value=consumer.treeherder.IntermittentMatch()
         ),
+        failing_tests=MagicMock(return_value=["dom/base/test/test_a.html"]),
+        has_clean_history=MagicMock(return_value=False),
         new_test_failures=MagicMock(
             side_effect=lambda p, r, cfg, groups, abort=None: set(groups)
         ),
@@ -341,6 +343,10 @@ def env(monkeypatch):
     )
     monkeypatch.setattr(
         consumer.treeherder, "intermittent_match", mocks.intermittent_match
+    )
+    monkeypatch.setattr(consumer.treeherder, "failing_tests", mocks.failing_tests)
+    monkeypatch.setattr(
+        consumer.flakiness, "has_clean_history", mocks.has_clean_history
     )
     monkeypatch.setattr(
         consumer.regression, "new_test_failures", mocks.new_test_failures
@@ -1030,3 +1036,47 @@ def test_a_classified_build_failure_is_read_after_the_walk(monkeypatch):
 def test_an_unclassified_build_failure_still_runs(monkeypatch):
     _build_env(monkeypatch)
     assert consumer.process(_build_msg()) == "run-1"
+
+
+def test_a_clean_test_history_skips_the_classification_wait(env):
+    env.has_clean_history.return_value = True
+    assert consumer.process(_test_msg()) == "tr-1"
+    env.await_skip_reason.assert_not_called()
+
+
+def test_a_test_with_a_failure_history_still_waits_for_the_verdict(env):
+    env.has_clean_history.return_value = False
+    assert consumer.process(_test_msg()) == "tr-1"
+    env.await_skip_reason.assert_called_once()
+
+
+def test_failures_not_attributable_to_tests_still_wait(env):
+    # Nothing to look a history up for, so the wait is the only filter left.
+    env.failing_tests.return_value = None
+    assert consumer.process(_test_msg()) == "tr-1"
+    env.has_clean_history.assert_not_called()
+    env.await_skip_reason.assert_called_once()
+
+
+def test_a_classification_already_in_hand_is_honoured_without_waiting(env):
+    # A clean history says no verdict is coming, not that one already made is to be
+    # ignored: an infra failure stays an infra failure.
+    env.has_clean_history.return_value = True
+    env.job_for_task.return_value = {
+        "failure_classification_id": 5,
+        "platform": "linux1804-64",
+        "platform_option": "opt",
+    }
+    assert consumer.process(_test_msg()) is None
+    env.has_clean_history.assert_not_called()
+    env.await_skip_reason.assert_not_called()
+    env.trigger_run.assert_not_called()
+
+
+def test_the_history_check_reads_the_task_suite_and_label(env):
+    env.has_clean_history.return_value = True
+    consumer.process(_test_msg())
+    tests, suite, label = env.has_clean_history.call_args.args
+    assert tests == ["dom/base/test/test_a.html"]
+    assert suite == "mochitest-browser-chrome"
+    assert label == "test-linux1804-64/opt-mochitest-browser-chrome-1"

--- a/services/hackbot-pulse-listener/tests/test_consumer.py
+++ b/services/hackbot-pulse-listener/tests/test_consumer.py
@@ -414,8 +414,28 @@ def test_later_task_of_a_claimed_push_stops_before_treeherder(env):
     env.failing_groups.assert_not_called()
 
 
-def test_no_failing_groups_skips(env):
+def test_no_failing_groups_and_no_failing_tests_skips(env):
     env.failing_groups.return_value = []
+    env.failing_tests.return_value = None
+    assert consumer.process(_test_msg()) is None
+    env.trigger_run.assert_not_called()
+    env.is_new_task_failure.assert_not_called()
+
+
+def test_failing_tests_without_a_failing_group_are_compared_as_a_whole_task(env):
+    # A debug assertion-count failure: the test passes, the job fails, and Treeherder
+    # records every manifest as green. That is a regression, not "nothing failed".
+    env.failing_groups.return_value = []
+    env.failing_tests.return_value = ["toolkit/content/tests/chrome/test_findbar.xhtml"]
+    assert consumer.process(_test_msg()) == "tr-1"
+    env.is_new_task_failure.assert_called_once()
+    env.new_test_failures.assert_not_called()
+
+
+def test_failing_tests_without_a_failing_group_still_honour_the_ancestor_walk(env):
+    env.failing_groups.return_value = []
+    env.failing_tests.return_value = ["toolkit/content/tests/chrome/test_findbar.xhtml"]
+    env.is_new_task_failure.return_value = False
     assert consumer.process(_test_msg()) is None
     env.trigger_run.assert_not_called()
 

--- a/services/hackbot-pulse-listener/tests/test_consumer.py
+++ b/services/hackbot-pulse-listener/tests/test_consumer.py
@@ -325,6 +325,7 @@ def env(monkeypatch):
         ),
         failing_tests=MagicMock(return_value=["dom/base/test/test_a.html"]),
         has_clean_history=MagicMock(return_value=False),
+        await_bug_suggestions=MagicMock(),
         new_test_failures=MagicMock(
             side_effect=lambda p, r, cfg, groups, abort=None: set(groups)
         ),
@@ -347,6 +348,9 @@ def env(monkeypatch):
     monkeypatch.setattr(consumer.treeherder, "failing_tests", mocks.failing_tests)
     monkeypatch.setattr(
         consumer.flakiness, "has_clean_history", mocks.has_clean_history
+    )
+    monkeypatch.setattr(
+        consumer.treeherder, "await_bug_suggestions", mocks.await_bug_suggestions
     )
     monkeypatch.setattr(
         consumer.regression, "new_test_failures", mocks.new_test_failures
@@ -438,6 +442,21 @@ def test_failing_tests_without_a_failing_group_still_honour_the_ancestor_walk(en
     env.is_new_task_failure.return_value = False
     assert consumer.process(_test_msg()) is None
     env.trigger_run.assert_not_called()
+
+
+def test_the_log_is_awaited_before_its_failure_lines_are_read(env):
+    order = []
+    env.await_bug_suggestions.side_effect = lambda p, j: order.append("await")
+    env.intermittent_match.side_effect = lambda p, j: (
+        order.append("match"),
+        consumer.treeherder.IntermittentMatch(),
+    )[1]
+    env.failing_tests.side_effect = lambda p, j: (order.append("tests"), ["t"])[1]
+    consumer.process(_test_msg())
+    assert order[:3] == ["await", "match", "tests"]
+    env.await_bug_suggestions.assert_called_once_with(
+        "autoland", env.job_for_task.return_value
+    )
 
 
 def test_task_without_group_results_still_triggers_run(env):

--- a/services/hackbot-pulse-listener/tests/test_flakiness.py
+++ b/services/hackbot-pulse-listener/tests/test_flakiness.py
@@ -1,0 +1,177 @@
+"""Tests for the tests.firefox.dev history gate."""
+
+import httpx
+import pytest
+from app import flakiness
+
+CLEAN = "browser/base/content/test/browser_clean.js"
+FLAKY = "browser/base/content/test/browser_flaky.js"
+
+
+def _bucket(**tests):
+    """A decoded bucket: ``path -> Flakiness``, given ``name=(passes, failures)``."""
+    return {
+        path: flakiness.Flakiness(passes=passes, fails=fails)
+        for path, (passes, fails) in tests.items()
+    }
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    flakiness._buckets.clear()
+    yield
+    flakiness._buckets.clear()
+
+
+@pytest.fixture
+def stats(monkeypatch):
+    """Stub the bucket lookup with one flat ``path -> Flakiness`` mapping."""
+
+    def use(mapping):
+        monkeypatch.setattr(
+            flakiness, "_bucket_stats", lambda harness, chunk: dict(mapping)
+        )
+
+    return use
+
+
+def test_a_test_that_never_failed_is_not_intermittent(stats):
+    stats(_bucket(**{CLEAN: (5000, 0)}))
+    assert flakiness.has_clean_history([CLEAN], "", "test-linux/opt-mochitest-1")
+
+
+def test_a_failure_rate_under_the_threshold_is_still_clean(stats):
+    # 1 in 10000 is not a flaky test; demanding a spotless record instead would
+    # abstain on most of the regressions this gate exists to speed up.
+    stats(_bucket(**{CLEAN: (9999, 1)}))
+    assert flakiness.has_clean_history([CLEAN], "", "test-linux/opt-mochitest-1")
+
+
+def test_a_failure_rate_over_the_threshold_keeps_the_wait(stats):
+    stats(_bucket(**{FLAKY: (999, 1)}))
+    assert not flakiness.has_clean_history([FLAKY], "", "test-linux/opt-mochitest-1")
+
+
+def test_one_flaky_test_among_clean_ones_keeps_the_wait(stats):
+    stats(_bucket(**{CLEAN: (5000, 0), FLAKY: (999, 1)}))
+    assert not flakiness.has_clean_history(
+        [CLEAN, FLAKY], "", "test-linux/opt-mochitest-1"
+    )
+
+
+def test_timeouts_and_crashes_count_as_failures(stats):
+    stats({CLEAN: flakiness.Flakiness(passes=999, timeouts=1)})
+    assert not flakiness.has_clean_history([CLEAN], "", "test-linux/opt-mochitest-1")
+
+    stats({CLEAN: flakiness.Flakiness(passes=999, crashes=1)})
+    assert not flakiness.has_clean_history([CLEAN], "", "test-linux/opt-mochitest-1")
+
+
+def test_a_test_with_too_little_history_keeps_the_wait(stats):
+    stats(_bucket(**{CLEAN: (99, 0)}))
+    assert not flakiness.has_clean_history([CLEAN], "", "test-linux/opt-mochitest-1")
+
+
+def test_skips_are_not_counted_as_evidence(stats):
+    stats({CLEAN: flakiness.Flakiness(passes=10, skips=5000)})
+    assert not flakiness.has_clean_history([CLEAN], "", "test-linux/opt-mochitest-1")
+
+
+def test_a_test_the_dataset_does_not_cover_keeps_the_wait(stats):
+    stats(_bucket(**{CLEAN: (5000, 0)}))
+    assert not flakiness.has_clean_history(
+        ["dom/base/test/test_brand_new.html"], "", "test-linux/opt-mochitest-1"
+    )
+
+
+def test_no_tests_keeps_the_wait(stats):
+    stats(_bucket(**{CLEAN: (5000, 0)}))
+    assert not flakiness.has_clean_history([], "", "test-linux/opt-mochitest-1")
+
+
+@pytest.mark.parametrize(
+    ("suite", "label"),
+    [
+        ("", "test-linux2404-64/opt-web-platform-tests-3"),
+        ("reftest", "test-linux2404-64/opt-reftest-2"),
+        ("", "test-linux2404-64/opt-gtest"),
+    ],
+)
+def test_a_harness_without_a_dataset_keeps_the_wait(stats, suite, label):
+    stats(_bucket(**{CLEAN: (5000, 0)}))
+    assert not flakiness.has_clean_history([CLEAN], suite, label)
+
+
+@pytest.mark.parametrize(
+    ("suite", "label", "harness"),
+    [
+        ("", "test-linux2404-64/opt-mochitest-plain-1", "mochitest"),
+        ("", "test-linux2404-64/opt-mochitest-browser-chrome-3", "mochitest"),
+        ("browser-chrome", "test-linux2404-64/debug-test-3", "mochitest"),
+        ("", "test-linux2404-64/opt-xpcshell-5", "xpcshell"),
+        ("xpcshell", "test-linux2404-64/debug-test-1", "xpcshell"),
+    ],
+)
+def test_the_harness_is_read_from_either_the_suite_or_the_label(suite, label, harness):
+    assert flakiness._harness(suite, label) == harness
+
+
+def test_a_lookup_error_keeps_the_wait(monkeypatch):
+    def boom(harness, chunk):
+        raise httpx.ConnectError("nope")
+
+    monkeypatch.setattr(flakiness, "_bucket_stats", boom)
+    assert not flakiness.has_clean_history([CLEAN], "", "test-linux/opt-mochitest-1")
+
+
+def test_a_missing_dataset_keeps_the_wait(monkeypatch):
+    request = httpx.Request("GET", "https://index.example/artifact")
+
+    def missing(harness, chunk):
+        raise httpx.HTTPStatusError(
+            "404", request=request, response=httpx.Response(404, request=request)
+        )
+
+    monkeypatch.setattr(flakiness, "_bucket_stats", missing)
+    assert not flakiness.has_clean_history([CLEAN], "", "test-linux/opt-mochitest-1")
+
+
+def test_each_bucket_is_fetched_once(monkeypatch):
+    calls = []
+
+    def fake_fetch(harness, chunk):
+        calls.append((harness, chunk))
+        return _RAW_BUCKET
+
+    monkeypatch.setattr(flakiness, "_fetch_bucket", fake_fetch)
+    first = flakiness.get_flakiness("dom/base/test/test_a.html", "mochitest")
+    second = flakiness.get_flakiness("dom/base/test/test_a.html", "mochitest")
+    assert first == second
+    assert len(calls) == 1
+
+
+# One test recorded as 3 PASS and 1 FAIL, in the dashboard's table-indexed shape.
+_RAW_BUCKET = {
+    "tables": {
+        "testPaths": ["dom/base/test"],
+        "testNames": ["test_a.html"],
+        "statuses": ["PASS", "FAIL", "SKIP"],
+    },
+    "testInfo": {"testPathIds": [0], "testNameIds": [0]},
+    "testRuns": [[{"counts": [3]}, {"counts": [1]}, None]],
+}
+
+
+def test_the_dashboard_bucket_format_is_decoded():
+    decoded = flakiness._decode_bucket(_RAW_BUCKET)
+    assert decoded == {
+        "dom/base/test/test_a.html": flakiness.Flakiness(passes=3, fails=1)
+    }
+
+
+def test_the_chunk_index_matches_the_dashboard_hash():
+    # Port of getChunkIndex; these are the values the published buckets are keyed by,
+    # so a drift here would silently look up the wrong bucket and find no history.
+    assert flakiness._chunk_index("") == 0
+    assert flakiness._chunk_index("a") == 33
+    assert 0 <= flakiness._chunk_index("dom/base/test/test_a.html") < 64

--- a/services/hackbot-pulse-listener/tests/test_regression.py
+++ b/services/hackbot-pulse-listener/tests/test_regression.py
@@ -112,6 +112,19 @@ def test_running_parent_is_waited_then_inherited():
     assert _run(_chain(running()), poll=[{"rev1": failed()}]) is False
 
 
+def test_a_build_does_not_look_past_a_running_parent():
+    # Unlike the test path: a build has no group dedupe, so deciding from the
+    # grandparent would run build-repair for both this push and, once it fails, the
+    # parent. The parent is waited for and, here, turns out to have failed.
+    assert (
+        _run(
+            _chain(running(), passed()),
+            poll=[{"rev1": failed(), "rev2": passed()}],
+        )
+        is False
+    )
+
+
 @pytest.mark.parametrize("result", ["retry", "exception", "unknown"])
 def test_unsettled_result_is_waited_not_skipped(result):
     # These may still change outcome, so the ancestor must be waited for. Asserting

--- a/services/hackbot-pulse-listener/tests/test_regression_test_failure.py
+++ b/services/hackbot-pulse-listener/tests/test_regression_test_failure.py
@@ -140,6 +140,41 @@ def test_nothing_recorded_yet_still_waits():
     assert _run([GROUP], jobs, {}, poll=poll) == {GROUP}
 
 
+def test_an_unsettled_parent_is_stepped_over_to_a_green_grandparent():
+    # The parent is still running -- on autoland it nearly always is -- but the
+    # grandparent ran the group and passed, so the failure is new within the last
+    # two pushes. Decided at once, without spending the wait (max_wait=0).
+    jobs = {
+        "rev1": {CONFIG: [_job(task_id="T1", state="running")]},
+        "rev2": {CONFIG: [_job(task_id="T2")]},
+    }
+    results = {"rev2": {"T2": {GROUP: True}}}
+    assert _run([GROUP], jobs, results, depth=2, max_wait=0) == {GROUP}
+
+
+def test_an_unsettled_parent_is_stepped_over_to_a_failing_grandparent():
+    jobs = {
+        "rev1": {CONFIG: [_job(task_id="T1", state="running")]},
+        "rev2": {CONFIG: [_job(task_id="T2")]},
+    }
+    results = {"rev2": {"T2": {GROUP: False}}}
+    assert _run([GROUP], jobs, results, depth=2, max_wait=0) == set()
+
+
+def test_unsettled_all_the_way_back_still_waits():
+    jobs = {
+        "rev1": {CONFIG: [_job(task_id="T1", state="running")]},
+        "rev2": {CONFIG: [_job(task_id="T2", state="running")]},
+    }
+    poll = [
+        (
+            {"rev1": {CONFIG: [_job(task_id="T1")]}, "rev2": jobs["rev2"]},
+            {"rev1": {"T1": {GROUP: True}}},
+        )
+    ]
+    assert _run([GROUP], jobs, {}, depth=2, poll=poll) == {GROUP}
+
+
 def test_ancestor_that_never_ran_the_group_is_skipped():
     # Coalesced, or the manifest was chunked into another task: non-decisive.
     jobs = {

--- a/services/hackbot-pulse-listener/tests/test_treeherder.py
+++ b/services/hackbot-pulse-listener/tests/test_treeherder.py
@@ -508,6 +508,66 @@ def test_bug_suggestions_are_fetched_once_per_job(monkeypatch):
     assert calls[0].endswith("/project/autoland/jobs/42/bug_suggestions/")
 
 
+def test_empty_bug_suggestions_are_not_cached(monkeypatch):
+    # Empty means the log is not parsed yet; the next reader must ask again.
+    responses = iter([[], [_suggestion(_FAIL_LINE, False)]])
+    monkeypatch.setattr(
+        treeherder.httpx, "get", lambda url, **kw: _response(next(responses))
+    )
+    assert treeherder.bug_suggestions("autoland", 42) == []
+    assert len(treeherder.bug_suggestions("autoland", 42)) == 1
+
+
+@pytest.fixture
+def parse_poll(monkeypatch):
+    """Stub bug_suggestions with successive results and record every sleep taken."""
+    sleeps = []
+    monkeypatch.setattr(treeherder.time, "sleep", lambda s: sleeps.append(s))
+
+    def use(*results):
+        it = iter(results)
+        monkeypatch.setattr(treeherder, "bug_suggestions", lambda p, j: next(it))
+
+    return type("Poll", (), {"use": staticmethod(use), "sleeps": sleeps})
+
+
+def test_a_parsed_log_is_not_waited_for(parse_poll):
+    parse_poll.use([_suggestion(_FAIL_LINE, False)])
+    treeherder.await_bug_suggestions("autoland", _failing_job())
+    assert parse_poll.sleeps == []
+
+
+def test_an_unparsed_log_is_polled_until_it_is_parsed(parse_poll):
+    parse_poll.use([], [], [_suggestion(_FAIL_LINE, False)])
+    treeherder.await_bug_suggestions("autoland", _failing_job())
+    assert len(parse_poll.sleeps) == 2
+
+
+def test_the_parse_wait_is_bounded(parse_poll, monkeypatch):
+    clock = iter(range(0, 10_000, 100))
+    monkeypatch.setattr(treeherder.time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(treeherder.settings, "treeherder_log_parse_wait_seconds", 250)
+    parse_poll.use(*([[]] * 50))
+    treeherder.await_bug_suggestions("autoland", _failing_job())
+    assert 1 <= len(parse_poll.sleeps) <= 3
+
+
+def test_the_parse_wait_is_skipped_without_a_job(parse_poll):
+    parse_poll.use([])
+    treeherder.await_bug_suggestions("autoland", None)
+    treeherder.await_bug_suggestions("autoland", {"task_id": "TT"})
+    assert parse_poll.sleeps == []
+
+
+def test_the_parse_wait_gives_up_on_an_error(monkeypatch, parse_poll):
+    def boom(project, job_id):
+        raise RuntimeError("treeherder is down")
+
+    monkeypatch.setattr(treeherder, "bug_suggestions", boom)
+    treeherder.await_bug_suggestions("autoland", _failing_job())
+    assert parse_poll.sleeps == []
+
+
 def test_push_url_points_at_the_push():
     assert treeherder.push_url("autoland", "abc123") == (
         "https://treeherder.mozilla.org/#/jobs?repo=autoland&revision=abc123"

--- a/services/hackbot-pulse-listener/tests/test_treeherder.py
+++ b/services/hackbot-pulse-listener/tests/test_treeherder.py
@@ -582,3 +582,72 @@ def test_a_real_error_is_not_retried(monkeypatch):
     with pytest.raises(httpx.HTTPStatusError):
         treeherder._get("autoland/push/")
     assert len(calls) == 1
+
+
+_TEST_LINE = (
+    "TEST-UNEXPECTED-FAIL | browser/base/content/test/browser_tab.js | Test timed out."
+)
+
+
+def test_failing_tests_reads_the_test_paths(suggestions):
+    suggestions(_suggestion(_TEST_LINE, True))
+    assert treeherder.failing_tests("autoland", _failing_job()) == [
+        "browser/base/content/test/browser_tab.js"
+    ]
+
+
+def test_failing_tests_strips_the_xpcshell_manifest_prefix(suggestions):
+    suggestions(
+        _suggestion(
+            "TEST-UNEXPECTED-FAIL | xpcshell.toml:netwerk/test/unit/test_bug.js | boom",
+            True,
+        )
+    )
+    assert treeherder.failing_tests("autoland", _failing_job()) == [
+        "netwerk/test/unit/test_bug.js"
+    ]
+
+
+def test_failing_tests_deduplicates_repeated_lines(suggestions):
+    suggestions(_suggestion(_TEST_LINE, True), _suggestion(_TEST_LINE, True))
+    assert treeherder.failing_tests("autoland", _failing_job()) == [
+        "browser/base/content/test/browser_tab.js"
+    ]
+
+
+def test_failing_tests_ignores_lines_that_are_not_failures(suggestions):
+    suggestions(
+        _suggestion(_TEST_LINE, True),
+        _suggestion("[taskcluster:error] exit status 1", True),
+    )
+    assert treeherder.failing_tests("autoland", _failing_job()) == [
+        "browser/base/content/test/browser_tab.js"
+    ]
+
+
+def test_a_failure_not_attributed_to_a_test_yields_none(suggestions):
+    # "ShutdownLeaks" and "shutdown hang" name no test, so the failing tests of the
+    # job cannot be enumerated -- which must not read as "only the other one failed".
+    suggestions(
+        _suggestion(_TEST_LINE, True),
+        _suggestion("TEST-UNEXPECTED-FAIL | ShutdownLeaks | leaked 2 windows", True),
+    )
+    assert treeherder.failing_tests("autoland", _failing_job()) is None
+
+
+def test_failing_tests_is_none_without_any_failure_line(suggestions):
+    suggestions(_suggestion("[taskcluster:error] exit status 1", True))
+    assert treeherder.failing_tests("autoland", _failing_job()) is None
+
+
+def test_failing_tests_is_none_without_a_job(suggestions):
+    suggestions(_suggestion(_TEST_LINE, True))
+    assert treeherder.failing_tests("autoland", None) is None
+
+
+def test_failing_tests_fails_soft_on_error(monkeypatch):
+    def boom(project, job_id):
+        raise RuntimeError("treeherder is down")
+
+    monkeypatch.setattr(treeherder, "bug_suggestions", boom)
+    assert treeherder.failing_tests("autoland", _failing_job()) is None


### PR DESCRIPTION
Another iteration of listener improvements with a focus on reducing the delay to trigger the agent. This will increase the number of runs when the agent analyzes an intermittent failure (capped at 100 per 24 hours).

Specifically:
- do not perform lengthy extra checks if the test was never intermittent based on tests.firefox.dev data.
- do not wait for the parent build to finish
- some other fixes for the issues the agent found during the iterative process of dry runs and analysis of the logs

Stats from the last tested dry run:

### Dry run (16.5 h, autoland)

| Metric | Value |
|---|---|
| Window | Sep 2 17:07 → Sep 3 09:37 (16.5 h) |
| Distinct failing tasks seen | 1315 |
| Test-repair would-triggers | 23 (~33 / day) |
| Build-repair would-triggers | 4 |
| Fast path fired | 36 |
| Fast-path fires that reached trigger | 6 |
| Job end → trigger, fast path | 0.1 – 0.6 min |
| Job end → trigger, wait path | 10.2 – 17.1 min |
| History check → trigger gap | 1 – 5 s |
| Ancestor walk stepped over a pending parent | 35 |
| Ancestor walk fail-open after 600 s | 3 |
| Fast-path triggers the skipped wait would have dropped | 0 (all classified 7–9 h later) |
| Log-parse wait exhausted (60 s) | 2 |
| Cross-push dedupe skips | 11 |
| Test triggers later classified intermittent | 19 / 23 (fast path 5/6, wait path 14/17) |
| Budget hits (cap 100) | 0 |
| Errors / tracebacks | 0 |


Redelpoyed live for testing

related to #6662 