### PR TITLE
Ask for a needinfo on hackbot@mozilla.tld in the frontend-triage footer so a reader can turn the fix plan into a patch

### DIFF
--- a/agents/frontend-triage/README.md
+++ b/agents/frontend-triage/README.md
@@ -213,11 +213,15 @@ Two further hooks shape the comment text as it is recorded:
   `ai-triage-hallucination`, `ai-triage-out-of-scope`, `ai-triage-wrong-fix`,
   `ai-triage-shallow-fix`. The last two are about the fix plan rather than the
   diagnosis: one for a fix that would not work, one for a fix that patches the
-  symptom instead of the cause the comment just named.
+  symptom instead of the cause the comment just named. The same hook closes the
+  comment by asking for a `needinfo?` on `hackbot@mozilla.tld`, which triggers a
+  `bug-fix` run ([triggers.md](../../docs/hackbot/triggers.md)).
 
 The tags go under the runtime's shared footer inviting a 👍 or 👎 reaction, which
 `bugzilla.add_comment` has already appended by the time the hook runs. Those
-reactions and tags are the feedback channel — the agent does not request needinfo.
+reactions and tags are the feedback channel; the needinfo is for the patch, and
+only from a requester in Bugzilla's `editbugs` group, which is what the webhook
+authorizes.
 
 ## Slack notification
 

--- a/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
+++ b/agents/frontend-triage/hackbot_agents/frontend_triage/agent.py
@@ -76,15 +76,26 @@ _FEEDBACK_TAGS = (
     "ai-triage-out-of-scope, ai-triage-wrong-fix, ai-triage-shallow-fix."
 )
 
+# Repeats the `bugzilla_webhook.bot_login` default in hackbot-api, which this agent
+# does not import; docs/hackbot/triggers.md covers what the needinfo starts.
+_PATCH_REQUEST = (
+    "Needinfo hackbot@mozilla.tld to have a patch generated for this bug, "
+    "include any questions or directions as needed in your comment."
+)
+
 
 def feedback_tags_hook(action: dict) -> None:
-    """Offer the triage-specific feedback tags below the runtime's footer."""
+    """Offer the feedback tags and the patch request below the runtime's footer.
+
+    The patch request takes a blank line: the comment is Markdown, where a lone
+    newline would fold it onto the end of the tag list.
+    """
     params = action.get("params")
     if not isinstance(params, dict):
         return
     text = params.get("text")
     if isinstance(text, str):
-        params["text"] = f"{text.rstrip()}\n{_FEEDBACK_TAGS}"
+        params["text"] = f"{text.rstrip()}\n{_FEEDBACK_TAGS}\n\n{_PATCH_REQUEST}"
 
 
 class SeverityAssessment(BaseModel):

--- a/agents/frontend-triage/tests/test_hooks.py
+++ b/agents/frontend-triage/tests/test_hooks.py
@@ -7,6 +7,11 @@ hackbot_agents/frontend_triage/hooks.py.
 
 import pytest
 from agent_tools.registry import ToolError
+from hackbot_agents.frontend_triage.agent import (
+    _FEEDBACK_TAGS,
+    _PATCH_REQUEST,
+    feedback_tags_hook,
+)
 from hackbot_agents.frontend_triage.config import ENABLED_ACTION_TYPES
 from hackbot_agents.frontend_triage.hooks import (
     add_comment_hook,
@@ -145,3 +150,11 @@ def test_a_comment_citing_no_owned_path_passes():
     # and Searchfox. Refusing here would fail the run over something the agent cannot
     # satisfy -- it would retry forever against guidance that does not exist.
     _guidance_hook("Firefox :: New Tab Page")(_cite("gfx/thebes/gfxPlatform.cpp"))
+
+
+def test_the_footer_asks_for_a_patch_needinfo_in_its_own_paragraph():
+    action = {"params": {"bug_id": BUG, "text": "Fix plan.\n\n---\n\nreaction footer"}}
+    feedback_tags_hook(action)
+    assert action["params"]["text"] == (
+        f"Fix plan.\n\n---\n\nreaction footer\n{_FEEDBACK_TAGS}\n\n{_PATCH_REQUEST}"
+    )


### PR DESCRIPTION
The needinfo triggers the existing `bug-fix` webhook, to make the feature discoverable from the bug. Note that the feature will only work if the requester has 'editbugs' permissions.