### PR TITLE
Route Firefox :: General, Toolkit :: General and Firefox :: Untriaged to #fx-toolkit-general-triage-notifications

### DIFF
--- a/agents/frontend-triage/README.md
+++ b/agents/frontend-triage/README.md
@@ -23,24 +23,27 @@ component's code lives in. A bug handed to the agent by hand in some other compo
 (`Firefox :: Menus`, say) is triaged the same way and reports to nobody. The components,
 and the channel each reports to:
 
-| Component                            | Reports to                       |
-| ------------------------------------ | -------------------------------- |
-| `Firefox :: New Tab Page`            | `#hnt-dev-triage`                |
-| `Firefox :: Sidebar`                 | `#p10y-bots`                     |
-| `Firefox :: Site Permissions`        | `#privacy-team-automation`       |
-| `Toolkit :: Data Sanitization`       | `#privacy-team-automation`       |
-| `Firefox :: Settings UI`             | `#fx-recomp-bots`                |
-| `Firefox :: Sharing`                 | `#content-sharing-automation`    |
-| `Firefox :: IP Protection`           | `#team-eng-ip-protection-triage` |
-| `Firefox :: Messaging System`        | `#omc-triage`                    |
-| `Core :: Machine Learning: Frontend` | `#smart-window-bug-triage`       |
-| `Core :: Machine Learning: Models`   | `#smart-window-bug-triage`       |
-| `Core :: Machine Learning: General`  | `#smart-window-bug-triage`       |
-| `Firefox for Android :: History`     | `#android-core-dev`              |
-| `Firefox for Android :: Toolbar`     | `#android-core-dev`              |
-| `Firefox for Android :: Homepage`    | `#android-core-dev`              |
-| `Toolkit :: Application Update`      | `#installer-updater-bug-triage`  |
-| `Firefox :: Installer`               | `#installer-updater-bug-triage`  |
+| Component                            | Reports to                                 |
+| ------------------------------------ | ------------------------------------------ |
+| `Firefox :: New Tab Page`            | `#hnt-dev-triage`                          |
+| `Firefox :: Sidebar`                 | `#p10y-bots`                               |
+| `Firefox :: Site Permissions`        | `#privacy-team-automation`                 |
+| `Toolkit :: Data Sanitization`       | `#privacy-team-automation`                 |
+| `Firefox :: Settings UI`             | `#fx-recomp-bots`                          |
+| `Firefox :: Sharing`                 | `#content-sharing-automation`              |
+| `Firefox :: IP Protection`           | `#team-eng-ip-protection-triage`           |
+| `Firefox :: Messaging System`        | `#omc-triage`                              |
+| `Core :: Machine Learning: Frontend` | `#smart-window-bug-triage`                 |
+| `Core :: Machine Learning: Models`   | `#smart-window-bug-triage`                 |
+| `Core :: Machine Learning: General`  | `#smart-window-bug-triage`                 |
+| `Firefox for Android :: History`     | `#android-core-dev`                        |
+| `Firefox for Android :: Toolbar`     | `#android-core-dev`                        |
+| `Firefox for Android :: Homepage`    | `#android-core-dev`                        |
+| `Toolkit :: Application Update`      | `#installer-updater-bug-triage`            |
+| `Firefox :: Installer`               | `#installer-updater-bug-triage`            |
+| `Firefox :: General`                 | `#fx-toolkit-general-triage-notifications` |
+| `Toolkit :: General`                 | `#fx-toolkit-general-triage-notifications` |
+| `Firefox :: Untriaged`               | `#fx-toolkit-general-triage-notifications` |
 
 No doc path or URL is listed anywhere here. mozilla-central already records where a
 component is documented in its `SPHINX_TREES` declarations, so `docs.py` runs one

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/config.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/config.py
@@ -671,6 +671,66 @@ TRIAGE_SCOPE = (
             "you looked."
         ),
     ),
+    # The three buckets, which are where a filing lands when the reporter could not pick
+    # a component. Grouped at the end rather than beside a related area because they are
+    # not an area: they route to one channel for the people who work the unowned queue.
+    #
+    # None of the three sets `owns`, which is deliberate and is the one thing to preserve
+    # if these entries are edited. `owns` is what `hooks.component_guidance_hook` refuses
+    # comments against and `owners_for_path` resolves longest-claim-wins, so claiming
+    # `browser/` for General would make every unclaimed file of desktop chrome General's
+    # and a Sidebar or Settings UI run -- which loads its own guidance and its `related`
+    # entries, not this one -- would have its comment refused for citing its own code. A
+    # `trees` this broad is only legal because nothing owns it.
+    ScopedComponent(
+        "Firefox",
+        "General",
+        "#fx-toolkit-general-triage-notifications",
+        trees=("browser/",),
+        notes=(
+            "**A holding component rather than an area, so the first useful output is "
+            "which component the bug belongs to**, not which file is at fault. The tree "
+            "above is the whole of desktop chrome and most of it belongs to some other "
+            "component, so a confident localization here is a re-componentization "
+            "suggestion: name the component that owns the code you found and say so "
+            "plainly, because the reporter picked this one for want of a better guess "
+            "rather than as a claim about where the code is. What legitimately stays "
+            "here is cross-component window, session and startup behavior that no single "
+            "team owns."
+        ),
+    ),
+    ScopedComponent(
+        "Toolkit",
+        "General",
+        "#fx-toolkit-general-triage-notifications",
+        trees=("toolkit/",),
+        notes=(
+            "The same holding-component caveat as `Firefox :: General`, with one "
+            "difference worth acting on: toolkit code is shared, so a bug filed here may "
+            "reproduce in Thunderbird and the other consumers as well as Firefox, and "
+            "the component that owns the code is as likely to be a `Core` one as a "
+            "`Toolkit` one. Establish which application the reporter was running before "
+            "localizing anything, since the same symptom in two consumers is usually two "
+            "different bugs."
+        ),
+    ),
+    ScopedComponent(
+        "Firefox",
+        "Untriaged",
+        "#fx-toolkit-general-triage-notifications",
+        trees=("browser/",),
+        notes=(
+            "**Not a component at all**: it is the default for a filing that named none, "
+            "so it says nothing about the area and everything on `Firefox :: General` "
+            "applies to it more strongly. One thing it adds is a race worth writing "
+            "around. bugbot's `component` rule moves low-confidence bugs out of here "
+            "into `Firefox :: General` hourly, and it runs in the same cron pass as the "
+            "rule that sends bugs here, so a bug may be reassigned between the run "
+            "starting and anyone reading the comment. Both components report to this "
+            "channel, so nothing is lost, but do not write a comment whose reasoning "
+            "depends on the bug still being Untriaged."
+        ),
+    ),
 )
 
 # Where an auto-applied run reports itself, by `"<Product> :: <Component>"`. Derived, so


### PR DESCRIPTION
`TRIAGE_SCOPE` covers 16 narrow components, each owned by a team, and none of the three buckets a reporter lands in when they cannot pick a component. Those are the filings that most need a first pass, so this adds all three to one channel for the people who work the unowned queue.

None of the three sets `owns`, which is the one decision here worth a look. `owns` is what `component_guidance_hook` refuses comments against and `owners_for_path` resolves longest-claim-wins, so claiming `browser/` for General would make every unclaimed file of desktop chrome General's and a Sidebar or Settings UI run would then have its comment refused for citing its own code. The README's own "Adding a triage component" recipe already names that trap.

## Tradeoffs worth a reviewer's attention

`docs_for` keys off `trees`, and a bucket has no narrow tree to give it. Measured against a mozilla-central checkout, the three arrive with 28, 33 and 28 doc registrations out of 135 tree-wide, where every existing component gets between zero and three. `docs.py` says the fix for a broad tree is narrowing the entry rather than filtering in the lookup, and there is nothing to narrow to here, so this is a real cost rather than one I can design away.

## Testing

`uv run --package hackbot-agent-frontend-triage pytest agents/frontend-triage/tests` is 115 passed with `SOURCE_REPO` pointed at a real checkout, 114 passed and 1 skipped without it. No test file needed editing: the channel and registry-shape tests loop over `TRIAGE_SCOPE`.

**This should land and deploy before the matching mozilla/bugbot change**, which adds the same three pairs to `TRIAGED_COMPONENTS`. `channel_for` fails closed, so a pair that arrives before the agent knows its channel is silent on Slack but still comments on the bug and still assesses severity.