### PR TITLE
Route the three Core :: Machine Learning components to #smart-window-bug-triage

### DIFF
--- a/agents/frontend-triage/README.md
+++ b/agents/frontend-triage/README.md
@@ -23,21 +23,24 @@ component's code lives in. A bug handed to the agent by hand in some other compo
 (`Firefox :: Menus`, say) is triaged the same way and reports to nobody. The components,
 and the channel each reports to:
 
-| Component                         | Reports to                       |
-| --------------------------------- | -------------------------------- |
-| `Firefox :: New Tab Page`         | `#hnt-dev-triage`                |
-| `Firefox :: Sidebar`              | `#p10y-bots`                     |
-| `Firefox :: Site Permissions`     | `#privacy-team-automation`       |
-| `Toolkit :: Data Sanitization`    | `#privacy-team-automation`       |
-| `Firefox :: Settings UI`          | `#fx-recomp-bots`                |
-| `Firefox :: Sharing`              | `#content-sharing-automation`    |
-| `Firefox :: IP Protection`        | `#team-eng-ip-protection-triage` |
-| `Firefox :: Messaging System`     | `#omc-triage`                    |
-| `Firefox for Android :: History`  | `#android-core-dev`              |
-| `Firefox for Android :: Toolbar`  | `#android-core-dev`              |
-| `Firefox for Android :: Homepage` | `#android-core-dev`              |
-| `Toolkit :: Application Update`   | `#installer-updater-bug-triage`  |
-| `Firefox :: Installer`            | `#installer-updater-bug-triage`  |
+| Component                            | Reports to                       |
+| ------------------------------------ | -------------------------------- |
+| `Firefox :: New Tab Page`            | `#hnt-dev-triage`                |
+| `Firefox :: Sidebar`                 | `#p10y-bots`                     |
+| `Firefox :: Site Permissions`        | `#privacy-team-automation`       |
+| `Toolkit :: Data Sanitization`       | `#privacy-team-automation`       |
+| `Firefox :: Settings UI`             | `#fx-recomp-bots`                |
+| `Firefox :: Sharing`                 | `#content-sharing-automation`    |
+| `Firefox :: IP Protection`           | `#team-eng-ip-protection-triage` |
+| `Firefox :: Messaging System`        | `#omc-triage`                    |
+| `Core :: Machine Learning: Frontend` | `#smart-window-bug-triage`       |
+| `Core :: Machine Learning: Models`   | `#smart-window-bug-triage`       |
+| `Core :: Machine Learning: General`  | `#smart-window-bug-triage`       |
+| `Firefox for Android :: History`     | `#android-core-dev`              |
+| `Firefox for Android :: Toolbar`     | `#android-core-dev`              |
+| `Firefox for Android :: Homepage`    | `#android-core-dev`              |
+| `Toolkit :: Application Update`      | `#installer-updater-bug-triage`  |
+| `Firefox :: Installer`               | `#installer-updater-bug-triage`  |
 
 No doc path or URL is listed anywhere here. mozilla-central already records where a
 component is documented in its `SPHINX_TREES` declarations, so `docs.py` runs one

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/config.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/config.py
@@ -511,6 +511,121 @@ TRIAGE_SCOPE = (
             "retitle or re-scope it to match."
         ),
     ),
+    # Three components, one team, one channel, and their trees interleave: a chat-UI bug
+    # filed under `Frontend` routinely localizes into `models/`. So all three name each
+    # other in `related`, or `component_guidance_hook` refuses the comment for citing a
+    # file the same team owns.
+    ScopedComponent(
+        "Core",
+        "Machine Learning: Frontend",
+        "#smart-window-bug-triage",
+        trees=("browser/components/genai/", "browser/components/aiwindow/ui/"),
+        owns=("browser/components/genai/", "browser/components/aiwindow/ui/"),
+        related=(
+            "Core :: Machine Learning: Models",
+            "Core :: Machine Learning: General",
+        ),
+        notes=(
+            "**Two unrelated UIs share this component, and almost nothing about them is "
+            "the same.** `browser/components/genai/` is the third-party chatbot sidebar: "
+            "`GenAI.sys.mjs` picks a provider and `chat.html` loads that provider's own "
+            "web page into a browser element, so ChatGPT, Gemini, Le Chat and "
+            "HuggingChat are remote documents we host rather than markup we wrote. "
+            "**That is the single most common misfiling here.** A report that a button "
+            "inside the ChatGPT panel is unlabelled, invisible in High Contrast, or in "
+            "the wrong tab order is usually the provider's page, not our code, and the "
+            "correct triage says so and stops -- do not go looking for the element in "
+            "`browser/components/genai/` and do not propose a fix to a page we do not "
+            "ship. What is ours in that tree is the frame around it: the provider list "
+            "and prompts in `GenAI.sys.mjs`, the context-menu and shortcut entry points "
+            "in `GenAIChild.sys.mjs`, and the separate Link Preview "
+            "(`LinkPreview.sys.mjs`) and Page Assist (`PageAssist.sys.mjs`) features "
+            "that happen to live beside it.\n\n"
+            "`browser/components/aiwindow/ui/` is Smart Window, and it **is** ours all "
+            "the way down -- lit custom elements under `browser/components/aiwindow/ui/"
+            "components/`, actors under `browser/components/aiwindow/ui/actors/`, and "
+            "the window and tab state in `browser/components/aiwindow/ui/modules/`. Work "
+            "out which of the two the reporter was in before reading either; the two "
+            "have no files in common.\n\n"
+            "Note also that the chatbot renders inside the sidebar's frame, so the "
+            "panel chrome around it -- resizing, the launcher, where the panel is "
+            "docked -- is `Firefox :: Sidebar` and not this component. Coverage is good "
+            "in both trees (`browser/components/genai/tests/` and "
+            "`browser/components/aiwindow/ui/test/`, each with `browser/` and "
+            "`xpcshell/` subdirectories), so an empty `relevant_tests` is usually wrong."
+        ),
+    ),
+    ScopedComponent(
+        "Core",
+        "Machine Learning: Models",
+        "#smart-window-bug-triage",
+        trees=("browser/components/aiwindow/models/",),
+        # `moz.build` assigns this directory to `Machine Learning: General`, and the bugs
+        # filed against it arrive under this component. Both claim the same string rather
+        # than one of them winning, so either team's guidance satisfies the citation hook.
+        owns=("browser/components/aiwindow/models/",),
+        related=(
+            "Core :: Machine Learning: General",
+            "Core :: Machine Learning: Frontend",
+        ),
+        notes=(
+            "The prompt, tool and routing layer under "
+            "`browser/components/aiwindow/models/`: `Chat.sys.mjs` drives a conversation, "
+            "`Tools.sys.mjs` declares the tools a model may call, `PromptLoader.sys.mjs` "
+            "and `PromptOptimizer.sys.mjs` assemble what is sent, and "
+            "`SearchBrowsingHistory.sys.mjs` and `WCSMerinoClient.sys.mjs` are the "
+            "retrieval side. `browser/components/aiwindow/models/memories/` is a separate "
+            "subsystem on the same code path -- extraction, scheduling and storage of "
+            "what the browser remembers about a user -- and a bug about what the model "
+            "recalled is usually there rather than in the chat modules above it.\n\n"
+            "**Most of what a bug here describes has no code in this tree.** Which model "
+            "answered, what a provider returned, whether a search result was relevant, "
+            "how good a response was: that is served remotely, and the in-tree half is "
+            "only the request that provoked it. Say the behavior is not localizable in "
+            "the checkout when it is not, rather than picking the nearest file that "
+            "mentions the feature -- a plausible wrong file costs more than an honest "
+            '"this is server-side".\n\n'
+            "One trap when looking for tests: "
+            "`browser/components/aiwindow/models/tests/browser_eval/` is a **model-quality "
+            "evaluation harness**, one file per model behind its own `eval.toml`, not a "
+            "regression suite, and it does not run in CI as one. The regression tests are "
+            "`browser/components/aiwindow/models/tests/browser/` and "
+            "`browser/components/aiwindow/models/tests/xpcshell/`; cite those."
+        ),
+    ),
+    ScopedComponent(
+        "Core",
+        "Machine Learning: General",
+        "#smart-window-bug-triage",
+        trees=("browser/components/aiwindow/", "dom/modelcontext/"),
+        owns=(
+            "browser/components/aiwindow/",
+            "browser/components/aiwindow/models/",
+            "dom/modelcontext/",
+        ),
+        related=(
+            "Core :: Machine Learning: Frontend",
+            "Core :: Machine Learning: Models",
+        ),
+        notes=(
+            "The catch-all of the three, and it spans two eras of the same product. Old "
+            "chatbot-sidebar reports still arrive here rather than under `Machine "
+            "Learning: Frontend` -- the two components were used interchangeably for that "
+            "UI for a year -- so the component name does not tell you which tree, and a "
+            "2024 or 2025 bug about a provider panel is `browser/components/genai/` even "
+            "though nothing here points at it. Newer bugs are the Smart Window plumbing "
+            "that is neither the UI nor the model layer: what sits at the root of "
+            "`browser/components/aiwindow/`, and the Model Context Protocol surface in "
+            "`dom/modelcontext/`.\n\n"
+            "Two neighbors this is regularly confused with, neither of them triaged here. "
+            "The on-device inference runtime -- model download, the WASM engine, the model "
+            "cache -- is `toolkit/components/ml/`, filed as `Machine Learning: On Device`. "
+            "The prompt and tool layer is `Machine Learning: Models`, which owns "
+            "`browser/components/aiwindow/models/` alongside this component. Triage the "
+            "bug under the component it was filed in and say where the code turned out to "
+            "be; do not retitle or re-scope it to match."
+        ),
+    ),
     # The installer and the updater are triaged by the same team, so two components
     # share a channel. Keying by product-and-component rather than by channel is what
     # lets them, without either one having to know about the other.


### PR DESCRIPTION
Smart Window work is filed under three Core Machine Learning components the agent has no channel or trees for, so those bugs report to nobody. `moz.build` assigns `browser/components/aiwindow/models/` to the General component while the bugs about that directory are filed under Models, so both claim it and the registry reads the identical claim as co-ownership.

**Deploy before the matching bugbot change**: `channel_for` fails closed, so the reverse order posts unattended analyses with nobody told.